### PR TITLE
test(core): fase 0 item 2 - testes de invariantes de dominio

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,8 +10,13 @@ repositories {
 }
 
 dependencies {
-    // Jackson annotations para serialização de domain objects
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.2'
     implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
+test {
+    useJUnitPlatform()
+}

--- a/core/src/main/java/com/marmitt/core/domain/portfolio/GlobalBalance.java
+++ b/core/src/main/java/com/marmitt/core/domain/portfolio/GlobalBalance.java
@@ -110,6 +110,12 @@ public class GlobalBalance {
         Objects.requireNonNull(cost, "cost cannot be null");
         Objects.requireNonNull(pnlAmount, "pnlAmount cannot be null");
         Objects.requireNonNull(feeConverted, "feeConverted cannot be null");
+        if (cost.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Execution cost must be positive");
+        }
+        if (reservedBalance.compareTo(cost) < 0) {
+            throw new IllegalStateException("Insufficient reserved balance for execution confirmation");
+        }
 
         this.reservedBalance = this.reservedBalance.subtract(cost);
         this.realizedBalance = this.realizedBalance.add(pnlAmount);
@@ -129,6 +135,9 @@ public class GlobalBalance {
         Objects.requireNonNull(amount, "amount cannot be null");
         if (amount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("Release amount must be positive");
+        }
+        if (reservedBalance.compareTo(amount) < 0) {
+            throw new IllegalStateException("Insufficient reserved balance for release");
         }
         this.reservedBalance = this.reservedBalance.subtract(amount);
         this.availableBalance = this.availableBalance.add(amount);

--- a/core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java
+++ b/core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java
@@ -35,6 +35,17 @@ class GlobalBalanceInvariantsTest {
     }
 
     @Test
+    void releaseMovesAmountFromReservedToAvailable() {
+        GlobalBalance balance = newBalance("100");
+        balance.reserve(new BigDecimal("40"));
+
+        balance.release(new BigDecimal("15"));
+
+        assertAmount("75", balance.getAvailableBalance());
+        assertAmount("25", balance.getReservedBalance());
+    }
+
+    @Test
     void confirmExecutionRejectsAmountGreaterThanReserved() {
         GlobalBalance balance = newBalance("100");
         balance.reserve(new BigDecimal("15"));
@@ -60,6 +71,23 @@ class GlobalBalanceInvariantsTest {
         assertAmount("0.5", balance.getTotalFeesPaid());
     }
 
+    @Test
+    void confirmExecutionSupportsNegativePnl() {
+        GlobalBalance balance = newBalance("100");
+        balance.reserve(new BigDecimal("25"));
+
+        balance.confirmExecution(
+                new BigDecimal("20"),
+                new BigDecimal("-5"),
+                BigDecimal.ZERO
+        );
+
+        assertAmount("90", balance.getAvailableBalance());
+        assertAmount("5", balance.getReservedBalance());
+        assertAmount("-5", balance.getRealizedBalance());
+        assertAmount("0", balance.getTotalFeesPaid());
+    }
+
     private static GlobalBalance newBalance(String initialCapital) {
         return new GlobalBalance(UUID.randomUUID(), new BigDecimal(initialCapital), "USDT");
     }
@@ -68,4 +96,3 @@ class GlobalBalanceInvariantsTest {
         assertEquals(0, new BigDecimal(expected).compareTo(actual));
     }
 }
-

--- a/core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java
+++ b/core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java
@@ -1,0 +1,71 @@
+package com.marmitt.core.domain.portfolio;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GlobalBalanceInvariantsTest {
+
+    @Test
+    void reserveMovesAmountFromAvailableToReserved() {
+        GlobalBalance balance = newBalance("100");
+
+        balance.reserve(new BigDecimal("30"));
+
+        assertAmount("70", balance.getAvailableBalance());
+        assertAmount("30", balance.getReservedBalance());
+    }
+
+    @Test
+    void reserveRejectsInsufficientAvailableBalance() {
+        GlobalBalance balance = newBalance("100");
+
+        assertThrows(IllegalArgumentException.class, () -> balance.reserve(new BigDecimal("150")));
+    }
+
+    @Test
+    void releaseRejectsAmountGreaterThanReserved() {
+        GlobalBalance balance = newBalance("100");
+
+        assertThrows(IllegalStateException.class, () -> balance.release(new BigDecimal("1")));
+    }
+
+    @Test
+    void confirmExecutionRejectsAmountGreaterThanReserved() {
+        GlobalBalance balance = newBalance("100");
+        balance.reserve(new BigDecimal("15"));
+
+        assertThrows(IllegalStateException.class,
+                () -> balance.confirmExecution(new BigDecimal("20"), BigDecimal.ONE, BigDecimal.ZERO));
+    }
+
+    @Test
+    void confirmExecutionUpdatesAvailableReservedRealizedAndFees() {
+        GlobalBalance balance = newBalance("100");
+        balance.reserve(new BigDecimal("25"));
+
+        balance.confirmExecution(
+                new BigDecimal("20"),
+                new BigDecimal("2"),
+                new BigDecimal("0.5")
+        );
+
+        assertAmount("97", balance.getAvailableBalance());
+        assertAmount("5", balance.getReservedBalance());
+        assertAmount("2", balance.getRealizedBalance());
+        assertAmount("0.5", balance.getTotalFeesPaid());
+    }
+
+    private static GlobalBalance newBalance(String initialCapital) {
+        return new GlobalBalance(UUID.randomUUID(), new BigDecimal(initialCapital), "USDT");
+    }
+
+    private static void assertAmount(String expected, BigDecimal actual) {
+        assertEquals(0, new BigDecimal(expected).compareTo(actual));
+    }
+}
+

--- a/core/src/test/java/com/marmitt/core/domain/runner/StrategyRunnerInvariantsTest.java
+++ b/core/src/test/java/com/marmitt/core/domain/runner/StrategyRunnerInvariantsTest.java
@@ -1,0 +1,111 @@
+package com.marmitt.core.domain.runner;
+
+import com.marmitt.core.enums.AccountingPolicyType;
+import com.marmitt.core.enums.ExecutionPolicy;
+import com.marmitt.core.enums.RunnerStatus;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StrategyRunnerInvariantsTest {
+
+    @Test
+    void lifecycleTransitionsFollowExpectedOrder() {
+        StrategyRunner runner = newRunner();
+
+        runner.startInitializing();
+        assertEquals(RunnerStatus.INITIALIZING, runner.getStatus());
+
+        runner.activate();
+        assertEquals(RunnerStatus.ACTIVE, runner.getStatus());
+
+        runner.halt();
+        assertEquals(RunnerStatus.HALTED, runner.getStatus());
+
+        runner.resume();
+        assertEquals(RunnerStatus.ACTIVE, runner.getStatus());
+
+        runner.startTerminating();
+        assertEquals(RunnerStatus.TERMINATING, runner.getStatus());
+
+        runner.archive();
+        assertEquals(RunnerStatus.ARCHIVED, runner.getStatus());
+    }
+
+    @Test
+    void beginReconciliationRejectsTerminatingAndArchived() {
+        StrategyRunner terminatingRunner = newRunner();
+        terminatingRunner.startInitializing();
+        terminatingRunner.activate();
+        terminatingRunner.startTerminating();
+
+        assertThrows(IllegalStateException.class, terminatingRunner::beginReconciliation);
+    }
+
+    @Test
+    void canAcceptSignalsOnlyWhenActiveAndNotReconciling() {
+        StrategyRunner runner = newRunner();
+        assertFalse(runner.canAcceptSignals());
+
+        runner.startInitializing();
+        assertFalse(runner.canAcceptSignals());
+
+        runner.activate();
+        assertTrue(runner.canAcceptSignals());
+
+        runner.beginReconciliation();
+        assertFalse(runner.canAcceptSignals());
+
+        runner.completeReconciliation();
+        assertTrue(runner.canAcceptSignals());
+    }
+
+    @Test
+    void shortCodeIsNormalizedToLowerCase() {
+        StrategyRunner runner = new StrategyRunner(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "A1B",
+                UUID.randomUUID(),
+                "SimpleMovingAverage",
+                "BTCUSDT",
+                "MOCK",
+                Set.of("BINANCE", "MOCK"),
+                ExecutionPolicy.SINGLE,
+                AccountingPolicyType.FIFO,
+                new BigDecimal("0.25"),
+                1,
+                1,
+                null
+        );
+
+        assertEquals("a1b", runner.getShortCode());
+    }
+
+    private static StrategyRunner newRunner() {
+        return new StrategyRunner(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "x1",
+                UUID.randomUUID(),
+                "SimpleMovingAverage",
+                "BTCUSDT",
+                "MOCK",
+                Set.of("BINANCE", "MOCK"),
+                ExecutionPolicy.SINGLE,
+                AccountingPolicyType.FIFO,
+                new BigDecimal("0.25"),
+                1,
+                1,
+                null
+        );
+    }
+}
+

--- a/core/src/test/java/com/marmitt/core/domain/runner/StrategyRunnerInvariantsTest.java
+++ b/core/src/test/java/com/marmitt/core/domain/runner/StrategyRunnerInvariantsTest.java
@@ -47,6 +47,14 @@ class StrategyRunnerInvariantsTest {
         terminatingRunner.startTerminating();
 
         assertThrows(IllegalStateException.class, terminatingRunner::beginReconciliation);
+
+        StrategyRunner archivedRunner = newRunner();
+        archivedRunner.startInitializing();
+        archivedRunner.activate();
+        archivedRunner.startTerminating();
+        archivedRunner.archive();
+
+        assertThrows(IllegalStateException.class, archivedRunner::beginReconciliation);
     }
 
     @Test
@@ -108,4 +116,3 @@ class StrategyRunnerInvariantsTest {
         );
     }
 }
-

--- a/core/src/test/java/com/marmitt/core/domain/runner/TransactionInvariantsTest.java
+++ b/core/src/test/java/com/marmitt/core/domain/runner/TransactionInvariantsTest.java
@@ -63,6 +63,18 @@ class TransactionInvariantsTest {
         assertAmount("23.00000000", transaction.getExecutedValue());
     }
 
+    @Test
+    void executedValueUsesLatestCumulativePartialFillAcrossMultipleUpdates() {
+        Transaction transaction = newTransaction();
+        transaction.submit("EX_ORDER_1");
+
+        transaction.partialFill(new BigDecimal("1.0"), new BigDecimal("10.0"));
+        assertAmount("10.00000000", transaction.getExecutedValue());
+
+        transaction.partialFill(new BigDecimal("2.5"), new BigDecimal("10.8"));
+        assertAmount("27.00000000", transaction.getExecutedValue());
+    }
+
     private static Transaction newTransaction() {
         BigDecimal quantity = new BigDecimal("2.5");
         BigDecimal price = new BigDecimal("10");
@@ -85,4 +97,3 @@ class TransactionInvariantsTest {
         assertEquals(0, new BigDecimal(expected).compareTo(actual));
     }
 }
-

--- a/core/src/test/java/com/marmitt/core/domain/runner/TransactionInvariantsTest.java
+++ b/core/src/test/java/com/marmitt/core/domain/runner/TransactionInvariantsTest.java
@@ -1,0 +1,88 @@
+package com.marmitt.core.domain.runner;
+
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TransactionInvariantsTest {
+
+    @Test
+    void submitTransitionsFromPendingAndRejectsDuplicateSubmit() {
+        Transaction transaction = newTransaction();
+
+        transaction.submit("EX_ORDER_1");
+
+        assertEquals(TransactionStatus.SUBMITTED, transaction.getStatus());
+        assertEquals("EX_ORDER_1", transaction.getExchangeOrderId());
+        assertThrows(IllegalStateException.class, () -> transaction.submit("EX_ORDER_2"));
+    }
+
+    @Test
+    void fillTransitionsToFinalAndBlocksFurtherNonTerminalTransitions() {
+        Transaction transaction = newTransaction();
+        transaction.submit("EX_ORDER_1");
+
+        transaction.fill(new BigDecimal("2.5"), new BigDecimal("10"));
+
+        assertEquals(TransactionStatus.FILLED, transaction.getStatus());
+        assertNotNull(transaction.getExecutedAt());
+        assertThrows(IllegalStateException.class, () ->
+                transaction.partialFill(new BigDecimal("2.5"), new BigDecimal("10")));
+        assertThrows(IllegalStateException.class, transaction::cancel);
+    }
+
+    @Test
+    void expireRejectsInvalidTransitionFromPartial() {
+        Transaction transaction = newTransaction();
+        transaction.submit("EX_ORDER_1");
+        transaction.partialFill(new BigDecimal("1.0"), new BigDecimal("9.5"));
+
+        assertThrows(IllegalStateException.class, transaction::expire);
+    }
+
+    @Test
+    void executedValueIsZeroBeforeExecution() {
+        Transaction transaction = newTransaction();
+
+        assertAmount("0", transaction.getExecutedValue());
+    }
+
+    @Test
+    void executedValueUsesAccumulatedExecution() {
+        Transaction transaction = newTransaction();
+        transaction.submit("EX_ORDER_1");
+        transaction.partialFill(new BigDecimal("2.0"), new BigDecimal("11.5"));
+
+        assertAmount("23.00000000", transaction.getExecutedValue());
+    }
+
+    private static Transaction newTransaction() {
+        BigDecimal quantity = new BigDecimal("2.5");
+        BigDecimal price = new BigDecimal("10");
+        BigDecimal total = quantity.multiply(price);
+        return new Transaction(
+                UUID.randomUUID(),
+                "client-order-id-1",
+                TransactionType.BUY,
+                "BTCUSDT",
+                quantity,
+                price,
+                total,
+                new BigDecimal("0.8"),
+                "test",
+                null
+        );
+    }
+
+    private static void assertAmount(String expected, BigDecimal actual) {
+        assertEquals(0, new BigDecimal(expected).compareTo(actual));
+    }
+}
+


### PR DESCRIPTION
## Contexto
Implementa o Item 2 da Fase 0 com testes reais no modulo `core`, focando invariantes criticas de dominio.

## O que foi alterado
- `core/build.gradle`
  - adiciona JUnit 5 no modulo core (`testImplementation` + `useJUnitPlatform`).
- `core/src/test/java/com/marmitt/core/domain/runner/TransactionInvariantsTest.java`
  - transicoes validas/invalidas de status (monotonicidade basica);
  - bloqueio de transicoes apos estado terminal;
  - validacao de calculo de valor executado.
- `core/src/test/java/com/marmitt/core/domain/runner/StrategyRunnerInvariantsTest.java`
  - ciclo de vida do runner;
  - bloqueio de reconciliacao em estados terminais;
  - regra de `canAcceptSignals`.
- `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
  - reserva, confirmacao de execucao e liberacao;
  - protecao contra consumo/liberacao acima do reservado.
- `core/src/main/java/com/marmitt/core/domain/portfolio/GlobalBalance.java`
  - validacoes adicionais para impedir `reservedBalance` negativo em `confirmExecution` e `release`.

## Validacao
- Executado: `./gradlew -q :core:test`