### PR TITLE
fix(F2-01,F2-02): wire shouldProcess guard and PENDING→SUBMITTED ACK path

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/handler/ProcessMessageHandler.java
+++ b/core/src/main/java/com/marmitt/core/application/handler/ProcessMessageHandler.java
@@ -142,7 +142,9 @@ public class ProcessMessageHandler implements HandlerProcessMessagePort {
 
         for (OrderUpdateListener listener : listeners) {
             try {
-                listener.onOrderUpdate(orderData);
+                if (listener.shouldProcess(orderData)) {
+                    listener.onOrderUpdate(orderData);
+                }
             } catch (Exception e) {
                 // Log error mas não propaga para não interromper outros listeners
                 System.err.println("Error notifying OrderUpdateListener " +

--- a/core/src/main/java/com/marmitt/core/application/listener/runner/PortfolioStrategyRunnerOrderUpdateListener.java
+++ b/core/src/main/java/com/marmitt/core/application/listener/runner/PortfolioStrategyRunnerOrderUpdateListener.java
@@ -47,7 +47,8 @@ public class PortfolioStrategyRunnerOrderUpdateListener implements OrderUpdateLi
 
     @Override
     public boolean shouldProcess(OrderDataDto orderData) {
-        return orderData.status() == OrderDataDto.OrderStatus.FILLED ||
+        return orderData.status() == OrderDataDto.OrderStatus.NEW ||
+                orderData.status() == OrderDataDto.OrderStatus.FILLED ||
                 orderData.status() == OrderDataDto.OrderStatus.PARTIALLY_FILLED ||
                 orderData.status() == OrderDataDto.OrderStatus.CANCELED ||
                 orderData.status() == OrderDataDto.OrderStatus.EXPIRED ||

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/OrderConciliationUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/OrderConciliationUseCase.java
@@ -56,6 +56,10 @@ public abstract class OrderConciliationUseCase implements OrderConciliationPort 
                 clientOrderId, transaction.getId(), orderData.status());
 
         switch (orderData.status()) {
+            case NEW -> {
+                transaction.submit(orderData.orderId());
+                transactionalSubmit(transaction);
+            }
             case FILLED -> {
                 BigDecimal prevQty = transaction.getEffectiveExecutedQuantity();
                 BigDecimal prevPrice = transaction.getEffectiveExecutedPrice();
@@ -91,9 +95,17 @@ public abstract class OrderConciliationUseCase implements OrderConciliationPort 
         }
     }
 
+    public abstract void transactionalSubmit(Transaction transaction);
+
     public abstract void transactionalProcessFill(Transaction transaction, OrderDataDto orderData,
                                                   BigDecimal fillIncrement, BigDecimal fillPrice,
                                                   boolean isFinal);
+
+    protected void submitTransaction(Transaction transaction) {
+        strategyRunnerRepository.saveTransaction(transaction);
+        log.info("orderConciliation: PENDING→SUBMITTED transactionId={} exchangeOrderId={}",
+                transaction.getId(), transaction.getExchangeOrderId());
+    }
 
     protected void processFill(Transaction transaction, OrderDataDto orderData,
                                 BigDecimal fillIncrement, BigDecimal fillPrice, boolean isFinal) {

--- a/core/src/main/java/com/marmitt/core/ports/inbound/runner/OrderConciliationPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/runner/OrderConciliationPort.java
@@ -10,4 +10,6 @@ public interface OrderConciliationPort {
     void releaseMargin(Transaction transaction);
 
     void transactionalReleaseMargin(Transaction transaction);
+
+    void transactionalSubmit(Transaction transaction);
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
@@ -48,6 +48,11 @@ public class RunnerConfig {
         return new OrderConciliationUseCase(strategyRunnerRepository, eventPublisher) {
 
             @Override
+            public void transactionalSubmit(Transaction transaction) {
+                txTemplate.executeWithoutResult(status -> submitTransaction(transaction));
+            }
+
+            @Override
             public void transactionalReleaseMargin(Transaction transaction) {
                 txTemplate.executeWithoutResult(status -> releaseMargin(transaction));
             }


### PR DESCRIPTION
## Summary

- **F2-02 fix**: `ProcessMessageHandler.notifyOrderUpdate()` now checks `listener.shouldProcess(orderData)` before dispatching — the guard existed on the interface but was never called
- **F2-01 fix (async ACK path)**: Added `NEW` to `PortfolioStrategyRunnerOrderUpdateListener.shouldProcess()` so exchange acknowledgement callbacks flow into the conciliation layer; `OrderConciliationUseCase` handles `case NEW` by calling `transaction.submit(orderId)` and persisting via `transactionalSubmit()` (new abstract method wired in `RunnerConfig` with `TransactionTemplate`)

## Files changed

| File | Change |
|---|---|
| `ProcessMessageHandler` | add `shouldProcess` guard in `notifyOrderUpdate` loop |
| `PortfolioStrategyRunnerOrderUpdateListener` | add `NEW` to `shouldProcess` |
| `OrderConciliationPort` | add `transactionalSubmit(Transaction)` contract |
| `OrderConciliationUseCase` | add `case NEW` + abstract `transactionalSubmit` + protected `submitTransaction` |
| `RunnerConfig` | implement `transactionalSubmit` via `TransactionTemplate` |

## Test plan

- [ ] Compile passes (`./gradlew :core:compileJava :spring-application:compileJava`)
- [ ] Confirm `NEW` WebSocket events from exchange trigger PENDING→SUBMITTED transition in DB
- [ ] Confirm non-matching statuses (e.g. exchange heartbeats) are not routed to listeners that declare they should not handle them

🤖 Generated with [Claude Code](https://claude.com/claude-code)