### PR TITLE
[F1-01] Criar enums e Value Objects novos

### DIFF
--- a/core/src/main/java/com/marmitt/core/domain/shared/ClientOrderId.java
+++ b/core/src/main/java/com/marmitt/core/domain/shared/ClientOrderId.java
@@ -1,0 +1,132 @@
+package com.marmitt.core.domain.shared;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Chave única de roteamento e idempotência, gerada pelo StrategyRunner antes do dispatch.
+ * <p>
+ * Formato: {@code v{version}r{runner_short}t{timestamp}s{sequence}{type}_{transaction_uuid}}
+ * <p>
+ * Exemplo: {@code v1r01ft1700000000000s001N_8da233214f11b12a}
+ * <p>
+ * Tamanho total: ~36 caracteres (compatível com limite da maioria das exchanges).
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.4.1</a>
+ */
+public record ClientOrderId(
+        String rawValue,
+        int version,
+        String runnerShort,
+        long timestamp,
+        int sequence,
+        char type,
+        String transactionUuid
+) {
+    /**
+     * Tipos de ordem suportados no clientOrderId
+     */
+    public static final char TYPE_NEW = 'N';
+    public static final char TYPE_SELL = 'S';
+    public static final char TYPE_CANCEL = 'C';
+
+    private static final int CURRENT_VERSION = 1;
+    private static final Pattern PARSE_PATTERN = Pattern.compile(
+            "^v(\\d+)r([a-zA-Z0-9]{2,4})t(\\d{13})s(\\d{3})([NSC])_([a-f0-9]{16})$"
+    );
+
+    public ClientOrderId {
+        Objects.requireNonNull(rawValue, "rawValue cannot be null");
+        Objects.requireNonNull(runnerShort, "runnerShort cannot be null");
+        Objects.requireNonNull(transactionUuid, "transactionUuid cannot be null");
+
+        if (runnerShort.length() < 2 || runnerShort.length() > 4) {
+            throw new IllegalArgumentException("runnerShort must be 2-4 characters, got: " + runnerShort);
+        }
+        if (type != TYPE_NEW && type != TYPE_SELL && type != TYPE_CANCEL) {
+            throw new IllegalArgumentException("Invalid type: " + type + ". Expected N, S, or C");
+        }
+    }
+
+    /**
+     * Gera um novo ClientOrderId para uma transação.
+     *
+     * @param shortCode     ShortCode do StrategyRunner (2-4 chars)
+     * @param transactionId UUID da Transaction
+     * @param type          Tipo da ordem: N (New/Buy), S (Sell), C (Cancel)
+     * @param sequence      Sequência dentro do mesmo milissegundo (0-999)
+     * @return novo ClientOrderId
+     */
+    public static ClientOrderId generate(String shortCode, UUID transactionId, char type, int sequence) {
+        Objects.requireNonNull(shortCode, "shortCode cannot be null");
+        Objects.requireNonNull(transactionId, "transactionId cannot be null");
+
+        long ts = Instant.now().toEpochMilli();
+        String truncatedUuid = transactionId.toString().replace("-", "").substring(0, 16);
+        String raw = String.format("v%dr%st%ds%03d%c_%s",
+                CURRENT_VERSION, shortCode, ts, sequence, type, truncatedUuid);
+
+        return new ClientOrderId(raw, CURRENT_VERSION, shortCode, ts, sequence, type, truncatedUuid);
+    }
+
+    /**
+     * Gera um novo ClientOrderId com sequence = 0.
+     */
+    public static ClientOrderId generate(String shortCode, UUID transactionId, char type) {
+        return generate(shortCode, transactionId, type, 0);
+    }
+
+    /**
+     * Faz parse de um clientOrderId raw retornado pela exchange.
+     * Se a versão for desconhecida, lança exceção (deve ser encaminhado para DLQ).
+     *
+     * @param rawString o clientOrderId completo
+     * @return ClientOrderId parseado
+     * @throws IllegalArgumentException se o formato for inválido ou versão desconhecida
+     */
+    public static ClientOrderId parse(String rawString) {
+        Objects.requireNonNull(rawString, "rawString cannot be null");
+
+        Matcher matcher = PARSE_PATTERN.matcher(rawString);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid clientOrderId format: " + rawString);
+        }
+
+        int parsedVersion = Integer.parseInt(matcher.group(1));
+        if (parsedVersion != CURRENT_VERSION) {
+            throw new IllegalArgumentException("Unknown clientOrderId version: " + parsedVersion);
+        }
+
+        return new ClientOrderId(
+                rawString,
+                parsedVersion,
+                matcher.group(2),
+                Long.parseLong(matcher.group(3)),
+                Integer.parseInt(matcher.group(4)),
+                matcher.group(5).charAt(0),
+                matcher.group(6)
+        );
+    }
+
+    /**
+     * Retorna o shortCode do Runner — usado pelo Portfolio para roteamento de callbacks.
+     */
+    public String getRunnerShort() {
+        return runnerShort;
+    }
+
+    /**
+     * Retorna o UUID truncado da Transaction — usado para reconciliação com o DB.
+     */
+    public String getTransactionUuid() {
+        return transactionUuid;
+    }
+
+    @Override
+    public String toString() {
+        return rawValue;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/domain/shared/Fee.java
+++ b/core/src/main/java/com/marmitt/core/domain/shared/Fee.java
@@ -1,0 +1,78 @@
+package com.marmitt.core.domain.shared;
+
+import com.marmitt.core.enums.FeeType;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Representa o custo operacional imutável de uma execução.
+ * Embutido no TransactionMatch como Value Object.
+ * <p>
+ * Se {@code asset} == baseCurrency do Portfolio, {@code convertedAmount} == {@code amount}.
+ * Se {@code asset} != baseCurrency, Portfolio converte usando Mark Price no momento do match.
+ * Em caso de falha na conversão, débito registrado na DustAccount como TECHNICAL_DEBT.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.4.2, Blueprint 9.1</a>
+ */
+public record Fee(
+        BigDecimal amount,
+        String asset,
+        FeeType type,
+        BigDecimal convertedAmount
+) {
+    public Fee {
+        Objects.requireNonNull(amount, "Fee amount cannot be null");
+        Objects.requireNonNull(asset, "Fee asset cannot be null");
+        Objects.requireNonNull(type, "Fee type cannot be null");
+
+        if (asset.isBlank()) {
+            throw new IllegalArgumentException("Fee asset cannot be blank");
+        }
+        if (amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Fee amount cannot be negative");
+        }
+    }
+
+    /**
+     * Cria uma Fee com conversão trivial (mesmo ativo que baseCurrency).
+     */
+    public static Fee sameBaseCurrency(BigDecimal amount, String asset, FeeType type) {
+        return new Fee(amount, asset.toUpperCase(), type, amount);
+    }
+
+    /**
+     * Cria uma Fee cross-currency com valor convertido.
+     */
+    public static Fee crossCurrency(BigDecimal amount, String asset, FeeType type, BigDecimal convertedAmount) {
+        return new Fee(amount, asset.toUpperCase(), type, convertedAmount);
+    }
+
+    /**
+     * Cria uma Fee cross-currency pendente de conversão (convertedAmount = null).
+     */
+    public static Fee pendingConversion(BigDecimal amount, String asset, FeeType type) {
+        return new Fee(amount, asset.toUpperCase(), type, null);
+    }
+
+    /**
+     * Cria uma Fee zero (sem custo).
+     */
+    public static Fee zero(String asset) {
+        return new Fee(BigDecimal.ZERO, asset.toUpperCase(), FeeType.UNKNOWN, BigDecimal.ZERO);
+    }
+
+    /**
+     * Verifica se a fee ainda precisa de conversão para baseCurrency.
+     */
+    public boolean isPendingConversion() {
+        return convertedAmount == null;
+    }
+
+    /**
+     * Retorna o valor convertido ou zero se pendente.
+     */
+    public BigDecimal getConvertedAmountOrZero() {
+        return convertedAmount != null ? convertedAmount : BigDecimal.ZERO;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/strategy/PositionContext.java
+++ b/core/src/main/java/com/marmitt/core/dto/strategy/PositionContext.java
@@ -1,0 +1,47 @@
+package com.marmitt.core.dto.strategy;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Objeto imutável injetado na Strategy pelo Runner, contendo o estado operacional
+ * necessário para decisão de trading. Read-only — a Strategy não modifica este objeto.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.4.3, Blueprint 9.3.D</a>
+ */
+@Builder
+public record PositionContext(
+        UUID positionId,
+        String symbol,
+        BigDecimal quantity,
+        BigDecimal averagePrice,
+        BigDecimal currentPrice,
+        BigDecimal unrealizedPnl,
+        BigDecimal realizedPnl,
+        List<OpenBuyEntryDto> openBuyEntries
+) {
+    /**
+     * Verifica se há posição aberta.
+     */
+    public boolean hasOpenPosition() {
+        return positionId != null && quantity != null && quantity.compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    /**
+     * Cria um PositionContext vazio (sem posição aberta).
+     */
+    public static PositionContext empty(String symbol) {
+        return PositionContext.builder()
+                .symbol(symbol)
+                .quantity(BigDecimal.ZERO)
+                .averagePrice(BigDecimal.ZERO)
+                .currentPrice(BigDecimal.ZERO)
+                .unrealizedPnl(BigDecimal.ZERO)
+                .realizedPnl(BigDecimal.ZERO)
+                .openBuyEntries(List.of())
+                .build();
+    }
+}

--- a/core/src/main/java/com/marmitt/core/enums/AccountingPolicyType.java
+++ b/core/src/main/java/com/marmitt/core/enums/AccountingPolicyType.java
@@ -1,0 +1,24 @@
+package com.marmitt.core.enums;
+
+/**
+ * Regra contábil — como vendas são casadas com compras para cálculo de P&L.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.5, Blueprint 2.B.2</a>
+ */
+public enum AccountingPolicyType {
+
+    /**
+     * First-In-First-Out — venda casa com a compra mais antiga
+     */
+    FIFO,
+
+    /**
+     * Last-In-First-Out — venda casa com a compra mais recente
+     */
+    LIFO,
+
+    /**
+     * Match específico — venda casa com um lote designado via targetLotId
+     */
+    SPECIFIC_MATCH
+}

--- a/core/src/main/java/com/marmitt/core/enums/CapitalPoolingMode.java
+++ b/core/src/main/java/com/marmitt/core/enums/CapitalPoolingMode.java
@@ -1,0 +1,19 @@
+package com.marmitt.core.enums;
+
+/**
+ * Modo de visibilidade de capital entre Runners de um Portfolio.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.5, Blueprint 11.2.C</a>
+ */
+public enum CapitalPoolingMode {
+
+    /**
+     * Todos os Runners competem pelo saldo disponível do GlobalBalance
+     */
+    SHARED,
+
+    /**
+     * Cada Runner tem uma fatia fixa (dedicatedBudget) reservada
+     */
+    DEDICATED
+}

--- a/core/src/main/java/com/marmitt/core/enums/DlqReason.java
+++ b/core/src/main/java/com/marmitt/core/enums/DlqReason.java
@@ -1,0 +1,29 @@
+package com.marmitt.core.enums;
+
+/**
+ * Motivo do encaminhamento de uma execução para a Dead Letter Queue (DLQ).
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.5, Blueprint 4.D, 10.3.D</a>
+ */
+public enum DlqReason {
+
+    /**
+     * Runner não encontrado pelo shortCode extraído do clientOrderId
+     */
+    UNKNOWN_RUNNER,
+
+    /**
+     * clientOrderId com formato inválido ou versão desconhecida
+     */
+    INVALID_FORMAT,
+
+    /**
+     * Conflito durante reconciliação (dados inconsistentes entre exchange e DB)
+     */
+    RECONCILIATION_CONFLICT,
+
+    /**
+     * Símbolo do callback não corresponde a nenhum Runner ativo
+     */
+    UNKNOWN_SYMBOL
+}

--- a/core/src/main/java/com/marmitt/core/enums/DustSourceType.java
+++ b/core/src/main/java/com/marmitt/core/enums/DustSourceType.java
@@ -1,0 +1,19 @@
+package com.marmitt.core.enums;
+
+/**
+ * Origem do resíduo registrado na DustAccount.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.5, Blueprint 9.2.C</a>
+ */
+public enum DustSourceType {
+
+    /**
+     * Resíduo de arredondamento quando a quantidade restante de um lote < minQty da exchange
+     */
+    ROUNDING_DUST,
+
+    /**
+     * Falha na conversão de fee cross-currency (fallback crítico)
+     */
+    TECHNICAL_DEBT
+}

--- a/core/src/main/java/com/marmitt/core/enums/ExecutionPolicy.java
+++ b/core/src/main/java/com/marmitt/core/enums/ExecutionPolicy.java
@@ -1,0 +1,24 @@
+package com.marmitt.core.enums;
+
+/**
+ * Regra de entrada do Runner — como reage a novos sinais quando já há posição aberta.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.5, Blueprint 2.B.1</a>
+ */
+public enum ExecutionPolicy {
+
+    /**
+     * Apenas uma posição aberta por vez. Novo sinal de compra é ignorado se já há posição.
+     */
+    SINGLE,
+
+    /**
+     * Permite múltiplas posições simultâneas (long e short) no mesmo ativo.
+     */
+    HEDGING,
+
+    /**
+     * Posição única consolidada — novos sinais ajustam a posição existente.
+     */
+    NETTING
+}

--- a/core/src/main/java/com/marmitt/core/enums/FeeType.java
+++ b/core/src/main/java/com/marmitt/core/enums/FeeType.java
@@ -1,0 +1,24 @@
+package com.marmitt.core.enums;
+
+/**
+ * Tipo da fee cobrada pela exchange na execução de uma ordem.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.5, Blueprint 9.1</a>
+ */
+public enum FeeType {
+
+    /**
+     * Fee de maker — ordem que adiciona liquidez ao order book
+     */
+    MAKER,
+
+    /**
+     * Fee de taker — ordem que remove liquidez do order book
+     */
+    TAKER,
+
+    /**
+     * Tipo de fee desconhecido ou não reportado pela exchange
+     */
+    UNKNOWN
+}

--- a/core/src/main/java/com/marmitt/core/enums/PositionStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/PositionStatus.java
@@ -1,0 +1,23 @@
+package com.marmitt.core.enums;
+
+/**
+ * Estado da posição no ciclo de vida.
+ * CLOSING indica que há ordens de venda em voo para esta posição.
+ */
+public enum PositionStatus {
+
+    /**
+     * Posição aberta com quantidade > 0
+     */
+    OPEN,
+
+    /**
+     * Posição com ordens de venda em voo (aguardando execução)
+     */
+    CLOSING,
+
+    /**
+     * Posição completamente fechada (quantity = 0)
+     */
+    CLOSED
+}

--- a/core/src/main/java/com/marmitt/core/enums/RunnerStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/RunnerStatus.java
@@ -1,0 +1,52 @@
+package com.marmitt.core.enums;
+
+/**
+ * Ciclo de vida do StrategyRunner.
+ * Transições: CREATED → INITIALIZING → ACTIVE → HALTED → TERMINATING → ARCHIVED
+ */
+public enum RunnerStatus {
+
+    /**
+     * Runner criado mas ainda não inicializado
+     */
+    CREATED,
+
+    /**
+     * Runner em processo de inicialização (Boot Sequence)
+     */
+    INITIALIZING,
+
+    /**
+     * Runner operacional, processando sinais da estratégia
+     */
+    ACTIVE,
+
+    /**
+     * Runner pausado (Safe Mode ou intervenção manual)
+     */
+    HALTED,
+
+    /**
+     * Runner em processo de encerramento (aguardando ordens em voo)
+     */
+    TERMINATING,
+
+    /**
+     * Runner arquivado (soft delete — nunca removido fisicamente)
+     */
+    ARCHIVED;
+
+    /**
+     * Verifica se o Runner está operacional (pode receber sinais)
+     */
+    public boolean isOperational() {
+        return this == ACTIVE;
+    }
+
+    /**
+     * Verifica se o Runner está em estado terminal
+     */
+    public boolean isTerminal() {
+        return this == TERMINATING || this == ARCHIVED;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/enums/SafeModeStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/SafeModeStatus.java
@@ -1,0 +1,37 @@
+package com.marmitt.core.enums;
+
+/**
+ * Níveis escaláveis do Safe Mode do Portfolio.
+ * Persistido para sobreviver a restarts.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.5, Blueprint 11.1.B.1</a>
+ */
+public enum SafeModeStatus {
+
+    /**
+     * Operação normal — todos os Runners podem operar
+     */
+    NORMAL,
+
+    /**
+     * Novos trades bloqueados — Runners ativos apenas monitoram
+     */
+    HALT,
+
+    /**
+     * Cancelar todas as ordens em voo
+     */
+    CANCEL_ALL,
+
+    /**
+     * Vender todas as posições abertas imediatamente
+     */
+    PANIC_SELL;
+
+    /**
+     * Verifica se o Safe Mode está ativo (qualquer nível acima de NORMAL)
+     */
+    public boolean isActive() {
+        return this != NORMAL;
+    }
+}


### PR DESCRIPTION
## Summary

- 9 novos enums para o modelo de dois agregados (Portfolio + StrategyRunner): `RunnerStatus`, `PositionStatus`, `ExecutionPolicy`, `AccountingPolicyType`, `SafeModeStatus`, `CapitalPoolingMode`, `FeeType`, `DustSourceType`, `DlqReason`
- 3 Value Objects: `ClientOrderId` (roteamento/idempotência, ~36 chars), `Fee` (custo de execução imutável), `PositionContext` (read-only DTO para Strategy)
- Novo package `domain.shared` para VOs cross-aggregate

## Referência

- **IG Seção 3.4** — Value Objects Compartilhados
- **IG Seção 3.5** — Definição de Enums

## Test plan

- [x] `./gradlew :core:compileJava` — compila sem erros
- [x] Revisão manual dos valores dos enums vs IG
- [x] Verificar formato do ClientOrderId (generate + parse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)