### PR TITLE
feat(F2-03): implement HandleOrderTermination flow

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/HandleOrderTerminationService.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/HandleOrderTerminationService.java
@@ -136,44 +136,52 @@ public class HandleOrderTerminationService {
                 .multiply(SAFETY_BUFFER)
                 .setScale(8, RoundingMode.HALF_UP);
 
-        MarginRelease release;
-
-        if (status == TransactionStatus.REJECTED || status == TransactionStatus.EXPIRED) {
-            release = MarginRelease.fullRelease(
-                    transaction.getId(),
-                    transaction.getRunnerId(),
-                    reserved,
-                    mapToReleaseReason(status)
-            );
-
-        } else { // CANCELED
-            BigDecimal executedValue = transaction.getExecutedValue();
-            BigDecimal toRelease = reserved.subtract(executedValue)
-                    .setScale(8, RoundingMode.HALF_UP);
-
-            if (toRelease.compareTo(BigDecimal.ZERO) <= 0) {
-                log.info("handleOrderTermination: no margin to release for CANCELED " +
-                                "transactionId={} (reserved={} executedValue={})",
-                        transaction.getId(), reserved, executedValue);
-                return;
-            }
-
-            release = MarginRelease.partialRelease(
-                    transaction.getId(),
-                    transaction.getRunnerId(),
-                    toRelease,
-                    executedValue
-            );
-        }
-
-        releaseMarginService.release(release);
-        log.info("handleOrderTermination: margin release published transactionId={} amount={} reason={}",
-                transaction.getId(), release.releaseAmount(), release.reason());
+        buildMarginRelease(transaction, reserved, status).ifPresent(release -> {
+            releaseMarginService.release(release);
+            log.info("handleOrderTermination: margin release published transactionId={} amount={} reason={}",
+                    transaction.getId(), release.releaseAmount(), release.reason());
+        });
     }
 
     // ============================================================
     // Private helpers
     // ============================================================
+
+    /**
+     * Constrói o {@link MarginRelease} apropriado para o status terminal.
+     * Retorna {@code null} para CANCELED cujo executedValue já cobre a reserva integralmente
+     * (nenhum release necessário).
+     */
+    private Optional<MarginRelease> buildMarginRelease(Transaction transaction, BigDecimal reserved,
+                                                       TransactionStatus status) {
+        if (status == TransactionStatus.REJECTED || status == TransactionStatus.EXPIRED) {
+            return Optional.of(MarginRelease.fullRelease(
+                    transaction.getId(),
+                    transaction.getRunnerId(),
+                    reserved,
+                    mapToReleaseReason(status)
+            ));
+        }
+
+        // CANCELED
+        BigDecimal executedValue = transaction.getExecutedValue();
+        BigDecimal toRelease = reserved.subtract(executedValue)
+                .setScale(8, RoundingMode.HALF_UP);
+
+        if (toRelease.compareTo(BigDecimal.ZERO) <= 0) {
+            log.info("handleOrderTermination: no margin to release for CANCELED " +
+                            "transactionId={} (reserved={} executedValue={})",
+                    transaction.getId(), reserved, executedValue);
+            return Optional.empty();
+        }
+
+        return Optional.of(MarginRelease.partialRelease(
+                transaction.getId(),
+                transaction.getRunnerId(),
+                toRelease,
+                executedValue
+        ));
+    }
 
     private ReleaseReason mapToReleaseReason(TransactionStatus status) {
         return switch (status) {

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/HandleOrderTerminationService.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/HandleOrderTerminationService.java
@@ -1,0 +1,186 @@
+package com.marmitt.core.application.usecase.runner;
+
+import com.marmitt.core.application.usecase.portfolio.ReleaseMarginService;
+import com.marmitt.core.domain.runner.Position;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.capital.MarginRelease;
+import com.marmitt.core.enums.PositionStatus;
+import com.marmitt.core.enums.ReleaseReason;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Optional;
+
+/**
+ * Serviço central do fluxo HandleOrderTermination (F2-03).
+ * <p>
+ * Processa o encerramento de Transactions que atingiram status terminal
+ * ({@code REJECTED}, {@code CANCELED}, {@code EXPIRED}), realizando:
+ * <ol>
+ *   <li>Desbloqueio da Position alvo (apenas para SELL)</li>
+ *   <li>Cálculo do montante a ser estornado</li>
+ *   <li>Publicação do {@code MarginReleaseEvent} via {@link ReleaseMarginService}</li>
+ * </ol>
+ * <p>
+ * <b>Cálculo do release:</b><br>
+ * O montante reservado foi {@code transaction.total × 1.005} (safety buffer aplicado em
+ * {@code ProcessTradeSignalService}). Para cada motivo de encerramento:
+ * <ul>
+ *   <li>{@code REJECTED} / {@code EXPIRED}: estorno total — {@code reserved}</li>
+ *   <li>{@code CANCELED}: estorno parcial — {@code reserved − executedValue}.
+ *       Se {@code ≤ 0}, o capital já foi integralmente confirmado via
+ *       {@code ExecutionConfirmedEvent}; nenhum release é necessário.</li>
+ * </ul>
+ * <p>
+ * <b>Idempotência:</b> garantida pelo {@code HandleMarginReleaseService} (Portfolio side),
+ * que verifica {@code reservedBalance >= releaseAmount} antes de aplicar o estorno.
+ *
+ * @implNote Pertence ao fluxo <b>HandleOrderTermination</b>.
+ *           Triggers: dispatch REJECTED (F2-01), exchange callbacks (F2-02),
+ *           Watchdog timeout (F2-06/F2-07).
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.3, 5.2.3</a>
+ */
+@Slf4j
+public class HandleOrderTerminationService {
+
+    /**
+     * Safety buffer aplicado na reserva de capital (deve ser idêntico ao de
+     * {@code ProcessTradeSignalService#SAFETY_BUFFER}).
+     */
+    private static final BigDecimal SAFETY_BUFFER = new BigDecimal("1.005");
+
+    private final StrategyRunnerRepositoryPort runnerRepository;
+    private final ReleaseMarginService releaseMarginService;
+
+    public HandleOrderTerminationService(
+            StrategyRunnerRepositoryPort runnerRepository,
+            ReleaseMarginService releaseMarginService
+    ) {
+        this.runnerRepository = runnerRepository;
+        this.releaseMarginService = releaseMarginService;
+    }
+
+    // ============================================================
+    // Position unlock
+    // ============================================================
+
+    /**
+     * Localiza e desbloqueia a Position vinculada à Transaction de SELL.
+     * <p>
+     * Retorna a Position modificada (pronta para persistência pelo Handler)
+     * ou {@code Optional.empty()} se:
+     * <ul>
+     *   <li>A Transaction é BUY (não há lock de Position)</li>
+     *   <li>Nenhuma posição encontrada para o símbolo do Runner</li>
+     *   <li>A posição encontrada não está bloqueada por esta Transaction</li>
+     * </ul>
+     *
+     * @param transaction transaction em estado terminal
+     * @return Position com lock removido e status reaberto, se aplicável
+     */
+    public Optional<Position> findAndUnlockPosition(Transaction transaction) {
+        if (!transaction.isSell()) {
+            return Optional.empty();
+        }
+
+        Optional<Position> positionOpt = Optional.empty();
+
+        // Preferência pelo targetLotId (FIFO/LIFO explícito)
+        if (transaction.getTargetLotId() != null) {
+            positionOpt = runnerRepository.findPositionById(transaction.getTargetLotId());
+        }
+
+        // Fallback: posição aberta do símbolo no Runner
+        if (positionOpt.isEmpty()) {
+            positionOpt = runnerRepository.findOpenPositionByRunnerIdAndSymbol(
+                    transaction.getRunnerId(), transaction.getSymbol());
+        }
+
+        return positionOpt
+                .filter(pos -> transaction.getId().equals(pos.getLockedByTransactionId()))
+                .map(pos -> {
+                    pos.unlock();
+                    if (pos.getStatus() == PositionStatus.CLOSING) {
+                        pos.reopen();
+                    }
+                    log.debug("handleOrderTermination: position unlocked positionId={} transactionId={}",
+                            pos.getId(), transaction.getId());
+                    return pos;
+                });
+    }
+
+    // ============================================================
+    // Margin release
+    // ============================================================
+
+    /**
+     * Calcula o montante a estornar e publica o {@code MarginReleaseEvent}.
+     * <p>
+     * Para {@code CANCELED} com {@code executedValue ≥ reserved}, o estorno é zero
+     * (capital já totalmente confirmado pelo HandleExecutionConfirmedService) e
+     * nenhum evento é publicado.
+     *
+     * @param transaction transaction em estado terminal com status já atualizado
+     */
+    public void releaseMargin(Transaction transaction) {
+        TransactionStatus status = transaction.getStatus();
+        if (!status.isFinal() || status == TransactionStatus.FILLED) {
+            throw new IllegalArgumentException(
+                    "releaseMargin requires a failed terminal status, got: " + status);
+        }
+
+        BigDecimal reserved = transaction.getTotal()
+                .multiply(SAFETY_BUFFER)
+                .setScale(8, RoundingMode.HALF_UP);
+
+        MarginRelease release;
+
+        if (status == TransactionStatus.REJECTED || status == TransactionStatus.EXPIRED) {
+            release = MarginRelease.fullRelease(
+                    transaction.getId(),
+                    transaction.getRunnerId(),
+                    reserved,
+                    mapToReleaseReason(status)
+            );
+
+        } else { // CANCELED
+            BigDecimal executedValue = transaction.getExecutedValue();
+            BigDecimal toRelease = reserved.subtract(executedValue)
+                    .setScale(8, RoundingMode.HALF_UP);
+
+            if (toRelease.compareTo(BigDecimal.ZERO) <= 0) {
+                log.info("handleOrderTermination: no margin to release for CANCELED " +
+                                "transactionId={} (reserved={} executedValue={})",
+                        transaction.getId(), reserved, executedValue);
+                return;
+            }
+
+            release = MarginRelease.partialRelease(
+                    transaction.getId(),
+                    transaction.getRunnerId(),
+                    toRelease,
+                    executedValue
+            );
+        }
+
+        releaseMarginService.release(release);
+        log.info("handleOrderTermination: margin release published transactionId={} amount={} reason={}",
+                transaction.getId(), release.releaseAmount(), release.reason());
+    }
+
+    // ============================================================
+    // Private helpers
+    // ============================================================
+
+    private ReleaseReason mapToReleaseReason(TransactionStatus status) {
+        return switch (status) {
+            case REJECTED -> ReleaseReason.REJECTED;
+            case EXPIRED  -> ReleaseReason.EXPIRED;
+            case CANCELED -> ReleaseReason.CANCELED;
+            default -> throw new IllegalArgumentException("Cannot map to ReleaseReason: " + status);
+        };
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
@@ -5,6 +5,7 @@ import com.marmitt.core.application.usecase.portfolio.HandleExecutionConfirmedSe
 import com.marmitt.core.application.usecase.portfolio.HandleMarginReleaseService;
 import com.marmitt.core.application.usecase.portfolio.ReserveCapitalService;
 import com.marmitt.core.application.usecase.portfolio.ReleaseMarginService;
+import com.marmitt.core.application.usecase.runner.HandleOrderTerminationService;
 import com.marmitt.core.application.usecase.runner.ProcessTradeSignalService;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
 import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
@@ -72,5 +73,15 @@ public class RunnerConfig {
             OrderDispatchPort orderDispatchPort
     ) {
         return new ProcessTradeSignalService(runnerRepository, reserveCapitalService, orderDispatchPort);
+    }
+
+    // ── Serviços do fluxo HandleOrderTermination (F2-03) ─────────────────────
+
+    @Bean
+    public HandleOrderTerminationService handleOrderTermination(
+            StrategyRunnerRepositoryPort runnerRepository,
+            ReleaseMarginService releaseMarginService
+    ) {
+        return new HandleOrderTerminationService(runnerRepository, releaseMarginService);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/handler/HandleOrderTerminationHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/handler/HandleOrderTerminationHandler.java
@@ -1,0 +1,76 @@
+package com.marmitt.application.spring.handler;
+
+import com.marmitt.core.application.usecase.runner.HandleOrderTerminationService;
+import com.marmitt.core.domain.runner.Position;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * Handler Spring do fluxo HandleOrderTermination (F2-03).
+ * <p>
+ * Gerencia o limite {@code @Transactional} para o encerramento de Transactions
+ * que atingiram status terminal ({@code REJECTED}, {@code CANCELED}, {@code EXPIRED}).
+ * <p>
+ * <b>Fluxo dentro da transação de banco:</b>
+ * <ol>
+ *   <li>Desbloquear Position (SELL) — {@code unlock()} + {@code reopen()} + {@code savePosition()}</li>
+ *   <li>Persistir Transaction com novo status terminal — {@code saveTransaction()}</li>
+ *   <li>Publicar {@code MarginReleaseEvent} — processado pelo Portfolio após o commit
+ *       via {@code @TransactionalEventListener(AFTER_COMMIT)}</li>
+ * </ol>
+ * <p>
+ * <b>Reusabilidade:</b> este handler é o ponto de entrada único para todos os triggers
+ * de HandleOrderTermination:
+ * <ul>
+ *   <li>Dispatch REJECTED (F2-01): chamado por {@code ProcessTradeSignalHandler.handleAck()}</li>
+ *   <li>Exchange callback — CANCELED/EXPIRED (F2-02): chamado pelo callback handler</li>
+ *   <li>Watchdog timeout (F2-06/F2-07): chamado pelo Watchdog</li>
+ * </ul>
+ *
+ * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.3, 5.2.3</a>
+ */
+@Component
+@Slf4j
+public class HandleOrderTerminationHandler {
+
+    private final HandleOrderTerminationService service;
+    private final StrategyRunnerRepositoryPort runnerRepository;
+
+    public HandleOrderTerminationHandler(
+            HandleOrderTerminationService service,
+            StrategyRunnerRepositoryPort runnerRepository
+    ) {
+        this.service = service;
+        this.runnerRepository = runnerRepository;
+    }
+
+    /**
+     * Processa o encerramento de uma Transaction em status terminal.
+     * <p>
+     * <b>Pré-condição:</b> {@code transaction.getStatus()} já deve estar atualizado
+     * para o status terminal ({@code reject()}, {@code cancel()} ou {@code expire()}
+     * chamados antes deste handler).
+     *
+     * @param transaction transaction com status terminal já aplicado
+     */
+    @Transactional
+    public void handle(Transaction transaction) {
+        log.debug("handleOrderTermination: processing transactionId={} status={}",
+                transaction.getId(), transaction.getStatus());
+
+        // Passo 1: desbloquear Position (SELL only)
+        Optional<Position> unlockedPosition = service.findAndUnlockPosition(transaction);
+        unlockedPosition.ifPresent(runnerRepository::savePosition);
+
+        // Passo 2: persistir Transaction com status terminal
+        runnerRepository.saveTransaction(transaction);
+
+        // Passo 3: publicar MarginReleaseEvent (processado AFTER_COMMIT pelo Portfolio)
+        service.releaseMargin(transaction);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/handler/ProcessTradeSignalHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/handler/ProcessTradeSignalHandler.java
@@ -30,8 +30,9 @@ import java.util.Optional;
  *   <li>{@link #persistAndReserve}: {@code @Transactional(rollbackFor = ...)} — persiste
  *       Transaction PENDING, aplica lock de Position (SELL) e reserva capital atomicamente.
  *       Lança {@link CapitalReservationRejectedException} para acionar rollback.</li>
- *   <li>{@link #handleAck}: {@code @Transactional} — atualiza status da Transaction
- *       após receber ACK da exchange.</li>
+ *   <li>{@link #handleAck}: {@code @Transactional} — ACCEPTED: persiste SUBMITTED.
+ *       REJECTED: delega a {@link HandleOrderTerminationHandler} (unlock + margin release).
+ *       TIMEOUT: não persiste (Transaction permanece PENDING para Boot Sequence).</li>
  * </ul>
  *
  * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.2.1</a>
@@ -42,13 +43,16 @@ public class ProcessTradeSignalHandler {
 
     private final ProcessTradeSignalService service;
     private final StrategyRunnerRepositoryPort runnerRepository;
+    private final HandleOrderTerminationHandler terminationHandler;
 
     public ProcessTradeSignalHandler(
             ProcessTradeSignalService service,
-            StrategyRunnerRepositoryPort runnerRepository
+            StrategyRunnerRepositoryPort runnerRepository,
+            HandleOrderTerminationHandler terminationHandler
     ) {
         this.service = service;
         this.runnerRepository = runnerRepository;
+        this.terminationHandler = terminationHandler;
     }
 
     /**
@@ -123,10 +127,15 @@ public class ProcessTradeSignalHandler {
     }
 
     /**
-     * Persiste o status da Transaction após o ACK da exchange.
+     * Processa o ACK recebido da exchange após o dispatch.
      * <p>
-     * {@code @Transactional} — ACCEPTED e REJECTED resultam em salvar status atualizado.
-     * TIMEOUT não salva (Transaction permanece PENDING para reconciliação no Boot Sequence).
+     * <ul>
+     *   <li>ACCEPTED: persiste Transaction como SUBMITTED</li>
+     *   <li>REJECTED: delega ao {@link HandleOrderTerminationHandler} —
+     *       unlock de Position (SELL) + persistência + release de margem</li>
+     *   <li>TIMEOUT: não persiste — Transaction permanece PENDING para
+     *       reconciliação no Boot Sequence (F2-06)</li>
+     * </ul>
      *
      * @param transaction transaction com status já atualizado pelo {@code dispatchAndApplyAck}
      * @param ack         ACK retornado pela exchange
@@ -137,6 +146,12 @@ public class ProcessTradeSignalHandler {
             // Transaction permanece PENDING — Boot Sequence (F2-06) reconcilia
             return;
         }
+        if (ack.isRejected()) {
+            // Delega ao HandleOrderTerminationHandler: unlock + save + margin release
+            terminationHandler.handle(transaction);
+            return;
+        }
+        // ACCEPTED: persiste Transaction como SUBMITTED
         runnerRepository.saveTransaction(transaction);
     }
 }


### PR DESCRIPTION
## Summary

- Implements the **HandleOrderTermination** operational flow for terminal transactions (`REJECTED`, `CANCELED`, `EXPIRED`)
- `HandleOrderTerminationService` handles domain logic: Position unlock/reopen (SELL only), margin release calculation with partial support for `CANCELED` with prior partial fills
- `HandleOrderTerminationHandler` (`@Component`) is the single `@Transactional` entry point for all termination triggers
- `ProcessTradeSignalHandler.handleAck()` updated: `REJECTED` ACK now delegates to `HandleOrderTerminationHandler` instead of bare `saveTransaction()`

## Release amount calculation

| Status | Formula |
|---|---|
| `REJECTED` | `total × 1.005` (full reserved amount) |
| `EXPIRED` | `total × 1.005` (full reserved amount) |
| `CANCELED` (no execution) | `total × 1.005` |
| `CANCELED` (partial execution) | `(total × 1.005) − executedValue` |
| `CANCELED` (fully executed) | No release — capital already confirmed via `ExecutionConfirmedEvent` |

## Termination triggers (all route to HandleOrderTerminationHandler.handle())

| Trigger | Implemented in |
|---|---|
| Dispatch `REJECTED` ACK | F2-01 (`ProcessTradeSignalHandler.handleAck()`) ← updated here |
| Exchange callback `CANCELED`/`EXPIRED` | F2-02 (future) |
| Watchdog timeout | F2-06/F2-07 (future) |

## Test plan

- [ ] Verify `REJECTED` BUY: Transaction REJECTED, margin released, no Position changes
- [ ] Verify `REJECTED` SELL: Transaction REJECTED, Position unlocked + reopened, margin released
- [ ] Verify `CANCELED` with zero execution: full margin release
- [ ] Verify `CANCELED` with partial execution: partial margin release (`reserved − executedValue`)
- [ ] Verify `CANCELED` where `executedValue ≥ reserved`: no release event published
- [ ] Verify `EXPIRED`: full margin release, same as REJECTED

🤖 Generated with [Claude Code](https://claude.com/claude-code)