### PR TITLE
[F1-06] Refatorar Transaction e TransactionMatch

### DIFF
--- a/core/src/main/java/com/marmitt/core/domain/portfolio/Transaction.java
+++ b/core/src/main/java/com/marmitt/core/domain/portfolio/Transaction.java
@@ -11,6 +11,14 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 
+/**
+ * @deprecated Substituído por {@link com.marmitt.core.domain.runner.Transaction} no modelo alvo.
+ *             A nova Transaction é FK para StrategyRunner (não Portfolio), usa BigDecimal em vez de Asset,
+ *             adiciona exchangeOrderId, confidence, reasoning e version, e remove o campo fee
+ *             (fee migra para TransactionMatch).
+ *             Mantida temporariamente para compatibilidade durante a migração (F1-08).
+ */
+@Deprecated(forRemoval = true)
 @Builder
 @With
 public record Transaction(

--- a/core/src/main/java/com/marmitt/core/domain/portfolio/TransactionMatch.java
+++ b/core/src/main/java/com/marmitt/core/domain/portfolio/TransactionMatch.java
@@ -4,6 +4,13 @@ import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.UUID;
 
+/**
+ * @deprecated Substituído por {@link com.marmitt.core.domain.runner.TransactionMatch} no modelo alvo.
+ *             O novo TransactionMatch tem PK própria, runnerId, preços denormalizados (buyPrice/sellPrice),
+ *             Fee VO embutido e pnlRealized calculado.
+ *             Mantida temporariamente para compatibilidade durante a migração (F1-08).
+ */
+@Deprecated(forRemoval = true)
 public record TransactionMatch(
         UUID buyTransactionId,
         UUID sellTransactionId,

--- a/core/src/main/java/com/marmitt/core/domain/runner/Transaction.java
+++ b/core/src/main/java/com/marmitt/core/domain/runner/Transaction.java
@@ -3,6 +3,7 @@ package com.marmitt.core.domain.runner;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.enums.TransactionType;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -26,6 +27,7 @@ import java.util.UUID;
  *
  * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.3.3, Blueprint 4, 6.A, 10.1</a>
  */
+@Getter
 public class Transaction {
 
     private final UUID id;
@@ -60,7 +62,11 @@ public class Transaction {
     /** Preço médio ponderado de execução (em quote asset). Null enquanto PENDING/SUBMITTED. */
     private BigDecimal executedPrice;
 
-    /** Valor total estimado: {@code quantity × price} (em quote asset). */
+    /**
+     * Valor total estimado: {@code quantity × price} (em quote asset).
+     * O caller é responsável pelo arredondamento antes de passar este valor
+     * (convenção: {@code setScale(8, RoundingMode.HALF_UP)}).
+     */
     private final BigDecimal total;
 
     /**
@@ -293,30 +299,6 @@ public class Transaction {
         }
         return executedQuantity.multiply(executedPrice).setScale(8, RoundingMode.HALF_UP);
     }
-
-    // ============================================================
-    // Getters
-    // ============================================================
-
-    public UUID getId()                  { return id; }
-    public UUID getRunnerId()            { return runnerId; }
-    public String getClientOrderId()     { return clientOrderId; }
-    public String getExchangeOrderId()   { return exchangeOrderId; }
-    public TransactionStatus getStatus() { return status; }
-    public TransactionType getType()     { return type; }
-    public String getSymbol()            { return symbol; }
-    public BigDecimal getQuantity()      { return quantity; }
-    public BigDecimal getExecutedQuantity() { return executedQuantity; }
-    public BigDecimal getPrice()         { return price; }
-    public BigDecimal getExecutedPrice() { return executedPrice; }
-    public BigDecimal getTotal()         { return total; }
-    public BigDecimal getConfidence()    { return confidence; }
-    public String getReasoning()         { return reasoning; }
-    public UUID getTargetLotId()         { return targetLotId; }
-    public Instant getRequestedAt()      { return requestedAt; }
-    public Instant getExecutedAt()       { return executedAt; }
-    public String getRejectReason()      { return rejectReason; }
-    public Long getVersion()             { return version; }
 
     // ============================================================
     // Helpers

--- a/core/src/main/java/com/marmitt/core/domain/runner/Transaction.java
+++ b/core/src/main/java/com/marmitt/core/domain/runner/Transaction.java
@@ -1,0 +1,355 @@
+package com.marmitt.core.domain.runner;
+
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Ordem de compra/venda gerenciada pelo StrategyRunner.
+ * Migra do Portfolio para o StrategyRunner — a FK principal passa de
+ * {@code portfolioId} para {@code runnerId}.
+ * <p>
+ * <b>Simplificação Asset → BigDecimal:</b> campos numéricos (quantity, price, total)
+ * usam {@code BigDecimal} puro. A moeda é inferida do {@code symbol} (base/quote asset).
+ * <p>
+ * <b>Fee removida:</b> a fee deixa de ser campo da Transaction e passa a ser VO embutido
+ * em cada {@code TransactionMatch} — fees existem apenas onde há execução real.
+ * <p>
+ * <b>Campos de auditoria:</b> {@code confidence} e {@code reasoning} registram a
+ * motivação do sinal da estratégia para rastreabilidade (Blueprint 4.A).
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.3.3, Blueprint 4, 6.A, 10.1</a>
+ */
+public class Transaction {
+
+    private final UUID id;
+    private final UUID runnerId;
+
+    /**
+     * Chave de idempotência e roteamento. Formato: {@code v1r{shortCode}t{ts}s{seq}{type}_{uuid}}.
+     * NOT NULL, UNIQUE.
+     */
+    private final String clientOrderId;
+
+    /**
+     * ID atribuído pela exchange após aceite da ordem. Null se crash antes do dispatch.
+     */
+    private String exchangeOrderId;
+
+    private TransactionStatus status;
+    private final TransactionType type;
+
+    /** Par de trading (ex: "BTCUSDT"). */
+    private final String symbol;
+
+    /** Quantidade solicitada (em base asset). */
+    private final BigDecimal quantity;
+
+    /** Quantidade efetivamente executada acumulada (em base asset). Null enquanto PENDING/SUBMITTED. */
+    private BigDecimal executedQuantity;
+
+    /** Preço solicitado/estimado (em quote asset). */
+    private final BigDecimal price;
+
+    /** Preço médio ponderado de execução (em quote asset). Null enquanto PENDING/SUBMITTED. */
+    private BigDecimal executedPrice;
+
+    /** Valor total estimado: {@code quantity × price} (em quote asset). */
+    private final BigDecimal total;
+
+    /**
+     * Confiança do sinal da estratégia (0.0–1.0). Nullable.
+     * Registrado para auditoria e ajuste futuro de modelos.
+     */
+    private final BigDecimal confidence;
+
+    /**
+     * Motivação textual do sinal da estratégia. Nullable.
+     * Registrado para auditoria (Blueprint 4.A).
+     */
+    private final String reasoning;
+
+    /**
+     * Para SELL: UUID da {@code Position} específica a fechar.
+     * Null = AccountingPolicy decide (FIFO/LIFO).
+     */
+    private final UUID targetLotId;
+
+    private final Instant requestedAt;
+    private Instant executedAt;
+    private String rejectReason;
+    private Long version;
+
+    /**
+     * Construtor para criação de nova Transaction (status inicial = PENDING).
+     */
+    public Transaction(
+            UUID runnerId,
+            String clientOrderId,
+            TransactionType type,
+            String symbol,
+            BigDecimal quantity,
+            BigDecimal price,
+            BigDecimal total,
+            BigDecimal confidence,
+            String reasoning,
+            UUID targetLotId
+    ) {
+        this.id = UUID.randomUUID();
+        this.runnerId = Objects.requireNonNull(runnerId, "runnerId cannot be null");
+        this.clientOrderId = Objects.requireNonNull(clientOrderId, "clientOrderId cannot be null");
+        this.type = Objects.requireNonNull(type, "type cannot be null");
+        this.symbol = requireNonBlank(symbol, "symbol");
+        this.quantity = requirePositive(quantity, "quantity");
+        this.price = requirePositive(price, "price");
+        this.total = requirePositive(total, "total");
+        this.confidence = validateConfidence(confidence);
+        this.reasoning = reasoning;
+        this.targetLotId = targetLotId;
+        this.status = TransactionStatus.PENDING;
+        this.requestedAt = Instant.now();
+        this.version = 0L;
+    }
+
+    /**
+     * Construtor completo para reconstituição a partir do banco de dados.
+     * Use {@code Transaction.reconstitute().id(...).build()} via Builder gerado.
+     */
+    @Builder(builderMethodName = "reconstitute")
+    public Transaction(
+            UUID id,
+            UUID runnerId,
+            String clientOrderId,
+            String exchangeOrderId,
+            TransactionStatus status,
+            TransactionType type,
+            String symbol,
+            BigDecimal quantity,
+            BigDecimal executedQuantity,
+            BigDecimal price,
+            BigDecimal executedPrice,
+            BigDecimal total,
+            BigDecimal confidence,
+            String reasoning,
+            UUID targetLotId,
+            Instant requestedAt,
+            Instant executedAt,
+            String rejectReason,
+            Long version
+    ) {
+        this.id = Objects.requireNonNull(id, "id cannot be null");
+        this.runnerId = Objects.requireNonNull(runnerId, "runnerId cannot be null");
+        this.clientOrderId = Objects.requireNonNull(clientOrderId, "clientOrderId cannot be null");
+        this.exchangeOrderId = exchangeOrderId;
+        this.status = Objects.requireNonNull(status, "status cannot be null");
+        this.type = Objects.requireNonNull(type, "type cannot be null");
+        this.symbol = Objects.requireNonNull(symbol, "symbol cannot be null");
+        this.quantity = Objects.requireNonNull(quantity, "quantity cannot be null");
+        this.executedQuantity = executedQuantity;
+        this.price = Objects.requireNonNull(price, "price cannot be null");
+        this.executedPrice = executedPrice;
+        this.total = Objects.requireNonNull(total, "total cannot be null");
+        this.confidence = confidence;
+        this.reasoning = reasoning;
+        this.targetLotId = targetLotId;
+        this.requestedAt = Objects.requireNonNull(requestedAt, "requestedAt cannot be null");
+        this.executedAt = executedAt;
+        this.rejectReason = rejectReason;
+        this.version = version;
+    }
+
+    // ============================================================
+    // Status transitions
+    // ============================================================
+
+    /**
+     * Exchange aceitou a ordem — registra o {@code exchangeOrderId}.
+     * Transição: PENDING → SUBMITTED.
+     */
+    public void submit(String exchangeOrderId) {
+        requireStatus(TransactionStatus.PENDING, "submit");
+        this.exchangeOrderId = Objects.requireNonNull(exchangeOrderId, "exchangeOrderId cannot be null");
+        this.status = TransactionStatus.SUBMITTED;
+    }
+
+    /**
+     * Execução parcial recebida. Atualiza quantidade e preço médio acumulados.
+     * Transição: SUBMITTED | PARTIAL → PARTIAL.
+     *
+     * @param cumulativeQty   quantidade total executada até agora (acumulada, em base asset)
+     * @param avgExecutedPrice preço médio ponderado acumulado (em quote asset)
+     */
+    public void partialFill(BigDecimal cumulativeQty, BigDecimal avgExecutedPrice) {
+        if (this.status != TransactionStatus.SUBMITTED && this.status != TransactionStatus.PARTIAL) {
+            throw new IllegalStateException(
+                    "Cannot apply partial fill from status: " + this.status);
+        }
+        requirePositive(cumulativeQty, "cumulativeQty");
+        requirePositive(avgExecutedPrice, "avgExecutedPrice");
+
+        this.executedQuantity = cumulativeQty;
+        this.executedPrice = avgExecutedPrice;
+        this.status = TransactionStatus.PARTIAL;
+    }
+
+    /**
+     * Execução total concluída.
+     * Transição: SUBMITTED | PARTIAL → FILLED.
+     *
+     * @param cumulativeQty   quantidade total executada (deve igualar {@code quantity})
+     * @param avgExecutedPrice preço médio ponderado final (em quote asset)
+     */
+    public void fill(BigDecimal cumulativeQty, BigDecimal avgExecutedPrice) {
+        if (this.status != TransactionStatus.SUBMITTED && this.status != TransactionStatus.PARTIAL) {
+            throw new IllegalStateException(
+                    "Cannot apply fill from status: " + this.status);
+        }
+        requirePositive(cumulativeQty, "cumulativeQty");
+        requirePositive(avgExecutedPrice, "avgExecutedPrice");
+
+        this.executedQuantity = cumulativeQty;
+        this.executedPrice = avgExecutedPrice;
+        this.executedAt = Instant.now();
+        this.status = TransactionStatus.FILLED;
+    }
+
+    /**
+     * Ordem cancelada (pelo Runner, operador ou exchange).
+     * Transição: PENDING | SUBMITTED | PARTIAL → CANCELED.
+     */
+    public void cancel() {
+        if (this.status == TransactionStatus.FILLED || this.status.isFinal()) {
+            throw new IllegalStateException(
+                    "Cannot cancel from status: " + this.status);
+        }
+        this.status = TransactionStatus.CANCELED;
+    }
+
+    /**
+     * Ordem expirou (timeout do Watchdog ou intenção não materializada após crash).
+     * Transição: PENDING | SUBMITTED → EXPIRED.
+     */
+    public void expire() {
+        if (this.status != TransactionStatus.PENDING && this.status != TransactionStatus.SUBMITTED) {
+            throw new IllegalStateException(
+                    "Cannot expire from status: " + this.status);
+        }
+        this.status = TransactionStatus.EXPIRED;
+    }
+
+    /**
+     * Ordem rejeitada (Portfolio negou Capital Request ou exchange rejeitou).
+     * Transição: PENDING | SUBMITTED → REJECTED.
+     *
+     * @param reason motivo da rejeição (não pode ser null)
+     */
+    public void reject(String reason) {
+        if (this.status != TransactionStatus.PENDING && this.status != TransactionStatus.SUBMITTED) {
+            throw new IllegalStateException(
+                    "Cannot reject from status: " + this.status);
+        }
+        this.rejectReason = Objects.requireNonNull(reason, "reason cannot be null");
+        this.status = TransactionStatus.REJECTED;
+    }
+
+    // ============================================================
+    // Query methods
+    // ============================================================
+
+    public boolean isBuy()  { return type == TransactionType.BUY; }
+    public boolean isSell() { return type == TransactionType.SELL; }
+    public boolean isPending()   { return status == TransactionStatus.PENDING; }
+    public boolean isSubmitted() { return status == TransactionStatus.SUBMITTED; }
+    public boolean isFinal()     { return status.isFinal(); }
+    public boolean isFailed()    { return status.isFailed(); }
+
+    /**
+     * Quantidade executada ou ZERO se ainda não houve execução.
+     */
+    public BigDecimal getEffectiveExecutedQuantity() {
+        return executedQuantity != null ? executedQuantity : BigDecimal.ZERO;
+    }
+
+    /**
+     * Preço efetivo de execução ou preço solicitado como fallback.
+     */
+    public BigDecimal getEffectiveExecutedPrice() {
+        return executedPrice != null ? executedPrice : price;
+    }
+
+    /**
+     * Valor executado acumulado: {@code executedQuantity × executedPrice}.
+     * Retorna ZERO se ainda não houve execução.
+     */
+    public BigDecimal getExecutedValue() {
+        if (executedQuantity == null || executedPrice == null) {
+            return BigDecimal.ZERO;
+        }
+        return executedQuantity.multiply(executedPrice).setScale(8, RoundingMode.HALF_UP);
+    }
+
+    // ============================================================
+    // Getters
+    // ============================================================
+
+    public UUID getId()                  { return id; }
+    public UUID getRunnerId()            { return runnerId; }
+    public String getClientOrderId()     { return clientOrderId; }
+    public String getExchangeOrderId()   { return exchangeOrderId; }
+    public TransactionStatus getStatus() { return status; }
+    public TransactionType getType()     { return type; }
+    public String getSymbol()            { return symbol; }
+    public BigDecimal getQuantity()      { return quantity; }
+    public BigDecimal getExecutedQuantity() { return executedQuantity; }
+    public BigDecimal getPrice()         { return price; }
+    public BigDecimal getExecutedPrice() { return executedPrice; }
+    public BigDecimal getTotal()         { return total; }
+    public BigDecimal getConfidence()    { return confidence; }
+    public String getReasoning()         { return reasoning; }
+    public UUID getTargetLotId()         { return targetLotId; }
+    public Instant getRequestedAt()      { return requestedAt; }
+    public Instant getExecutedAt()       { return executedAt; }
+    public String getRejectReason()      { return rejectReason; }
+    public Long getVersion()             { return version; }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private void requireStatus(TransactionStatus expected, String operation) {
+        if (this.status != expected) {
+            throw new IllegalStateException(
+                    "Cannot " + operation + " from status: " + this.status + " (expected: " + expected + ")");
+        }
+    }
+
+    private static BigDecimal requirePositive(BigDecimal value, String fieldName) {
+        Objects.requireNonNull(value, fieldName + " cannot be null");
+        if (value.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException(fieldName + " must be positive");
+        }
+        return value;
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        Objects.requireNonNull(value, fieldName + " cannot be null");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+
+    private static BigDecimal validateConfidence(BigDecimal confidence) {
+        if (confidence == null) return null;
+        if (confidence.compareTo(BigDecimal.ZERO) < 0 || confidence.compareTo(BigDecimal.ONE) > 0) {
+            throw new IllegalArgumentException("confidence must be between 0.0 and 1.0");
+        }
+        return confidence;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/domain/runner/TransactionMatch.java
+++ b/core/src/main/java/com/marmitt/core/domain/runner/TransactionMatch.java
@@ -105,7 +105,8 @@ public record TransactionMatch(
         BigDecimal grossPnl = sellPrice.subtract(buyPrice)
                 .multiply(matchedQuantity)
                 .setScale(8, RoundingMode.HALF_UP);
-        BigDecimal pnlRealized = grossPnl.subtract(fee.getConvertedAmountOrZero());
+        BigDecimal pnlRealized = grossPnl.subtract(fee.getConvertedAmountOrZero())
+                .setScale(8, RoundingMode.HALF_UP);
 
         return new TransactionMatch(
                 UUID.randomUUID(),

--- a/core/src/main/java/com/marmitt/core/domain/runner/TransactionMatch.java
+++ b/core/src/main/java/com/marmitt/core/domain/runner/TransactionMatch.java
@@ -1,0 +1,123 @@
+package com.marmitt.core.domain.runner;
+
+import com.marmitt.core.domain.shared.Fee;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Registro imutável de uma execução de matching entre compra e venda.
+ * Ganha PK própria, {@code runnerId}, preços denormalizados, Fee VO embutido
+ * e PnL realizado — permite cálculos sem JOINs adicionais.
+ * <p>
+ * <b>Constraint DB:</b> {@code UNIQUE(buyTransactionId, sellTransactionId)} garante
+ * integridade de matching sem ser a PK.
+ * <p>
+ * <b>Imutabilidade:</b> TransactionMatch nunca é alterado após criação — é um registro
+ * histórico de uma execução. Use o factory method {@link #create} para instanciar.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 3.3.4, Blueprint 4.D, 9.1, 9.3</a>
+ */
+public record TransactionMatch(
+        UUID id,
+        UUID runnerId,
+        UUID buyTransactionId,
+        UUID sellTransactionId,
+        BigDecimal matchedQuantity,
+
+        /** Preço de execução da compra no momento do match (em quote asset). Denormalizado. */
+        BigDecimal buyPrice,
+
+        /** Preço de execução da venda no momento do match (em quote asset). Denormalizado. */
+        BigDecimal sellPrice,
+
+        /**
+         * Fee desta execução. Pode ser cross-currency (ex: BNB).
+         * Se {@code fee.isPendingConversion()}, Portfolio converte via Mark Price
+         * e registra em DustAccount em caso de falha.
+         */
+        Fee fee,
+
+        /**
+         * PnL líquido deste match:
+         * {@code (sellPrice - buyPrice) × matchedQuantity - fee.convertedAmountOrZero()}.
+         * Em quote asset.
+         */
+        BigDecimal pnlRealized,
+
+        Instant createdAt
+) {
+    public TransactionMatch {
+        Objects.requireNonNull(id, "id cannot be null");
+        Objects.requireNonNull(runnerId, "runnerId cannot be null");
+        Objects.requireNonNull(buyTransactionId, "buyTransactionId cannot be null");
+        Objects.requireNonNull(sellTransactionId, "sellTransactionId cannot be null");
+        Objects.requireNonNull(matchedQuantity, "matchedQuantity cannot be null");
+        Objects.requireNonNull(buyPrice, "buyPrice cannot be null");
+        Objects.requireNonNull(sellPrice, "sellPrice cannot be null");
+        Objects.requireNonNull(fee, "fee cannot be null");
+        Objects.requireNonNull(pnlRealized, "pnlRealized cannot be null");
+        Objects.requireNonNull(createdAt, "createdAt cannot be null");
+
+        if (matchedQuantity.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("matchedQuantity must be positive");
+        }
+        if (buyPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("buyPrice must be positive");
+        }
+        if (sellPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("sellPrice must be positive");
+        }
+    }
+
+    /**
+     * Factory method para criação de um novo match.
+     * Calcula automaticamente o {@code pnlRealized} a partir dos preços e fee.
+     *
+     * @param runnerId         Runner que originou as transações
+     * @param buyTransactionId FK para a Transaction de compra
+     * @param sellTransactionId FK para a Transaction de venda
+     * @param matchedQuantity  quantidade casada neste match (em base asset)
+     * @param buyPrice         preço de execução da compra (em quote asset)
+     * @param sellPrice        preço de execução da venda (em quote asset)
+     * @param fee              fee desta execução (pode ser cross-currency)
+     */
+    public static TransactionMatch create(
+            UUID runnerId,
+            UUID buyTransactionId,
+            UUID sellTransactionId,
+            BigDecimal matchedQuantity,
+            BigDecimal buyPrice,
+            BigDecimal sellPrice,
+            Fee fee
+    ) {
+        Objects.requireNonNull(runnerId, "runnerId cannot be null");
+        Objects.requireNonNull(buyTransactionId, "buyTransactionId cannot be null");
+        Objects.requireNonNull(sellTransactionId, "sellTransactionId cannot be null");
+        Objects.requireNonNull(matchedQuantity, "matchedQuantity cannot be null");
+        Objects.requireNonNull(buyPrice, "buyPrice cannot be null");
+        Objects.requireNonNull(sellPrice, "sellPrice cannot be null");
+        Objects.requireNonNull(fee, "fee cannot be null");
+
+        BigDecimal grossPnl = sellPrice.subtract(buyPrice)
+                .multiply(matchedQuantity)
+                .setScale(8, RoundingMode.HALF_UP);
+        BigDecimal pnlRealized = grossPnl.subtract(fee.getConvertedAmountOrZero());
+
+        return new TransactionMatch(
+                UUID.randomUUID(),
+                runnerId,
+                buyTransactionId,
+                sellTransactionId,
+                matchedQuantity,
+                buyPrice,
+                sellPrice,
+                fee,
+                pnlRealized,
+                Instant.now()
+        );
+    }
+}

--- a/core/src/main/java/com/marmitt/core/enums/TransactionStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/TransactionStatus.java
@@ -16,9 +16,17 @@ public enum TransactionStatus {
     SUBMITTED,
 
     /**
-     * Transação parcialmente executada
+     * Transação parcialmente executada.
+     *
+     * @deprecated Substituído por {@link #PARTIAL} no modelo alvo (F1-06). Removido em F1-08.
      */
+    @Deprecated(forRemoval = true)
     PARTIALLY_FILLED,
+
+    /**
+     * Transação parcialmente executada — pelo menos um TransactionMatch existe.
+     */
+    PARTIAL,
 
     /**
      * Transação completamente executada com sucesso
@@ -53,8 +61,9 @@ public enum TransactionStatus {
     /**
      * Verifica se a transação foi executada (total ou parcialmente)
      */
+    @SuppressWarnings("deprecation")
     public boolean isExecuted() {
-        return this == FILLED || this == PARTIALLY_FILLED;
+        return this == FILLED || this == PARTIALLY_FILLED || this == PARTIAL;
     }
 
     /**


### PR DESCRIPTION
## Resumo

Refatora `Transaction` e `TransactionMatch` para o modelo dois agregados (IG Seção 3.3.3–3.3.4). Estratégia additive-first: novas classes em `domain.runner`, versões antigas em `domain.portfolio` marcadas `@Deprecated(forRemoval=true)` até F1-08.

## Mudanças

### `domain.runner.Transaction` (nova)
- **`runnerId`** substitui `portfolioId` como FK principal
- **BigDecimal** em todos os campos numéricos (quantity, price, total, executedQuantity, executedPrice) — elimina padrão Asset 3-colunas
- **Campos novos:** `exchangeOrderId` (ID da exchange, nullable), `confidence` (0.0–1.0, auditoria), `reasoning` (TEXT, auditoria), `version` (optimistic lock)
- **Campo removido:** `fee` — migra para `TransactionMatch`
- **Lifecycle explícito:** `submit()`, `partialFill()`, `fill()`, `cancel()`, `expire()`, `reject(reason)`
- **`@Builder(builderMethodName="reconstitute")`** no construtor de 19 parâmetros

### `domain.runner.TransactionMatch` (nova)
- **PK própria** (`id UUID`) — antes PK composta `(buyTransactionId, sellTransactionId)`
- **`runnerId`** para queries eficientes sem JOIN
- **Preços denormalizados:** `buyPrice` e `sellPrice` — cálculos sem JOIN adicional
- **`Fee` VO embutido** (feeAmount, feeAsset, feeType, feeConvertedAmount)
- **`pnlRealized`** calculado automaticamente no factory `create()`: `(sellPrice - buyPrice) × matchedQuantity - feeConverted`
- Constraint DB: `UNIQUE(buyTransactionId, sellTransactionId)`

### `TransactionStatus`
- Adiciona `PARTIAL` (substitui `PARTIALLY_FILLED`)
- `PARTIALLY_FILLED` marcado `@Deprecated(forRemoval=true)`
- Helpers `isExecuted()` atualizados para incluir `PARTIAL`

### Deprecated
- `domain.portfolio.Transaction` → `@Deprecated(forRemoval=true)`
- `domain.portfolio.TransactionMatch` → `@Deprecated(forRemoval=true)`

## Dependências

- Depende de: F1-01 ✅ (Fee VO, FeeType), F1-04 ✅ (StrategyRunner), F1-05 ✅ (runner.Position para targetLotId)
- Desbloqueia: F1-07 (StrategyRunnerRepository), F1-08 (Flyway migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)