### PR TITLE
feat(F2-01): implement ProcessTradeSignal flow (Persist-First protocol)

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/exception/CapitalReservationRejectedException.java
+++ b/core/src/main/java/com/marmitt/core/application/exception/CapitalReservationRejectedException.java
@@ -1,0 +1,37 @@
+package com.marmitt.core.application.exception;
+
+import com.marmitt.core.enums.RejectionReason;
+
+import java.util.UUID;
+
+/**
+ * Lançada pelo {@code ProcessTradeSignalService} quando a reserva de capital é rejeitada.
+ * <p>
+ * Por ser um {@code RuntimeException}, sinaliza ao container transacional (@Transactional)
+ * que o rollback deve ser executado, desfazendo a persistência da Transaction PENDING
+ * e do lock de Position (quando aplicável) no mesmo banco de dados.
+ * <p>
+ * O caller (Handler de Spring) captura esta exceção, loga o evento e descarta o sinal —
+ * não há retry para rejeição de capital.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.2.1 (passo 6c)</a>
+ */
+public class CapitalReservationRejectedException extends RuntimeException {
+
+    private final UUID transactionId;
+    private final RejectionReason reason;
+
+    public CapitalReservationRejectedException(UUID transactionId, RejectionReason reason) {
+        super("Capital reservation rejected for transaction " + transactionId + ": " + reason);
+        this.transactionId = transactionId;
+        this.reason = reason;
+    }
+
+    public UUID getTransactionId() {
+        return transactionId;
+    }
+
+    public RejectionReason getReason() {
+        return reason;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/ProcessTradeSignalService.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/ProcessTradeSignalService.java
@@ -1,0 +1,279 @@
+package com.marmitt.core.application.usecase.runner;
+
+import com.marmitt.core.application.exception.CapitalReservationRejectedException;
+import com.marmitt.core.application.usecase.portfolio.ReserveCapitalService;
+import com.marmitt.core.domain.runner.ClientOrderId;
+import com.marmitt.core.domain.runner.Position;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.capital.CapitalRequest;
+import com.marmitt.core.dto.capital.ReservationResult;
+import com.marmitt.core.dto.runner.OrderAck;
+import com.marmitt.core.dto.runner.OrderDispatchCommand;
+import com.marmitt.core.dto.strategy.StrategyOutputDto;
+import com.marmitt.core.enums.ExecutionPolicy;
+import com.marmitt.core.enums.TradingAction;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Serviço central do fluxo ProcessTradeSignal (F2-01).
+ * <p>
+ * Implementa o protocolo Persist-First (IG Seção 6.2.1), em 9 passos:
+ * <ol>
+ *   <li>Validar Runner (canAcceptSignals)</li>
+ *   <li>Validar sinal (HOLD → discard)</li>
+ *   <li>Validar Execution Policy (SINGLE: rejeitar se posição aberta para BUY)</li>
+ *   <li>Mapear TradingAction → TransactionType</li>
+ *   <li>Gerar ClientOrderId</li>
+ *   <li>Atomicamente: persistir Transaction PENDING + (SELL) lock de Position + reservar capital</li>
+ *   <li>Despachar ordem para a exchange via {@code OrderDispatchPort}</li>
+ *   <li>Processar ACK: ACCEPTED → submit(); REJECTED → reject(); TIMEOUT → manter PENDING</li>
+ * </ol>
+ * <p>
+ * <b>Limite de @Transactional:</b> os passos 6a-6c (persist + lock + reserve) são
+ * executados dentro de uma transação de banco gerenciada pelo Handler de Spring
+ * {@code ProcessTradeSignalHandler.persistAndReserve()}, que delimita o limite @Transactional.
+ * Se a reserva de capital falhar, {@link CapitalReservationRejectedException} é lançada
+ * para acionar rollback automático. O dispatch (passo 7) ocorre FORA da transação.
+ *
+ * @implNote Pertence ao fluxo <b>ProcessTradeSignal</b>.
+ *           Será integrado ao fluxo completo em refatoração futura (F2-01 absorção).
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.2.1</a>
+ */
+@Slf4j
+public class ProcessTradeSignalService {
+
+    /** Safety buffer aplicado ao amount antes de reservar capital (0.5%). */
+    private static final BigDecimal SAFETY_BUFFER = new BigDecimal("1.005");
+
+    private final StrategyRunnerRepositoryPort runnerRepository;
+    private final ReserveCapitalService reserveCapitalService;
+    private final OrderDispatchPort orderDispatchPort;
+
+    public ProcessTradeSignalService(
+            StrategyRunnerRepositoryPort runnerRepository,
+            ReserveCapitalService reserveCapitalService,
+            OrderDispatchPort orderDispatchPort
+    ) {
+        this.runnerRepository = runnerRepository;
+        this.reserveCapitalService = reserveCapitalService;
+        this.orderDispatchPort = orderDispatchPort;
+    }
+
+    // ============================================================
+    // Passo 1-5: Validação e Preparação (fora da transação de banco)
+    // ============================================================
+
+    /**
+     * Valida o sinal antes de entrar na zona transacional.
+     * Retorna {@code false} se o sinal deve ser descartado silenciosamente.
+     *
+     * @param runner runner que recebeu o sinal
+     * @param signal output da estratégia
+     * @return {@code true} se o sinal deve ser processado; {@code false} para descartar
+     */
+    public boolean validate(StrategyRunner runner, StrategyOutputDto signal) {
+        // Passo 1: Runner pode aceitar sinais
+        if (!runner.canAcceptSignals()) {
+            log.warn("processTradeSignal: runner={} cannot accept signals (status={} reconciling={})",
+                    runner.getId(), runner.getStatus(), runner.isReconciling());
+            return false;
+        }
+
+        // Passo 2: HOLD → discard
+        if (signal.decision() == TradingAction.SHOULD_HOLD) {
+            log.debug("processTradeSignal: HOLD signal discarded for runner={}", runner.getId());
+            return false;
+        }
+
+        // Passo 3: Execution Policy SINGLE
+        if (runner.getExecutionPolicy() == ExecutionPolicy.SINGLE) {
+            TransactionType type = mapToTransactionType(signal.decision());
+            if (type == TransactionType.BUY) {
+                boolean hasOpenPositionOrInflight = hasOpenPositionOrInflight(runner);
+                if (hasOpenPositionOrInflight) {
+                    log.info("processTradeSignal: BUY signal rejected by SINGLE policy — " +
+                                    "open position or in-flight orders exist for runner={}",
+                            runner.getId());
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Prepara a Transaction para persistência — gera clientOrderId, calcula total.
+     * Não persiste — a persistência é responsabilidade do Handler.
+     *
+     * @param runner       runner que processa o sinal
+     * @param signal       output da estratégia
+     * @param currentPrice preço de mercado corrente
+     * @return Transaction no status PENDING, pronta para persistência
+     */
+    public Transaction buildTransaction(StrategyRunner runner, StrategyOutputDto signal,
+                                        BigDecimal currentPrice) {
+        TransactionType type = mapToTransactionType(signal.decision());
+        String clientOrderId = ClientOrderId.generate(runner.getShortCode(), type);
+        BigDecimal total = signal.quantity()
+                .multiply(currentPrice)
+                .setScale(8, RoundingMode.HALF_UP);
+
+        return new Transaction(
+                runner.getId(),
+                clientOrderId,
+                type,
+                runner.getSymbol(),
+                signal.quantity(),
+                currentPrice,
+                total,
+                signal.confidence(),
+                signal.reasoning(),
+                signal.targetLotId()
+        );
+    }
+
+    /**
+     * Constrói o {@link CapitalRequest} para a reserva de capital.
+     * Aplica o safety buffer de 0.5% ao amount (total * 1.005).
+     *
+     * @param runner      runner que solicita a reserva
+     * @param transaction transaction criada em {@link #buildTransaction}
+     * @return CapitalRequest pronto para {@code ReserveCapitalService.reserve()}
+     */
+    public CapitalRequest buildCapitalRequest(StrategyRunner runner, Transaction transaction) {
+        BigDecimal amountWithBuffer = transaction.getTotal()
+                .multiply(SAFETY_BUFFER)
+                .setScale(8, RoundingMode.HALF_UP);
+
+        return new CapitalRequest(
+                transaction.getId(),
+                runner.getId(),
+                runner.getShortCode(),
+                runner.getSymbol(),
+                amountWithBuffer,
+                transaction.getType()
+        );
+    }
+
+    /**
+     * Reserva capital. Lança {@link CapitalReservationRejectedException} se rejeitada,
+     * para acionar rollback da transação de banco corrente.
+     *
+     * @param request capital request montado em {@link #buildCapitalRequest}
+     * @throws CapitalReservationRejectedException se o capital não foi aprovado
+     */
+    public void reserveCapital(CapitalRequest request) {
+        ReservationResult result = reserveCapitalService.reserve(request);
+        if (result.isRejected()) {
+            log.warn("processTradeSignal: capital reservation rejected — transactionId={} reason={}",
+                    request.transactionId(), result.rejectionReason());
+            throw new CapitalReservationRejectedException(request.transactionId(), result.rejectionReason());
+        }
+        log.debug("processTradeSignal: capital reserved — transactionId={} reservationId={}",
+                request.transactionId(), result.reservationId());
+    }
+
+    // ============================================================
+    // Passo 7-8: Dispatch e ACK (fora da transação de banco)
+    // ============================================================
+
+    /**
+     * Despacha a ordem para a exchange e processa o ACK.
+     * <p>
+     * <ul>
+     *   <li>ACCEPTED → chama {@code transaction.submit(exchangeOrderId)}</li>
+     *   <li>REJECTED → chama {@code transaction.reject(reason)}</li>
+     *   <li>TIMEOUT  → mantém PENDING (Boot Sequence reconcilia)</li>
+     * </ul>
+     * O caller deve persistir a Transaction após este método.
+     *
+     * @param runner      runner dono da transação
+     * @param transaction transaction persistida com status PENDING
+     * @return o ACK retornado pela exchange
+     */
+    public OrderAck dispatchAndApplyAck(StrategyRunner runner, Transaction transaction) {
+        OrderDispatchCommand command = new OrderDispatchCommand(
+                transaction.getClientOrderId(),
+                runner.getId(),
+                runner.getSymbol(),
+                runner.getExchangeId(),
+                transaction.getType(),
+                transaction.getQuantity(),
+                transaction.getPrice()
+        );
+
+        OrderAck ack = orderDispatchPort.dispatch(command);
+
+        switch (ack.status()) {
+            case ACCEPTED -> {
+                transaction.submit(ack.exchangeOrderId());
+                log.info("processTradeSignal: order accepted — clientOrderId={} exchangeOrderId={}",
+                        transaction.getClientOrderId(), ack.exchangeOrderId());
+            }
+            case REJECTED -> {
+                transaction.reject(ack.rejectionReason());
+                log.warn("processTradeSignal: order rejected by exchange — clientOrderId={} reason={}",
+                        transaction.getClientOrderId(), ack.rejectionReason());
+            }
+            case TIMEOUT -> log.warn(
+                    "processTradeSignal: dispatch timeout — clientOrderId={} left as PENDING for reconciliation",
+                    transaction.getClientOrderId());
+        }
+
+        return ack;
+    }
+
+    // ============================================================
+    // Position helpers
+    // ============================================================
+
+    /**
+     * Busca a Position alvo para uma operação de SELL.
+     * Usa {@code targetLotId} se informado; caso contrário, busca a posição aberta do símbolo.
+     *
+     * @param runner runner dono da transação
+     * @param signal output da estratégia
+     * @return Position aberta, se encontrada
+     */
+    public Optional<Position> findTargetPosition(StrategyRunner runner, StrategyOutputDto signal) {
+        if (signal.targetLotId() != null) {
+            return runnerRepository.findPositionById(signal.targetLotId());
+        }
+        return runnerRepository.findOpenPositionByRunnerIdAndSymbol(runner.getId(), runner.getSymbol());
+    }
+
+    // ============================================================
+    // Private helpers
+    // ============================================================
+
+    private TransactionType mapToTransactionType(TradingAction action) {
+        return switch (action) {
+            case SHOULD_BUY -> TransactionType.BUY;
+            case SHOULD_SELL -> TransactionType.SELL;
+            default -> throw new IllegalArgumentException("Cannot map TradingAction to TransactionType: " + action);
+        };
+    }
+
+    private boolean hasOpenPositionOrInflight(StrategyRunner runner) {
+        List<Position> openPositions = runnerRepository.findOpenPositionsByRunnerId(runner.getId());
+        if (!openPositions.isEmpty()) return true;
+
+        List<com.marmitt.core.domain.runner.Transaction> inflight =
+                runnerRepository.findByRunnerIdAndStatuses(runner.getId(), List.of(
+                        com.marmitt.core.enums.TransactionStatus.PENDING,
+                        com.marmitt.core.enums.TransactionStatus.SUBMITTED,
+                        com.marmitt.core.enums.TransactionStatus.PARTIAL
+                ));
+        return !inflight.isEmpty();
+    }
+}

--- a/core/src/main/java/com/marmitt/core/domain/runner/ClientOrderId.java
+++ b/core/src/main/java/com/marmitt/core/domain/runner/ClientOrderId.java
@@ -1,0 +1,82 @@
+package com.marmitt.core.domain.runner;
+
+import com.marmitt.core.enums.TransactionType;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Utilitário estático para geração e parsing de clientOrderId.
+ * <p>
+ * Formato: {@code v1r{shortCode}t{epochMillis}s{seq3d}{type}_{uuid12chars}}
+ * <p>
+ * Exemplo: {@code v1r01ft1700000000000s001B_a3f9c2d14e7b}
+ * <ul>
+ *   <li>{@code v1} — versão do formato</li>
+ *   <li>{@code r{shortCode}} — código curto do Runner (2-4 chars)</li>
+ *   <li>{@code t{epochMillis}} — timestamp em milissegundos</li>
+ *   <li>{@code s{seq3d}} — sequência de 3 dígitos (0-padded, wraps at 999)</li>
+ *   <li>{@code {type}} — B=BUY, S=SELL</li>
+ *   <li>{@code _{uuid12chars}} — primeiros 12 chars de um UUID sem hifens</li>
+ * </ul>
+ * <p>
+ * Unicidade garantida pela combinação timestamp + seq + uuid parcial.
+ * O prefixo {@code v1r{shortCode}} serve como chave de roteamento no Portfolio
+ * para identificar qual Runner emitiu a ordem.
+ *
+ * @implNote Utilitário de domínio — sem dependências de framework.
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 5.6</a>
+ */
+public final class ClientOrderId {
+
+    private static final AtomicInteger SEQ = new AtomicInteger(0);
+
+    private ClientOrderId() {
+    }
+
+    /**
+     * Gera um novo clientOrderId único para o Runner e tipo informados.
+     *
+     * @param shortCode código curto do Runner (2-4 chars)
+     * @param type      BUY ou SELL
+     * @return clientOrderId no formato {@code v1r{shortCode}t{ts}s{seq}{type}_{uuid12}}
+     */
+    public static String generate(String shortCode, TransactionType type) {
+        long ts = System.currentTimeMillis();
+        int seq = SEQ.getAndUpdate(v -> (v + 1) % 1000);
+        String typeChar = type == TransactionType.BUY ? "B" : "S";
+        String uuid12 = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        return String.format("v1r%st%ds%03d%s_%s", shortCode, ts, seq, typeChar, uuid12);
+    }
+
+    /**
+     * Extrai o {@code shortCode} do Runner a partir do clientOrderId.
+     * Retorna {@code null} se o formato não for reconhecido.
+     *
+     * @param clientOrderId clientOrderId no formato v1 esperado
+     * @return shortCode (ex: "01f") ou {@code null}
+     */
+    public static String getRunnerShortCode(String clientOrderId) {
+        if (clientOrderId == null || !clientOrderId.startsWith("v1r")) {
+            return null;
+        }
+        int tIndex = clientOrderId.indexOf('t');
+        if (tIndex < 3) {
+            return null;
+        }
+        return clientOrderId.substring(3, tIndex);
+    }
+
+    /**
+     * Valida se o clientOrderId está no formato v1 esperado.
+     *
+     * @param clientOrderId string a validar
+     * @return {@code true} se o formato é válido
+     */
+    public static boolean isValid(String clientOrderId) {
+        if (clientOrderId == null) return false;
+        return clientOrderId.startsWith("v1r")
+                && clientOrderId.contains("t")
+                && clientOrderId.contains("_");
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/runner/OrderAck.java
+++ b/core/src/main/java/com/marmitt/core/dto/runner/OrderAck.java
@@ -1,0 +1,55 @@
+package com.marmitt.core.dto.runner;
+
+import java.util.Objects;
+
+/**
+ * Resposta síncrona do {@code OrderDispatchPort} após tentativa de envio de ordem.
+ * <p>
+ * Três outcomes possíveis:
+ * <ul>
+ *   <li>{@link AckStatus#ACCEPTED} — exchange aceitou a ordem; {@code exchangeOrderId} não é null.</li>
+ *   <li>{@link AckStatus#REJECTED} — exchange rejeitou a ordem (inválida, fora de limites, etc.);
+ *       {@code rejectionReason} explica o motivo.</li>
+ *   <li>{@link AckStatus#TIMEOUT} — não foi possível confirmar aceitação dentro do SLA;
+ *       a Transaction permanece PENDING para reconciliação no Boot Sequence (F2-06).</li>
+ * </ul>
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.2.1, 6.3.2</a>
+ */
+public record OrderAck(
+        AckStatus status,
+        String exchangeOrderId,
+        String rejectionReason
+) {
+
+    public enum AckStatus {
+        ACCEPTED,
+        REJECTED,
+        TIMEOUT
+    }
+
+    public OrderAck {
+        Objects.requireNonNull(status, "status cannot be null");
+    }
+
+    /** Exchange aceitou a ordem e atribuiu um ID. */
+    public static OrderAck accepted(String exchangeOrderId) {
+        Objects.requireNonNull(exchangeOrderId, "exchangeOrderId cannot be null");
+        return new OrderAck(AckStatus.ACCEPTED, exchangeOrderId, null);
+    }
+
+    /** Exchange rejeitou explicitamente a ordem. */
+    public static OrderAck rejected(String reason) {
+        Objects.requireNonNull(reason, "reason cannot be null");
+        return new OrderAck(AckStatus.REJECTED, null, reason);
+    }
+
+    /** Envio não confirmado dentro do SLA — deixar para reconciliação. */
+    public static OrderAck timeout() {
+        return new OrderAck(AckStatus.TIMEOUT, null, null);
+    }
+
+    public boolean isAccepted() { return status == AckStatus.ACCEPTED; }
+    public boolean isRejected() { return status == AckStatus.REJECTED; }
+    public boolean isTimeout()  { return status == AckStatus.TIMEOUT; }
+}

--- a/core/src/main/java/com/marmitt/core/dto/runner/OrderDispatchCommand.java
+++ b/core/src/main/java/com/marmitt/core/dto/runner/OrderDispatchCommand.java
@@ -1,0 +1,42 @@
+package com.marmitt.core.dto.runner;
+
+import com.marmitt.core.enums.TransactionType;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Comando enviado ao {@code OrderDispatchPort} para submeter uma ordem na exchange.
+ * <p>
+ * Carrega os dados mínimos necessários para o adapter construir a requisição REST/WebSocket
+ * específica da exchange. O adapter não deve persistir nem acessar repositórios.
+ *
+ * @param clientOrderId chave de idempotência gerada pelo Runner
+ * @param runnerId      UUID do Runner que emite a ordem
+ * @param symbol        par de trading (ex: "BTCUSDT")
+ * @param exchangeId    identificador da exchange destino
+ * @param type          BUY ou SELL
+ * @param quantity      quantidade a negociar (em base asset)
+ * @param price         preço de referência (market price — a exchange decide o melhor fill)
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.2.1</a>
+ */
+public record OrderDispatchCommand(
+        String clientOrderId,
+        UUID runnerId,
+        String symbol,
+        String exchangeId,
+        TransactionType type,
+        BigDecimal quantity,
+        BigDecimal price
+) {
+    public OrderDispatchCommand {
+        Objects.requireNonNull(clientOrderId, "clientOrderId cannot be null");
+        Objects.requireNonNull(runnerId, "runnerId cannot be null");
+        Objects.requireNonNull(symbol, "symbol cannot be null");
+        Objects.requireNonNull(exchangeId, "exchangeId cannot be null");
+        Objects.requireNonNull(type, "type cannot be null");
+        Objects.requireNonNull(quantity, "quantity cannot be null");
+        Objects.requireNonNull(price, "price cannot be null");
+    }
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/OrderDispatchPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/OrderDispatchPort.java
@@ -1,0 +1,34 @@
+package com.marmitt.core.ports.outbound.exchange;
+
+import com.marmitt.core.dto.runner.OrderAck;
+import com.marmitt.core.dto.runner.OrderDispatchCommand;
+
+/**
+ * Porta de saída para envio de ordens a uma exchange.
+ * <p>
+ * Cada exchange tem sua própria implementação (Binance, Mock, etc.).
+ * A implementação deve:
+ * <ul>
+ *   <li>Enviar a ordem para a exchange usando o protocolo adequado (REST/WebSocket)</li>
+ *   <li>Aguardar confirmação síncrona dentro do SLA configurado</li>
+ *   <li>Retornar {@link OrderAck#accepted(String)} se a exchange atribuiu um ID</li>
+ *   <li>Retornar {@link OrderAck#rejected(String)} se a exchange recusou explicitamente</li>
+ *   <li>Retornar {@link OrderAck#timeout()} se o SLA expirou sem resposta</li>
+ * </ul>
+ * <p>
+ * <b>Contrato de exceções:</b> o adapter NUNCA deve lançar exceção por rejeição ou timeout
+ * — o {@link OrderAck} é o contrato. Exceções técnicas (falha de conexão, serialização)
+ * podem ser propagadas e serão tratadas pelo chamador.
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.2.1, 6.3.2</a>
+ */
+public interface OrderDispatchPort {
+
+    /**
+     * Despacha uma ordem para a exchange e aguarda confirmação síncrona.
+     *
+     * @param command dados da ordem a enviar
+     * @return {@link OrderAck} com o resultado do dispatch
+     */
+    OrderAck dispatch(OrderDispatchCommand command);
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
@@ -1,0 +1,76 @@
+package com.marmitt.application.spring.config.core;
+
+import com.marmitt.core.application.usecase.portfolio.ConfirmExecutionService;
+import com.marmitt.core.application.usecase.portfolio.HandleExecutionConfirmedService;
+import com.marmitt.core.application.usecase.portfolio.HandleMarginReleaseService;
+import com.marmitt.core.application.usecase.portfolio.ReserveCapitalService;
+import com.marmitt.core.application.usecase.portfolio.ReleaseMarginService;
+import com.marmitt.core.application.usecase.runner.ProcessTradeSignalService;
+import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
+import com.marmitt.core.ports.outbound.repository.GlobalBalanceRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuração Spring dos serviços do fluxo Runner (F2-01 e subsequentes).
+ * <p>
+ * Registra os serviços provisórios de capital e o {@code ProcessTradeSignalService}.
+ * Os serviços marcados com {@code @implNote} serão absorvidos pelos fluxos corretos
+ * durante refatoração futura (F2-xx).
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.2.1</a>
+ */
+@Configuration
+public class RunnerConfig {
+
+    // ── Serviços de capital provisórios (F1-11, absorção futura em F2-xx) ────
+
+    @Bean
+    public ReserveCapitalService reserveCapital(
+            StrategyRunnerRepositoryPort runnerRepository,
+            PortfolioRepositoryPort portfolioRepository,
+            GlobalBalanceRepositoryPort globalBalanceRepository
+    ) {
+        return new ReserveCapitalService(runnerRepository, portfolioRepository, globalBalanceRepository);
+    }
+
+    @Bean
+    public ConfirmExecutionService confirmExecution(EventPublisherPort eventPublisher) {
+        return new ConfirmExecutionService(eventPublisher);
+    }
+
+    @Bean
+    public ReleaseMarginService releaseMargin(EventPublisherPort eventPublisher) {
+        return new ReleaseMarginService(eventPublisher);
+    }
+
+    @Bean
+    public HandleExecutionConfirmedService handleExecutionConfirmed(
+            StrategyRunnerRepositoryPort runnerRepository,
+            GlobalBalanceRepositoryPort globalBalanceRepository
+    ) {
+        return new HandleExecutionConfirmedService(runnerRepository, globalBalanceRepository);
+    }
+
+    @Bean
+    public HandleMarginReleaseService handleMarginRelease(
+            StrategyRunnerRepositoryPort runnerRepository,
+            GlobalBalanceRepositoryPort globalBalanceRepository
+    ) {
+        return new HandleMarginReleaseService(runnerRepository, globalBalanceRepository);
+    }
+
+    // ── Serviços do fluxo ProcessTradeSignal (F2-01) ─────────────────────────
+
+    @Bean
+    public ProcessTradeSignalService processTradeSignal(
+            StrategyRunnerRepositoryPort runnerRepository,
+            ReserveCapitalService reserveCapitalService,
+            OrderDispatchPort orderDispatchPort
+    ) {
+        return new ProcessTradeSignalService(runnerRepository, reserveCapitalService, orderDispatchPort);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/handler/ProcessTradeSignalHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/handler/ProcessTradeSignalHandler.java
@@ -1,0 +1,142 @@
+package com.marmitt.application.spring.handler;
+
+import com.marmitt.core.application.exception.CapitalReservationRejectedException;
+import com.marmitt.core.application.usecase.runner.ProcessTradeSignalService;
+import com.marmitt.core.domain.runner.Position;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.capital.CapitalRequest;
+import com.marmitt.core.dto.runner.OrderAck;
+import com.marmitt.core.dto.strategy.StrategyOutputDto;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/**
+ * Handler Spring do fluxo ProcessTradeSignal (F2-01).
+ * <p>
+ * Coordena o protocolo Persist-First delegando lógica de domínio ao
+ * {@link ProcessTradeSignalService} e gerenciando os limites @Transactional.
+ * <p>
+ * <b>Limites de transação:</b>
+ * <ul>
+ *   <li>{@link #handle}: ponto de entrada — sem transação ativa. Válida e prepara o sinal.
+ *       Chama {@link #persistAndReserve} dentro de uma transação, depois dispatch fora.</li>
+ *   <li>{@link #persistAndReserve}: {@code @Transactional(rollbackFor = ...)} — persiste
+ *       Transaction PENDING, aplica lock de Position (SELL) e reserva capital atomicamente.
+ *       Lança {@link CapitalReservationRejectedException} para acionar rollback.</li>
+ *   <li>{@link #handleAck}: {@code @Transactional} — atualiza status da Transaction
+ *       após receber ACK da exchange.</li>
+ * </ul>
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.2.1</a>
+ */
+@Component
+@Slf4j
+public class ProcessTradeSignalHandler {
+
+    private final ProcessTradeSignalService service;
+    private final StrategyRunnerRepositoryPort runnerRepository;
+
+    public ProcessTradeSignalHandler(
+            ProcessTradeSignalService service,
+            StrategyRunnerRepositoryPort runnerRepository
+    ) {
+        this.service = service;
+        this.runnerRepository = runnerRepository;
+    }
+
+    /**
+     * Ponto de entrada do fluxo ProcessTradeSignal.
+     * <p>
+     * Sem transação ativa — orquestra os passos 1-8 do protocolo Persist-First.
+     *
+     * @param runner       runner que recebeu o sinal
+     * @param signal       output da estratégia
+     * @param currentPrice preço de mercado corrente
+     */
+    public void handle(StrategyRunner runner, StrategyOutputDto signal, BigDecimal currentPrice) {
+        // Passos 1-3: validação
+        if (!service.validate(runner, signal)) {
+            return;
+        }
+
+        // Passos 4-5: construção da Transaction (sem persistência)
+        Transaction transaction = service.buildTransaction(runner, signal, currentPrice);
+        CapitalRequest capitalRequest = service.buildCapitalRequest(runner, transaction);
+
+        // Passo 6: persiste Transaction + lock Position (SELL) + reserva capital — atômico
+        Optional<Position> targetPosition = Optional.empty();
+        if (transaction.getType() == TransactionType.SELL) {
+            targetPosition = service.findTargetPosition(runner, signal);
+            if (targetPosition.isEmpty()) {
+                log.warn("processTradeSignal: SELL signal discarded — no open position for runner={} symbol={}",
+                        runner.getId(), runner.getSymbol());
+                return;
+            }
+        }
+
+        try {
+            persistAndReserve(transaction, targetPosition.orElse(null), capitalRequest);
+        } catch (CapitalReservationRejectedException ex) {
+            log.warn("processTradeSignal: signal discarded — capital rejected transactionId={} reason={}",
+                    ex.getTransactionId(), ex.getReason());
+            return;
+        }
+
+        // Passo 7-8: dispatch e ACK (fora da transação de banco)
+        OrderAck ack = service.dispatchAndApplyAck(runner, transaction);
+        handleAck(transaction, ack);
+    }
+
+    /**
+     * Persiste atomicamente Transaction PENDING, lock de Position (quando SELL) e reserva capital.
+     * <p>
+     * {@code @Transactional} garante rollback automático se {@link CapitalReservationRejectedException}
+     * for lançada — desfazendo a persistência da Transaction e do lock de Position.
+     *
+     * @param transaction    transaction criada em {@link ProcessTradeSignalService#buildTransaction}
+     * @param targetPosition position a bloquear (SELL); null para BUY
+     * @param capitalRequest request de reserva criado em {@link ProcessTradeSignalService#buildCapitalRequest}
+     * @throws CapitalReservationRejectedException se a reserva de capital falhar
+     */
+    @Transactional(rollbackFor = CapitalReservationRejectedException.class)
+    public void persistAndReserve(Transaction transaction, Position targetPosition,
+                                  CapitalRequest capitalRequest) {
+        if (targetPosition != null) {
+            // Passo 6a-6b: persiste Transaction e aplica lock de Position atomicamente
+            targetPosition.lock(transaction.getId(), transaction.getQuantity());
+            targetPosition.startClosing();
+            runnerRepository.saveAtomicTransactionAndPositionLock(transaction, targetPosition);
+        } else {
+            // Passo 6a (BUY): persiste Transaction apenas
+            runnerRepository.saveTransaction(transaction);
+        }
+
+        // Passo 6c: reserva capital — lança exceção para rollback se rejeitada
+        service.reserveCapital(capitalRequest);
+    }
+
+    /**
+     * Persiste o status da Transaction após o ACK da exchange.
+     * <p>
+     * {@code @Transactional} — ACCEPTED e REJECTED resultam em salvar status atualizado.
+     * TIMEOUT não salva (Transaction permanece PENDING para reconciliação no Boot Sequence).
+     *
+     * @param transaction transaction com status já atualizado pelo {@code dispatchAndApplyAck}
+     * @param ack         ACK retornado pela exchange
+     */
+    @Transactional
+    public void handleAck(Transaction transaction, OrderAck ack) {
+        if (ack.isTimeout()) {
+            // Transaction permanece PENDING — Boot Sequence (F2-06) reconcilia
+            return;
+        }
+        runnerRepository.saveTransaction(transaction);
+    }
+}


### PR DESCRIPTION
## Summary

- Implements the **ProcessTradeSignal** operational flow (IG Section 6.2.1) using the Persist-First protocol
- Adds `ClientOrderId` static utility, `OrderDispatchPort` outbound port, `OrderAck`/`OrderDispatchCommand` DTOs
- `ProcessTradeSignalService` handles domain logic: Runner validation, SINGLE execution policy guard, Transaction building, capital reservation via `ReserveCapitalService`, dispatch + ACK processing
- `ProcessTradeSignalHandler` (Spring) manages `@Transactional` boundaries: `persistAndReserve()` atomically persists Transaction + Position lock (SELL) + reserves capital; rollback via `CapitalReservationRejectedException`
- `RunnerConfig` wires all Runner and capital services as Spring beans

## @Transactional boundaries

| Method | Boundary |
|---|---|
| `handle()` | No transaction — orchestrates the 8-step flow |
| `persistAndReserve()` | `@Transactional(rollbackFor = CapitalReservationRejectedException)` — atomic DB write |
| `handleAck()` | `@Transactional` — persists Transaction status after ACK |

## TIMEOUT handling

When `OrderAck.TIMEOUT` is returned, `Transaction` remains `PENDING`. Boot Sequence (F2-06) will reconcile orphan PENDING transactions.

## Test plan

- [ ] Verify `ClientOrderId.generate()` produces valid, unique IDs with correct format
- [ ] Verify `validate()` returns `false` for HOLD, non-ACTIVE runner, SINGLE policy with open position
- [ ] Verify `persistAndReserve()` rolls back Transaction on capital rejection
- [ ] Verify ACCEPTED ACK transitions Transaction to SUBMITTED
- [ ] Verify REJECTED ACK transitions Transaction to REJECTED  
- [ ] Verify TIMEOUT leaves Transaction as PENDING

🤖 Generated with [Claude Code](https://claude.com/claude-code)