### PR TITLE
[F1-09] Criar interface CapitalManager e DTOs

### DIFF
--- a/core/src/main/java/com/marmitt/core/dto/capital/CapitalRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/capital/CapitalRequest.java
@@ -1,0 +1,44 @@
+package com.marmitt.core.dto.capital;
+
+import com.marmitt.core.enums.TransactionType;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Payload da solicitação de reserva de capital enviada pelo Runner ao Portfolio.
+ * Entrada do método síncrono {@code CapitalManager.reserve()}.
+ * <p>
+ * {@code amount} inclui o safety buffer aplicado pelo Runner antes da chamada
+ * (ex: {@code rawAmount * 1.005} para cobrir slippage e fee estimada).
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 5.2.1, 7.2</a>
+ */
+public record CapitalRequest(
+        UUID transactionId,
+        UUID runnerId,
+        String runnerShortCode,
+        String symbol,
+        BigDecimal amount,
+        TransactionType type
+) {
+    public CapitalRequest {
+        Objects.requireNonNull(transactionId, "transactionId cannot be null");
+        Objects.requireNonNull(runnerId, "runnerId cannot be null");
+        Objects.requireNonNull(runnerShortCode, "runnerShortCode cannot be null");
+        Objects.requireNonNull(symbol, "symbol cannot be null");
+        Objects.requireNonNull(amount, "amount cannot be null");
+        Objects.requireNonNull(type, "type cannot be null");
+
+        if (runnerShortCode.isBlank()) {
+            throw new IllegalArgumentException("runnerShortCode cannot be blank");
+        }
+        if (symbol.isBlank()) {
+            throw new IllegalArgumentException("symbol cannot be blank");
+        }
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/capital/CapitalRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/capital/CapitalRequest.java
@@ -37,8 +37,11 @@ public record CapitalRequest(
         if (symbol.isBlank()) {
             throw new IllegalArgumentException("symbol cannot be blank");
         }
-        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new IllegalArgumentException("amount must be positive");
+        if (amount.compareTo(BigDecimal.ZERO) == 0) {
+            throw new IllegalArgumentException("amount cannot be zero");
+        }
+        if (amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("amount cannot be negative");
         }
     }
 }

--- a/core/src/main/java/com/marmitt/core/dto/capital/ExecutionConfirmation.java
+++ b/core/src/main/java/com/marmitt/core/dto/capital/ExecutionConfirmation.java
@@ -1,0 +1,50 @@
+package com.marmitt.core.dto.capital;
+
+import com.marmitt.core.domain.shared.Fee;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Payload da notificação de execução enviada pelo Runner ao Portfolio após cada match.
+ * Entrada do método assíncrono {@code CapitalManager.confirmExecution()}.
+ * <p>
+ * Publicado após cada {@code TransactionMatch} ser persistido (PARTIAL ou FILLED).
+ * O Portfolio usa {@code matchId} para garantir idempotência — duplicatas são descartadas.
+ * <p>
+ * Efeito contábil: {@code reserved -= totalCost}, {@code realized += pnlAmount},
+ * {@code totalFeesPaid += fee.convertedAmount()}.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 5.2.2</a>
+ */
+public record ExecutionConfirmation(
+        UUID transactionId,
+        UUID runnerId,
+        UUID matchId,
+        BigDecimal executedQuantity,
+        BigDecimal executedPrice,
+        Fee fee,
+        BigDecimal totalCost,
+        boolean isFinal
+) {
+    public ExecutionConfirmation {
+        Objects.requireNonNull(transactionId, "transactionId cannot be null");
+        Objects.requireNonNull(runnerId, "runnerId cannot be null");
+        Objects.requireNonNull(matchId, "matchId cannot be null");
+        Objects.requireNonNull(executedQuantity, "executedQuantity cannot be null");
+        Objects.requireNonNull(executedPrice, "executedPrice cannot be null");
+        Objects.requireNonNull(fee, "fee cannot be null");
+        Objects.requireNonNull(totalCost, "totalCost cannot be null");
+
+        if (executedQuantity.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("executedQuantity must be positive");
+        }
+        if (executedPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("executedPrice must be positive");
+        }
+        if (totalCost.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("totalCost cannot be negative");
+        }
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/capital/MarginRelease.java
+++ b/core/src/main/java/com/marmitt/core/dto/capital/MarginRelease.java
@@ -1,0 +1,60 @@
+package com.marmitt.core.dto.capital;
+
+import com.marmitt.core.enums.ReleaseReason;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Payload da devolução de margem enviada pelo Runner ao Portfolio quando uma
+ * Transaction atinge estado terminal sem execução total.
+ * Entrada do método assíncrono {@code CapitalManager.release()}.
+ * <p>
+ * {@code releaseAmount = originalReserved - executedAmount}.<br>
+ * Para REJECTED/EXPIRED: {@code executedAmount = ZERO} → estorno total da reserva.<br>
+ * Para CANCELED parcial: {@code executedAmount > ZERO} → estorno proporcional.
+ * <p>
+ * O Portfolio usa {@code transactionId} para garantir idempotência — duplicatas descartadas.
+ * Este evento <b>nunca pode ser perdido</b> — o Runner persiste localmente e reenvia em retry.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 5.2.3</a>
+ */
+public record MarginRelease(
+        UUID transactionId,
+        UUID runnerId,
+        BigDecimal releaseAmount,
+        ReleaseReason reason,
+        BigDecimal executedAmount
+) {
+    public MarginRelease {
+        Objects.requireNonNull(transactionId, "transactionId cannot be null");
+        Objects.requireNonNull(runnerId, "runnerId cannot be null");
+        Objects.requireNonNull(releaseAmount, "releaseAmount cannot be null");
+        Objects.requireNonNull(reason, "reason cannot be null");
+        Objects.requireNonNull(executedAmount, "executedAmount cannot be null");
+
+        if (releaseAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("releaseAmount must be positive");
+        }
+        if (executedAmount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("executedAmount cannot be negative");
+        }
+    }
+
+    /**
+     * Cria um release de estorno total (REJECTED ou EXPIRED).
+     */
+    public static MarginRelease fullRelease(UUID transactionId, UUID runnerId,
+                                            BigDecimal reservedAmount, ReleaseReason reason) {
+        return new MarginRelease(transactionId, runnerId, reservedAmount, reason, BigDecimal.ZERO);
+    }
+
+    /**
+     * Cria um release de estorno parcial (CANCELED após execução parcial).
+     */
+    public static MarginRelease partialRelease(UUID transactionId, UUID runnerId,
+                                               BigDecimal releaseAmount, BigDecimal executedAmount) {
+        return new MarginRelease(transactionId, runnerId, releaseAmount, ReleaseReason.CANCELED, executedAmount);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/capital/ReservationResult.java
+++ b/core/src/main/java/com/marmitt/core/dto/capital/ReservationResult.java
@@ -1,0 +1,44 @@
+package com.marmitt.core.dto.capital;
+
+import com.marmitt.core.enums.RejectionReason;
+import com.marmitt.core.enums.ReservationStatus;
+
+import java.util.UUID;
+
+/**
+ * Resultado síncrono da operação {@code CapitalManager.reserve()}.
+ * <p>
+ * Se {@code status == APPROVED}: {@code reservationId} identifica o lock contábil criado;
+ * {@code rejectionReason} é {@code null}.<br>
+ * Se {@code status == REJECTED}: {@code reservationId} é {@code null};
+ * {@code rejectionReason} indica o motivo.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 5.2.1</a>
+ */
+public record ReservationResult(
+        ReservationStatus status,
+        UUID reservationId,
+        RejectionReason rejectionReason
+) {
+    /**
+     * Cria um resultado de aprovação com o ID da reserva criada.
+     */
+    public static ReservationResult approved(UUID reservationId) {
+        return new ReservationResult(ReservationStatus.APPROVED, reservationId, null);
+    }
+
+    /**
+     * Cria um resultado de rejeição com o motivo.
+     */
+    public static ReservationResult rejected(RejectionReason reason) {
+        return new ReservationResult(ReservationStatus.REJECTED, null, reason);
+    }
+
+    public boolean isApproved() {
+        return status == ReservationStatus.APPROVED;
+    }
+
+    public boolean isRejected() {
+        return status == ReservationStatus.REJECTED;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/enums/RejectionReason.java
+++ b/core/src/main/java/com/marmitt/core/enums/RejectionReason.java
@@ -1,0 +1,25 @@
+package com.marmitt.core.enums;
+
+/**
+ * Motivo de rejeição de um Capital Request pelo Portfolio.
+ * Populado no {@code ReservationResult} quando {@code status == REJECTED}.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 5.2.1</a>
+ */
+public enum RejectionReason {
+
+    /** SafeMode ativo no Portfolio (HALT, CANCEL_ALL ou PANIC_SELL). */
+    RISK_VIOLATION,
+
+    /** A alocação do Runner excederia o limite percentual configurado. */
+    RUNNER_LIMIT_EXCEEDED,
+
+    /** Saldo disponível insuficiente para cobrir o amount solicitado. */
+    INSUFFICIENT_FUNDS,
+
+    /** Timeout na comunicação com o Portfolio. Runner trata como rejeição. */
+    TIMEOUT,
+
+    /** runnerId não encontrado no Portfolio — indica configuração inválida. */
+    UNKNOWN_RUNNER
+}

--- a/core/src/main/java/com/marmitt/core/enums/ReleaseReason.java
+++ b/core/src/main/java/com/marmitt/core/enums/ReleaseReason.java
@@ -1,0 +1,28 @@
+package com.marmitt.core.enums;
+
+/**
+ * Motivo da devolução de margem reservada via {@code CapitalManager.release()}.
+ * Determina o tipo de estorno contábil aplicado ao GlobalBalance.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 5.2.3</a>
+ */
+public enum ReleaseReason {
+
+    /**
+     * Portfolio recusou o Capital Request ou exchange rejeitou a ordem.
+     * executedAmount = 0 → estorno total da reserva.
+     */
+    REJECTED,
+
+    /**
+     * Ordem cancelada pelo Runner, operador ou exchange após submissão.
+     * executedAmount pode ser {@literal >} 0 (caso parcialmente executado antes do cancelamento).
+     */
+    CANCELED,
+
+    /**
+     * Ordem expirou (timeout do Watchdog) ou intenção não materializada (crash recovery).
+     * executedAmount = 0 → estorno total.
+     */
+    EXPIRED
+}

--- a/core/src/main/java/com/marmitt/core/enums/ReservationStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/ReservationStatus.java
@@ -1,0 +1,15 @@
+package com.marmitt.core.enums;
+
+/**
+ * Resultado de uma solicitação de reserva de capital via {@code CapitalManager.reserve()}.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 5.2.1</a>
+ */
+public enum ReservationStatus {
+
+    /** Capital reservado com sucesso. O Runner pode prosseguir com o Order Dispatch. */
+    APPROVED,
+
+    /** Reserva negada. O Runner deve descartar o sinal. */
+    REJECTED
+}

--- a/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/CapitalManager.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/CapitalManager.java
@@ -51,7 +51,9 @@ public interface CapitalManager {
      * <p>
      * Deve ser invocado após cada {@code TransactionMatch} ser persistido.
      * O Portfolio garante idempotência via {@code matchId} — duplicatas descartadas.
-     * Em caso de falha, o evento é reenfileirado com backoff exponencial (max 5 tentativas).
+     * Em caso de falha, o evento é reenfileirado com backoff exponencial. O número máximo de
+     * tentativas (default: 5) e o backoff são configuráveis via {@code @Retryable} na implementação
+     * do Portfolio (IG Seção 5.2.2). Após esgotar as tentativas, o evento vai para a DLQ.
      *
      * @param confirmation payload com matchId, quantidade executada, preço, fee e totalCost
      */

--- a/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/CapitalManager.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/CapitalManager.java
@@ -1,0 +1,71 @@
+package com.marmitt.core.ports.inbound.portfolio;
+
+import com.marmitt.core.dto.capital.CapitalRequest;
+import com.marmitt.core.dto.capital.ExecutionConfirmation;
+import com.marmitt.core.dto.capital.MarginRelease;
+import com.marmitt.core.dto.capital.ReservationResult;
+
+/**
+ * Único ponto de acoplamento entre StrategyRunner e Portfolio.
+ * O Runner injeta esta interface via Spring DI — nunca referencia Portfolio diretamente.
+ * <p>
+ * <b>Contrato de comunicação (Seção 5.2):</b>
+ * <ul>
+ *   <li>{@link #reserve} — síncrono, bloqueante, strong consistency</li>
+ *   <li>{@link #confirmExecution} — assíncrono, at-least-once, idempotente por {@code matchId}</li>
+ *   <li>{@link #release} — assíncrono, at-least-once sem limite de retry (capital preso é inaceitável)</li>
+ * </ul>
+ * <p>
+ * <b>Implementação V1 (monólito):</b>
+ * <ul>
+ *   <li>{@code reserve()} → chamada direta de método (síncrono in-process)</li>
+ *   <li>{@code confirmExecution()} → {@code ApplicationEventPublisher.publishEvent(ExecutionConfirmedEvent)}</li>
+ *   <li>{@code release()} → {@code ApplicationEventPublisher.publishEvent(MarginReleaseEvent)}</li>
+ * </ul>
+ * Listeners no Portfolio usam {@code @TransactionalEventListener(phase = AFTER_COMMIT)}
+ * para garantir que o Runner tenha commitado antes do processamento.
+ * <p>
+ * Esta interface isola o transporte — migrar para Outbox+Kafka (V2+) exige apenas
+ * nova implementação, sem alterar o domínio do Runner.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seções 5.2, 5.3</a>
+ */
+public interface CapitalManager {
+
+    /**
+     * Solicita reserva de capital para uma nova ordem.
+     * <b>Síncrono e bloqueante.</b> Ponto de serialização do GlobalBalance.
+     * <p>
+     * O Runner deve invocar este método após persistir a Transaction (PENDING)
+     * e antes do Order Dispatch. Se retornar REJECTED, a Transaction deve ser
+     * marcada como REJECTED e o sinal descartado.
+     *
+     * @param request payload com transactionId, runnerId, symbol, amount e tipo da operação
+     * @return {@link ReservationResult} com status APPROVED (com reservationId) ou REJECTED (com motivo)
+     */
+    ReservationResult reserve(CapitalRequest request);
+
+    /**
+     * Notifica o Portfolio sobre a execução (total ou parcial) de uma ordem.
+     * <b>Assíncrono, fire-and-forget com garantia at-least-once.</b>
+     * <p>
+     * Deve ser invocado após cada {@code TransactionMatch} ser persistido.
+     * O Portfolio garante idempotência via {@code matchId} — duplicatas descartadas.
+     * Em caso de falha, o evento é reenfileirado com backoff exponencial (max 5 tentativas).
+     *
+     * @param confirmation payload com matchId, quantidade executada, preço, fee e totalCost
+     */
+    void confirmExecution(ExecutionConfirmation confirmation);
+
+    /**
+     * Solicita devolução de margem reservada quando uma Transaction encerra sem execução total.
+     * <b>Assíncrono com retries ilimitados — capital preso (starvation) é inaceitável.</b>
+     * <p>
+     * Deve ser invocado quando a Transaction atinge REJECTED, CANCELED ou EXPIRED.
+     * O Runner persiste o evento localmente para garantir reenvio em caso de crash.
+     * O Portfolio garante idempotência via {@code transactionId}.
+     *
+     * @param release payload com transactionId, releaseAmount, motivo e executedAmount (parcial)
+     */
+    void release(MarginRelease release);
+}


### PR DESCRIPTION
## Resumo

Implementa o único ponto de acoplamento entre `StrategyRunner` e `Portfolio` conforme IG Seção 5.2.

## Mudanças

### Interface
- `CapitalManager` (`ports/inbound/portfolio`) — contrato com 3 operações:
  - `reserve(CapitalRequest)` → síncrono, bloqueante, strong consistency
  - `confirmExecution(ExecutionConfirmation)` → assíncrono, at-least-once, idempotente por `matchId`
  - `release(MarginRelease)` → assíncrono, retries ilimitados (capital preso = inaceitável)

### DTOs (`dto/capital/`)
- `CapitalRequest` — payload do `reserve()`: transactionId, runnerId, runnerShortCode, symbol, amount, type
- `ReservationResult` — resposta do `reserve()`: factory methods `approved(UUID)` / `rejected(RejectionReason)`
- `ExecutionConfirmation` — payload do `confirmExecution()`: matchId, executedQuantity, executedPrice, fee (Fee VO), totalCost, isFinal
- `MarginRelease` — payload do `release()`: releaseAmount, reason, executedAmount; factory methods `fullRelease()` / `partialRelease()`

### Enums
- `ReservationStatus` — APPROVED / REJECTED
- `RejectionReason` — RISK_VIOLATION, RUNNER_LIMIT_EXCEEDED, INSUFFICIENT_FUNDS, TIMEOUT, UNKNOWN_RUNNER
- `ReleaseReason` — REJECTED, CANCELED, EXPIRED

## Referências

- IG Seções 5.2.1, 5.2.2, 5.2.3, 5.3
- Blueprint Seção 4.C (Capital Request)

## Dependências

- Bloqueia: F1-10 (`reserve()` síncrono), F1-11 (`confirmExecution()` / `release()` assíncronos)
- Depende de: F1-01 ✅ (enums base, Fee VO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)