### PR TITLE
[F1-02] Refatorar Portfolio + criar GlobalBalance

### DIFF
--- a/core/src/main/java/com/marmitt/core/domain/portfolio/Balance.java
+++ b/core/src/main/java/com/marmitt/core/domain/portfolio/Balance.java
@@ -5,6 +5,11 @@ import lombok.Getter;
 import java.math.BigDecimal;
 import java.util.Objects;
 
+/**
+ * @deprecated Substituído por {@link GlobalBalance} no modelo alvo (IG Seção 3.2.2).
+ *             Mantido temporariamente para compatibilidade durante a migração.
+ */
+@Deprecated(forRemoval = true)
 @Getter
 public class Balance {
 

--- a/core/src/main/java/com/marmitt/core/domain/portfolio/GlobalBalance.java
+++ b/core/src/main/java/com/marmitt/core/domain/portfolio/GlobalBalance.java
@@ -1,0 +1,152 @@
+package com.marmitt.core.domain.portfolio;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Saldo global do Portfolio — substitui o {@link Balance} no modelo alvo.
+ * Opera em moeda única ({@code baseCurrency}), eliminando a redundância de currency/type por campo.
+ * <p>
+ * Semântica dos campos:
+ * <ul>
+ *   <li>{@code availableBalance} — poder de compra real (Total - Reserved - DustDebits)</li>
+ *   <li>{@code reservedBalance} — margem congelada para ordens em voo (cresce no Capital Request, decresce na confirmação)</li>
+ *   <li>{@code realizedBalance} — PnL líquido acumulado de todas as operações fechadas</li>
+ *   <li>{@code totalFeesPaid} — soma incremental de todas as fees (métrica de eficiência)</li>
+ * </ul>
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.2.2</a>
+ */
+@Getter
+public class GlobalBalance {
+
+    private final UUID portfolioId;
+    private BigDecimal availableBalance;
+    private BigDecimal reservedBalance;
+    private BigDecimal realizedBalance;
+    private final BigDecimal initialCapital;
+    private final String baseCurrency;
+    private BigDecimal totalFeesPaid;
+    private Instant lastExecutionTime;
+    private Instant updatedAt;
+    private Long version;
+
+    public GlobalBalance(
+            UUID portfolioId,
+            BigDecimal initialCapital,
+            String baseCurrency
+    ) {
+        this.portfolioId = Objects.requireNonNull(portfolioId, "portfolioId cannot be null");
+        this.initialCapital = Objects.requireNonNull(initialCapital, "initialCapital cannot be null");
+        this.baseCurrency = Objects.requireNonNull(baseCurrency, "baseCurrency cannot be null");
+        this.availableBalance = initialCapital;
+        this.reservedBalance = BigDecimal.ZERO;
+        this.realizedBalance = BigDecimal.ZERO;
+        this.totalFeesPaid = BigDecimal.ZERO;
+        this.lastExecutionTime = null;
+        this.updatedAt = Instant.now();
+        this.version = 0L;
+    }
+
+    /**
+     * Construtor completo para reconstituição a partir do banco de dados.
+     */
+    public GlobalBalance(
+            UUID portfolioId,
+            BigDecimal availableBalance,
+            BigDecimal reservedBalance,
+            BigDecimal realizedBalance,
+            BigDecimal initialCapital,
+            String baseCurrency,
+            BigDecimal totalFeesPaid,
+            Instant lastExecutionTime,
+            Instant updatedAt,
+            Long version
+    ) {
+        this.portfolioId = Objects.requireNonNull(portfolioId, "portfolioId cannot be null");
+        this.availableBalance = Objects.requireNonNull(availableBalance, "availableBalance cannot be null");
+        this.reservedBalance = Objects.requireNonNull(reservedBalance, "reservedBalance cannot be null");
+        this.realizedBalance = Objects.requireNonNull(realizedBalance, "realizedBalance cannot be null");
+        this.initialCapital = Objects.requireNonNull(initialCapital, "initialCapital cannot be null");
+        this.baseCurrency = Objects.requireNonNull(baseCurrency, "baseCurrency cannot be null");
+        this.totalFeesPaid = Objects.requireNonNull(totalFeesPaid, "totalFeesPaid cannot be null");
+        this.lastExecutionTime = lastExecutionTime;
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt cannot be null");
+        this.version = version;
+    }
+
+    /**
+     * Reserva capital para uma ordem (Capital Request — síncrono).
+     * Move {@code amount} de Available → Reserved.
+     *
+     * @param amount valor a reservar (deve ser positivo e ≤ availableBalance)
+     * @throws IllegalArgumentException se saldo insuficiente
+     */
+    public void reserve(BigDecimal amount) {
+        Objects.requireNonNull(amount, "amount cannot be null");
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Reserve amount must be positive");
+        }
+        if (availableBalance.compareTo(amount) < 0) {
+            throw new IllegalArgumentException("Insufficient available balance for reservation");
+        }
+        this.availableBalance = this.availableBalance.subtract(amount);
+        this.reservedBalance = this.reservedBalance.add(amount);
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Confirma execução — converte Reserved → Realized.
+     * Chamado após TransactionMatch ser persistido.
+     *
+     * @param cost         custo total da operação (margem consumida)
+     * @param pnlAmount    PnL líquido da operação
+     * @param feeConverted fee convertida para baseCurrency
+     */
+    public void confirmExecution(BigDecimal cost, BigDecimal pnlAmount, BigDecimal feeConverted) {
+        Objects.requireNonNull(cost, "cost cannot be null");
+        Objects.requireNonNull(pnlAmount, "pnlAmount cannot be null");
+        Objects.requireNonNull(feeConverted, "feeConverted cannot be null");
+
+        this.reservedBalance = this.reservedBalance.subtract(cost);
+        this.realizedBalance = this.realizedBalance.add(pnlAmount);
+        this.availableBalance = this.availableBalance.add(cost).add(pnlAmount);
+        this.totalFeesPaid = this.totalFeesPaid.add(feeConverted);
+        this.lastExecutionTime = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Libera margem reservada — devolve Reserved → Available.
+     * Chamado quando transação é REJECTED, CANCELED ou EXPIRED.
+     *
+     * @param amount valor a liberar
+     */
+    public void release(BigDecimal amount) {
+        Objects.requireNonNull(amount, "amount cannot be null");
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Release amount must be positive");
+        }
+        this.reservedBalance = this.reservedBalance.subtract(amount);
+        this.availableBalance = this.availableBalance.add(amount);
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Verifica se há saldo disponível suficiente para uma reserva.
+     */
+    public boolean hasAvailableBalance(BigDecimal amount) {
+        return availableBalance.compareTo(amount) >= 0;
+    }
+
+    /**
+     * Retorna o saldo total (available + reserved).
+     */
+    public BigDecimal getTotalBalance() {
+        return availableBalance.add(reservedBalance);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/domain/portfolio/Portfolio.java
+++ b/core/src/main/java/com/marmitt/core/domain/portfolio/Portfolio.java
@@ -5,6 +5,8 @@ import com.marmitt.core.domain.portfolio.contrats.AccountingPolicy;
 import com.marmitt.core.dto.strategy.OpenBuyEntryDto;
 import com.marmitt.core.dto.strategy.PendingSellEntryDto;
 import com.marmitt.core.dto.strategy.PortfolioContextDto;
+import com.marmitt.core.enums.CapitalPoolingMode;
+import com.marmitt.core.enums.SafeModeStatus;
 import com.marmitt.core.enums.TransactionStatus;
 import lombok.Getter;
 
@@ -24,12 +26,13 @@ public class Portfolio {
 
     private final UUID id;
     private final String name;
-    private final UUID strategyId;
-    private final String strategyName;
-    private final Symbol symbol;
     private boolean isActive;
     private final Instant createdAt;
     private Instant lastExecutionTime;
+
+    // Novos campos — modelo alvo (IG 3.2.1)
+    private SafeModeStatus safeModeStatus;
+    private CapitalPoolingMode capitalPoolingMode;
 
     private final AccountingPolicy accountingPolicy;
 
@@ -37,8 +40,26 @@ public class Portfolio {
     private final List<Transaction> transactions;
     private final List<TransactionMatch> transactionMatches = new ArrayList<>();
 
-    // Exchange configuration
+    // === Campos deprecados — migram para StrategyRunner (F1-04) ===
+
+    /** @deprecated Migra para StrategyRunner.strategyId */
+    @Deprecated(forRemoval = true)
+    private final UUID strategyId;
+
+    /** @deprecated Migra para StrategyRunner.strategyName */
+    @Deprecated(forRemoval = true)
+    private final String strategyName;
+
+    /** @deprecated Migra para StrategyRunner.symbol */
+    @Deprecated(forRemoval = true)
+    private final Symbol symbol;
+
+    /** @deprecated Migra para StrategyRunner.exchangeId */
+    @Deprecated(forRemoval = true)
     private final String orderExecutionExchange;
+
+    /** @deprecated Migra para runner_market_data_sources */
+    @Deprecated(forRemoval = true)
     private final Set<String> allowedMarketDataSources;
 
     // Configurações de limitação
@@ -70,6 +91,30 @@ public class Portfolio {
         this.orderExecutionExchange = Objects.requireNonNull(orderExecutionExchange, "Order execution exchange cannot be null");
         this.allowedMarketDataSources = allowedMarketDataSources != null ?
                 Collections.unmodifiableSet(allowedMarketDataSources) : null;
+        this.safeModeStatus = SafeModeStatus.NORMAL;
+        this.capitalPoolingMode = CapitalPoolingMode.SHARED;
+    }
+
+    // ============================================================
+    // Safe Mode Management
+    // ============================================================
+
+    /**
+     * Atualiza o nível do Safe Mode do Portfolio.
+     *
+     * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.2.1, Blueprint 11.1.B.1</a>
+     */
+    public void setSafeModeStatus(SafeModeStatus status) {
+        this.safeModeStatus = Objects.requireNonNull(status, "SafeModeStatus cannot be null");
+    }
+
+    /**
+     * Atualiza o modo de pooling de capital.
+     *
+     * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.2.1, Blueprint 11.2.C</a>
+     */
+    public void setCapitalPoolingMode(CapitalPoolingMode mode) {
+        this.capitalPoolingMode = Objects.requireNonNull(mode, "CapitalPoolingMode cannot be null");
     }
 
     /**


### PR DESCRIPTION
## Summary

- Criado `GlobalBalance` com operações `reserve()`, `confirmExecution()` e `release()` para o novo fluxo de capital entre agregados
- Adicionados `safeModeStatus` (SafeModeStatus) e `capitalPoolingMode` (CapitalPoolingMode) ao Portfolio
- Campos legados do Portfolio marcados como `@Deprecated(forRemoval = true)`: strategyId, strategyName, symbol, orderExecutionExchange, allowedMarketDataSources
- Classe `Balance` marcada como `@Deprecated` — substituída por GlobalBalance no modelo alvo

## Abordagem

Seguindo a estratégia **additive-first** do IG 3.8: novos tipos criados primeiro, campos antigos mantidos para compatibilidade. A remoção efetiva acontece na migração (F1-08).

## Referência

- **IG Seção 3.2.1** — Portfolio (campos novos e removidos)
- **IG Seção 3.2.2** — GlobalBalance (substitui Balance)
- **IG Seção 3.8** — Estratégia de Migração (additive-first)

## Test plan

- [x] `./gradlew compileJava` — build completo sem erros
- [x] Revisão dos campos do GlobalBalance vs IG 3.2.2
- [x] Verificar semântica de reserve/confirmExecution/release

🤖 Generated with [Claude Code](https://claude.com/claude-code)