### PR TITLE
[F1-03] Criar sub-entidades do Portfolio (MarginAccount, DustAccount, DeadLetterEntry)

### DIFF
--- a/core/src/main/java/com/marmitt/core/domain/portfolio/DeadLetterEntry.java
+++ b/core/src/main/java/com/marmitt/core/domain/portfolio/DeadLetterEntry.java
@@ -1,0 +1,123 @@
+package com.marmitt.core.domain.portfolio;
+
+import com.marmitt.core.enums.DlqReason;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Captura execuções órfãs, IDs inválidos ou transações irreconciliáveis
+ * para intervenção manual.
+ * <p>
+ * Criado pelo Portfolio (Router) quando um callback da exchange não pode
+ * ser roteado para o Runner correto.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.2.5, Blueprint 4.D, 10.3.D</a>
+ */
+public class DeadLetterEntry {
+
+    private final UUID id;
+    private final UUID portfolioId;
+
+    /**
+     * clientOrderId extraído do payload. Nullable se malformado.
+     */
+    private final String clientOrderId;
+
+    /**
+     * ID atribuído pela exchange. Nullable se não disponível no payload.
+     */
+    private final String exchangeOrderId;
+
+    /**
+     * JSON original do callback da exchange — preservado integralmente para reprocessamento.
+     */
+    private final String rawPayload;
+
+    private final DlqReason reason;
+    private boolean isResolved;
+
+    /**
+     * Operador que resolveu manualmente. Nullable.
+     */
+    private String resolvedBy;
+
+    private Instant resolvedAt;
+    private final Instant createdAt;
+
+    /**
+     * Construtor para criação de novo registro DLQ.
+     */
+    public DeadLetterEntry(
+            UUID portfolioId,
+            String clientOrderId,
+            String exchangeOrderId,
+            String rawPayload,
+            DlqReason reason
+    ) {
+        this.id = UUID.randomUUID();
+        this.portfolioId = Objects.requireNonNull(portfolioId, "portfolioId cannot be null");
+        this.clientOrderId = clientOrderId;
+        this.exchangeOrderId = exchangeOrderId;
+        this.rawPayload = Objects.requireNonNull(rawPayload, "rawPayload cannot be null");
+        this.reason = Objects.requireNonNull(reason, "reason cannot be null");
+        this.isResolved = false;
+        this.resolvedBy = null;
+        this.resolvedAt = null;
+        this.createdAt = Instant.now();
+    }
+
+    /**
+     * Construtor completo para reconstituição a partir do banco de dados.
+     */
+    public DeadLetterEntry(
+            UUID id,
+            UUID portfolioId,
+            String clientOrderId,
+            String exchangeOrderId,
+            String rawPayload,
+            DlqReason reason,
+            boolean isResolved,
+            String resolvedBy,
+            Instant resolvedAt,
+            Instant createdAt
+    ) {
+        this.id = Objects.requireNonNull(id, "id cannot be null");
+        this.portfolioId = Objects.requireNonNull(portfolioId, "portfolioId cannot be null");
+        this.clientOrderId = clientOrderId;
+        this.exchangeOrderId = exchangeOrderId;
+        this.rawPayload = Objects.requireNonNull(rawPayload, "rawPayload cannot be null");
+        this.reason = Objects.requireNonNull(reason, "reason cannot be null");
+        this.isResolved = isResolved;
+        this.resolvedBy = resolvedBy;
+        this.resolvedAt = resolvedAt;
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt cannot be null");
+    }
+
+    /**
+     * Marca a entrada como resolvida por um operador.
+     *
+     * @param operator identificador do operador (nome, email, sistema)
+     */
+    public void resolve(String operator) {
+        if (this.isResolved) {
+            throw new IllegalStateException("DeadLetterEntry already resolved: " + id);
+        }
+        Objects.requireNonNull(operator, "operator cannot be null");
+        this.isResolved = true;
+        this.resolvedBy = operator;
+        this.resolvedAt = Instant.now();
+    }
+
+    public UUID getId() { return id; }
+    public UUID getPortfolioId() { return portfolioId; }
+    public String getClientOrderId() { return clientOrderId; }
+    public String getExchangeOrderId() { return exchangeOrderId; }
+    public String getRawPayload() { return rawPayload; }
+    public DlqReason getReason() { return reason; }
+    public boolean isResolved() { return isResolved; }
+    public String getResolvedBy() { return resolvedBy; }
+    public Instant getResolvedAt() { return resolvedAt; }
+    public Instant getCreatedAt() { return createdAt; }
+}

--- a/core/src/main/java/com/marmitt/core/domain/portfolio/DustAccount.java
+++ b/core/src/main/java/com/marmitt/core/domain/portfolio/DustAccount.java
@@ -1,0 +1,149 @@
+package com.marmitt.core.domain.portfolio;
+
+import com.marmitt.core.enums.DustSourceType;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Receptor universal de débitos não resolvidos e resíduos operacionais.
+ * Seus valores são excluídos do {@code availableBalance} do GlobalBalance,
+ * mantendo o capital de giro "limpo".
+ * <p>
+ * Fontes de entrada:
+ * <ul>
+ *   <li>{@code ROUNDING_DUST} — resíduo de arredondamento quando quantidade restante {@literal <} minQty da exchange</li>
+ *   <li>{@code TECHNICAL_DEBT} — falha na conversão de fee cross-currency (Fallback Crítico)</li>
+ * </ul>
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.2.4, Blueprint 9.2.C</a>
+ */
+public class DustAccount {
+
+    private final UUID id;
+    private final UUID portfolioId;
+
+    /**
+     * Runner que gerou o resíduo. Nullable para dust do próprio Portfolio.
+     */
+    private final UUID runnerId;
+
+    private final DustSourceType sourceType;
+    private final String originalAsset;
+    private final BigDecimal originalAmount;
+
+    /**
+     * Valor convertido para baseCurrency. Null = pendente de conversão.
+     */
+    private BigDecimal convertedAmount;
+
+    /**
+     * Transação que originou o resíduo. Nullable.
+     */
+    private final UUID transactionId;
+
+    private boolean isResolved;
+    private Instant resolvedAt;
+    private final Instant createdAt;
+
+    /**
+     * Construtor para criação de novo registro de dust/debt.
+     */
+    public DustAccount(
+            UUID portfolioId,
+            UUID runnerId,
+            DustSourceType sourceType,
+            String originalAsset,
+            BigDecimal originalAmount,
+            UUID transactionId
+    ) {
+        this.id = UUID.randomUUID();
+        this.portfolioId = Objects.requireNonNull(portfolioId, "portfolioId cannot be null");
+        this.runnerId = runnerId;
+        this.sourceType = Objects.requireNonNull(sourceType, "sourceType cannot be null");
+        this.originalAsset = validateAsset(originalAsset);
+        this.originalAmount = Objects.requireNonNull(originalAmount, "originalAmount cannot be null");
+        this.transactionId = transactionId;
+        this.convertedAmount = null;
+        this.isResolved = false;
+        this.resolvedAt = null;
+        this.createdAt = Instant.now();
+    }
+
+    /**
+     * Construtor completo para reconstituição a partir do banco de dados.
+     */
+    public DustAccount(
+            UUID id,
+            UUID portfolioId,
+            UUID runnerId,
+            DustSourceType sourceType,
+            String originalAsset,
+            BigDecimal originalAmount,
+            BigDecimal convertedAmount,
+            UUID transactionId,
+            boolean isResolved,
+            Instant resolvedAt,
+            Instant createdAt
+    ) {
+        this.id = Objects.requireNonNull(id, "id cannot be null");
+        this.portfolioId = Objects.requireNonNull(portfolioId, "portfolioId cannot be null");
+        this.runnerId = runnerId;
+        this.sourceType = Objects.requireNonNull(sourceType, "sourceType cannot be null");
+        this.originalAsset = validateAsset(originalAsset);
+        this.originalAmount = Objects.requireNonNull(originalAmount, "originalAmount cannot be null");
+        this.convertedAmount = convertedAmount;
+        this.transactionId = transactionId;
+        this.isResolved = isResolved;
+        this.resolvedAt = resolvedAt;
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt cannot be null");
+    }
+
+    /**
+     * Registra o valor convertido para baseCurrency após precificação.
+     */
+    public void setConvertedAmount(BigDecimal convertedAmount) {
+        Objects.requireNonNull(convertedAmount, "convertedAmount cannot be null");
+        if (convertedAmount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("convertedAmount cannot be negative");
+        }
+        this.convertedAmount = convertedAmount;
+    }
+
+    /**
+     * Marca o resíduo como resolvido (processado pelo Sweep Worker).
+     */
+    public void resolve() {
+        if (this.isResolved) {
+            throw new IllegalStateException("DustAccount already resolved: " + id);
+        }
+        this.isResolved = true;
+        this.resolvedAt = Instant.now();
+    }
+
+    public boolean isPendingConversion() {
+        return convertedAmount == null;
+    }
+
+    public UUID getId() { return id; }
+    public UUID getPortfolioId() { return portfolioId; }
+    public UUID getRunnerId() { return runnerId; }
+    public DustSourceType getSourceType() { return sourceType; }
+    public String getOriginalAsset() { return originalAsset; }
+    public BigDecimal getOriginalAmount() { return originalAmount; }
+    public BigDecimal getConvertedAmount() { return convertedAmount; }
+    public UUID getTransactionId() { return transactionId; }
+    public boolean isResolved() { return isResolved; }
+    public Instant getResolvedAt() { return resolvedAt; }
+    public Instant getCreatedAt() { return createdAt; }
+
+    private static String validateAsset(String asset) {
+        Objects.requireNonNull(asset, "originalAsset cannot be null");
+        if (asset.isBlank()) {
+            throw new IllegalArgumentException("originalAsset cannot be blank");
+        }
+        return asset.toUpperCase();
+    }
+}

--- a/core/src/main/java/com/marmitt/core/domain/portfolio/MarginAccount.java
+++ b/core/src/main/java/com/marmitt/core/domain/portfolio/MarginAccount.java
@@ -1,0 +1,124 @@
+package com.marmitt.core.domain.portfolio;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Controla o capital reservado por exchange/sub-conta de um Portfolio.
+ * Permite que um Portfolio opere em múltiplas exchanges simultaneamente,
+ * cada uma com sua própria contabilidade de margem.
+ * <p>
+ * Constraint: UNIQUE(portfolioId, exchangeId) — no máximo uma conta por exchange por portfolio.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.2.3, Blueprint 3, 7.A</a>
+ */
+public class MarginAccount {
+
+    private final UUID id;
+    private final UUID portfolioId;
+    private final String exchangeId;
+    private BigDecimal reservedCapital;
+    private BigDecimal totalFeesPaid;
+    private boolean isActive;
+    private final Instant createdAt;
+    private Instant updatedAt;
+    private Long version;
+
+    public MarginAccount(UUID portfolioId, String exchangeId) {
+        this.id = UUID.randomUUID();
+        this.portfolioId = Objects.requireNonNull(portfolioId, "portfolioId cannot be null");
+        this.exchangeId = validateExchangeId(exchangeId);
+        this.reservedCapital = BigDecimal.ZERO;
+        this.totalFeesPaid = BigDecimal.ZERO;
+        this.isActive = true;
+        this.createdAt = Instant.now();
+        this.updatedAt = Instant.now();
+        this.version = 0L;
+    }
+
+    /**
+     * Construtor completo para reconstituição a partir do banco de dados.
+     */
+    public MarginAccount(
+            UUID id,
+            UUID portfolioId,
+            String exchangeId,
+            BigDecimal reservedCapital,
+            BigDecimal totalFeesPaid,
+            boolean isActive,
+            Instant createdAt,
+            Instant updatedAt,
+            Long version
+    ) {
+        this.id = Objects.requireNonNull(id, "id cannot be null");
+        this.portfolioId = Objects.requireNonNull(portfolioId, "portfolioId cannot be null");
+        this.exchangeId = validateExchangeId(exchangeId);
+        this.reservedCapital = Objects.requireNonNull(reservedCapital, "reservedCapital cannot be null");
+        this.totalFeesPaid = Objects.requireNonNull(totalFeesPaid, "totalFeesPaid cannot be null");
+        this.isActive = isActive;
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt cannot be null");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt cannot be null");
+        this.version = version;
+    }
+
+    /**
+     * Adiciona capital reservado para ordens desta exchange.
+     */
+    public void addReservedCapital(BigDecimal amount) {
+        Objects.requireNonNull(amount, "amount cannot be null");
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Reserved capital amount must be positive");
+        }
+        this.reservedCapital = this.reservedCapital.add(amount);
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Libera capital reservado após execução ou cancelamento.
+     */
+    public void releaseReservedCapital(BigDecimal amount) {
+        Objects.requireNonNull(amount, "amount cannot be null");
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Release amount must be positive");
+        }
+        this.reservedCapital = this.reservedCapital.subtract(amount).max(BigDecimal.ZERO);
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Acumula fee paga nesta exchange (em baseCurrency).
+     */
+    public void accumulateFee(BigDecimal feeAmount) {
+        Objects.requireNonNull(feeAmount, "feeAmount cannot be null");
+        if (feeAmount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Fee amount cannot be negative");
+        }
+        this.totalFeesPaid = this.totalFeesPaid.add(feeAmount);
+        this.updatedAt = Instant.now();
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+        this.updatedAt = Instant.now();
+    }
+
+    public UUID getId() { return id; }
+    public UUID getPortfolioId() { return portfolioId; }
+    public String getExchangeId() { return exchangeId; }
+    public BigDecimal getReservedCapital() { return reservedCapital; }
+    public BigDecimal getTotalFeesPaid() { return totalFeesPaid; }
+    public boolean isActive() { return isActive; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+    public Long getVersion() { return version; }
+
+    private static String validateExchangeId(String exchangeId) {
+        Objects.requireNonNull(exchangeId, "exchangeId cannot be null");
+        if (exchangeId.isBlank()) {
+            throw new IllegalArgumentException("exchangeId cannot be blank");
+        }
+        return exchangeId.toUpperCase();
+    }
+}


### PR DESCRIPTION
## Summary

- **MarginAccount** — controla capital reservado por exchange/sub-conta. Constraint UNIQUE(portfolioId, exchangeId). Operações: `addReservedCapital()`, `releaseReservedCapital()`, `accumulateFee()`
- **DustAccount** — receptor de resíduos operacionais. Suporta `ROUNDING_DUST` (quantidade < minQty da exchange) e `TECHNICAL_DEBT` (falha de conversão fee cross-currency). Rastreia `convertedAmount` (nullable = pendente)
- **DeadLetterEntry** — DLQ para callbacks órfãos. Preserva `rawPayload` completo para reprocessamento manual. Resolve via `resolve(operator)`

## Referência

- **IG Seção 3.2.3** — MarginAccount
- **IG Seção 3.2.4** — DustAccount
- **IG Seção 3.2.5** — DeadLetterEntry (DLQ)
- **IG Seção 3.6** — Schema: `margin_accounts`, `dust_accounts`, `dead_letter_entries`

## Test plan

- [x] `./gradlew :core:compileJava` — sem erros
- [x] Revisar campos vs IG 3.2.3, 3.2.4, 3.2.5
- [x] Verificar constraint UNIQUE implícita no MarginAccount

🤖 Generated with [Claude Code](https://claude.com/claude-code)