### PR TITLE
test(core): fase 0 item 3 - idempotencia em conciliacao de ordens

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
 }
 
 test {

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateIdempotencyTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateIdempotencyTest.java
@@ -1,0 +1,224 @@
+package com.marmitt.core.application.usecase.runner.orderconciliation;
+
+import com.marmitt.core.domain.Symbol;
+import com.marmitt.core.domain.runner.ClientOrderId;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class ConciliationOrderUpdateIdempotencyTest {
+
+    @Test
+    void executeSkipsInvalidClientOrderId() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        OrderDataDto orderData = orderData(
+                "invalid-client-order-id",
+                OrderDataDto.OrderStatus.NEW,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO
+        );
+
+        conciliation.execute(orderData, tx -> {}, (tx, od, finalFill) -> {}, tx -> {});
+
+        verify(repository, never()).findTransactionByClientOrderId(orderData.clientOrderId());
+    }
+
+    @Test
+    void executeNewTransitionsPendingTransactionAndCallsSubmitAction() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        String clientOrderId = transaction.getClientOrderId();
+        when(repository.findTransactionByClientOrderId(clientOrderId)).thenReturn(Optional.of(transaction));
+
+        AtomicInteger submitCalls = new AtomicInteger();
+        AtomicInteger fillCalls = new AtomicInteger();
+        AtomicInteger releaseCalls = new AtomicInteger();
+
+        conciliation.execute(
+                orderData(clientOrderId, OrderDataDto.OrderStatus.NEW, BigDecimal.ZERO, BigDecimal.ZERO),
+                tx -> submitCalls.incrementAndGet(),
+                (tx, od, finalFill) -> fillCalls.incrementAndGet(),
+                tx -> releaseCalls.incrementAndGet()
+        );
+
+        assertEquals(TransactionStatus.SUBMITTED, transaction.getStatus());
+        assertEquals("EX_ORDER_1", transaction.getExchangeOrderId());
+        assertEquals(1, submitCalls.get());
+        assertEquals(0, fillCalls.get());
+        assertEquals(0, releaseCalls.get());
+    }
+
+    @Test
+    void executeNewIgnoresAlreadySubmittedTransaction() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("PREVIOUS_EX_ORDER");
+        String clientOrderId = transaction.getClientOrderId();
+        when(repository.findTransactionByClientOrderId(clientOrderId)).thenReturn(Optional.of(transaction));
+
+        AtomicInteger submitCalls = new AtomicInteger();
+
+        conciliation.execute(
+                orderData(clientOrderId, OrderDataDto.OrderStatus.NEW, BigDecimal.ZERO, BigDecimal.ZERO),
+                tx -> submitCalls.incrementAndGet(),
+                (tx, od, finalFill) -> {
+                },
+                tx -> {
+                }
+        );
+
+        assertEquals(TransactionStatus.SUBMITTED, transaction.getStatus());
+        assertEquals("PREVIOUS_EX_ORDER", transaction.getExchangeOrderId());
+        assertEquals(0, submitCalls.get());
+    }
+
+    @Test
+    void processFillIgnoresDuplicatePartiallyFilledWhenQuantityDidNotIncrease() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_1");
+        transaction.partialFill(new BigDecimal("1.00000000"), new BigDecimal("10.00000000"));
+
+        conciliation.processFill(
+                transaction,
+                orderData(
+                        transaction.getClientOrderId(),
+                        OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                        new BigDecimal("1.00000000"),
+                        new BigDecimal("10.50000000")
+                ),
+                false
+        );
+
+        assertEquals(TransactionStatus.PARTIAL, transaction.getStatus());
+        assertAmount("1.00000000", transaction.getExecutedQuantity());
+        assertAmount("10.00000000", transaction.getExecutedPrice());
+        verifyNoInteractions(repository, publisher);
+    }
+
+    @Test
+    void processFillIgnoresDuplicateFilledWhenAlreadyFinal() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_1");
+        transaction.fill(new BigDecimal("2.50000000"), new BigDecimal("10.20000000"));
+
+        conciliation.processFill(
+                transaction,
+                orderData(
+                        transaction.getClientOrderId(),
+                        OrderDataDto.OrderStatus.FILLED,
+                        new BigDecimal("2.50000000"),
+                        new BigDecimal("10.30000000")
+                ),
+                true
+        );
+
+        assertEquals(TransactionStatus.FILLED, transaction.getStatus());
+        assertAmount("2.50000000", transaction.getExecutedQuantity());
+        assertAmount("10.20000000", transaction.getExecutedPrice());
+        verifyNoInteractions(repository, publisher);
+    }
+
+    @Test
+    void executeRejectsInvalidTransitionToCanceledFromFilled() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_1");
+        transaction.fill(new BigDecimal("2.50000000"), new BigDecimal("10.20000000"));
+        when(repository.findTransactionByClientOrderId(transaction.getClientOrderId()))
+                .thenReturn(Optional.of(transaction));
+
+        assertThrows(IllegalStateException.class, () ->
+                conciliation.execute(
+                        orderData(transaction.getClientOrderId(), OrderDataDto.OrderStatus.CANCELED,
+                                transaction.getExecutedQuantity(), transaction.getExecutedPrice()),
+                        tx -> {
+                        },
+                        (tx, od, finalFill) -> {
+                        },
+                        tx -> {
+                        }
+                )
+        );
+    }
+
+    private static Transaction newBuyTransaction() {
+        BigDecimal quantity = new BigDecimal("2.50000000");
+        BigDecimal price = new BigDecimal("10.00000000");
+        return new Transaction(
+                UUID.randomUUID(),
+                ClientOrderId.generate("x1", TransactionType.BUY),
+                TransactionType.BUY,
+                "BTCUSDT",
+                quantity,
+                price,
+                quantity.multiply(price),
+                new BigDecimal("0.8"),
+                "test",
+                null
+        );
+    }
+
+    private static OrderDataDto orderData(String clientOrderId,
+                                          OrderDataDto.OrderStatus status,
+                                          BigDecimal executedQty,
+                                          BigDecimal executedPrice) {
+        return new OrderDataDto(
+                "EX_ORDER_1",
+                clientOrderId,
+                Symbol.of("BTCUSDT"),
+                OrderDataDto.OrderSide.BUY,
+                OrderDataDto.OrderType.LIMIT,
+                new BigDecimal("2.50000000"),
+                executedQty,
+                new BigDecimal("10.00000000"),
+                executedPrice,
+                BigDecimal.ZERO,
+                status,
+                null,
+                Instant.now()
+        );
+    }
+
+    private static void assertAmount(String expected, BigDecimal actual) {
+        assertEquals(0, new BigDecimal(expected).compareTo(actual));
+    }
+}
+

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateIdempotencyTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateIdempotencyTest.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -100,6 +101,98 @@ class ConciliationOrderUpdateIdempotencyTest {
     }
 
     @Test
+    void executeFilledRoutesToFillActionWithFinalFlag() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        String clientOrderId = transaction.getClientOrderId();
+        when(repository.findTransactionByClientOrderId(clientOrderId)).thenReturn(Optional.of(transaction));
+
+        AtomicInteger submitCalls = new AtomicInteger();
+        AtomicInteger fillCalls = new AtomicInteger();
+        AtomicInteger releaseCalls = new AtomicInteger();
+        AtomicReference<Boolean> receivedFinalFlag = new AtomicReference<>(null);
+
+        conciliation.execute(
+                orderData(clientOrderId, OrderDataDto.OrderStatus.FILLED,
+                        new BigDecimal("2.50000000"), new BigDecimal("10.20000000")),
+                tx -> submitCalls.incrementAndGet(),
+                (tx, od, finalFill) -> {
+                    fillCalls.incrementAndGet();
+                    assertEquals(transaction, tx);
+                    assertEquals(OrderDataDto.OrderStatus.FILLED, od.status());
+                    receivedFinalFlag.set(finalFill);
+                },
+                tx -> releaseCalls.incrementAndGet()
+        );
+
+        assertEquals(0, submitCalls.get());
+        assertEquals(1, fillCalls.get());
+        assertEquals(0, releaseCalls.get());
+        assertEquals(Boolean.TRUE, receivedFinalFlag.get());
+    }
+
+    @Test
+    void executePartiallyFilledRoutesToFillActionWithPartialFlag() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        String clientOrderId = transaction.getClientOrderId();
+        when(repository.findTransactionByClientOrderId(clientOrderId)).thenReturn(Optional.of(transaction));
+
+        AtomicInteger fillCalls = new AtomicInteger();
+        AtomicReference<Boolean> receivedFinalFlag = new AtomicReference<>(null);
+
+        conciliation.execute(
+                orderData(clientOrderId, OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                        new BigDecimal("1.25000000"), new BigDecimal("10.10000000")),
+                tx -> {
+                },
+                (tx, od, finalFill) -> {
+                    fillCalls.incrementAndGet();
+                    assertEquals(transaction, tx);
+                    assertEquals(OrderDataDto.OrderStatus.PARTIALLY_FILLED, od.status());
+                    receivedFinalFlag.set(finalFill);
+                },
+                tx -> {
+                }
+        );
+
+        assertEquals(1, fillCalls.get());
+        assertEquals(Boolean.FALSE, receivedFinalFlag.get());
+    }
+
+    @Test
+    void executeSkipsWhenTransactionNotFoundForValidClientOrderId() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        String validClientOrderId = ClientOrderId.generate("x1", TransactionType.BUY);
+        when(repository.findTransactionByClientOrderId(validClientOrderId)).thenReturn(Optional.empty());
+
+        AtomicInteger submitCalls = new AtomicInteger();
+        AtomicInteger fillCalls = new AtomicInteger();
+        AtomicInteger releaseCalls = new AtomicInteger();
+
+        conciliation.execute(
+                orderData(validClientOrderId, OrderDataDto.OrderStatus.NEW, BigDecimal.ZERO, BigDecimal.ZERO),
+                tx -> submitCalls.incrementAndGet(),
+                (tx, od, finalFill) -> fillCalls.incrementAndGet(),
+                tx -> releaseCalls.incrementAndGet()
+        );
+
+        verify(repository).findTransactionByClientOrderId(validClientOrderId);
+        assertEquals(0, submitCalls.get());
+        assertEquals(0, fillCalls.get());
+        assertEquals(0, releaseCalls.get());
+    }
+
+    @Test
     void processFillIgnoresDuplicatePartiallyFilledWhenQuantityDidNotIncrease() {
         StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
         EventPublisherPort publisher = mock(EventPublisherPort.class);
@@ -179,6 +272,82 @@ class ConciliationOrderUpdateIdempotencyTest {
         );
     }
 
+    @Test
+    void executeCanceledCallsReleaseActionAndTransitionsStatus() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        when(repository.findTransactionByClientOrderId(transaction.getClientOrderId()))
+                .thenReturn(Optional.of(transaction));
+
+        AtomicInteger releaseCalls = new AtomicInteger();
+        conciliation.execute(
+                orderData(transaction.getClientOrderId(), OrderDataDto.OrderStatus.CANCELED,
+                        BigDecimal.ZERO, BigDecimal.ZERO),
+                tx -> {
+                },
+                (tx, od, finalFill) -> {
+                },
+                tx -> releaseCalls.incrementAndGet()
+        );
+
+        assertEquals(TransactionStatus.CANCELED, transaction.getStatus());
+        assertEquals(1, releaseCalls.get());
+    }
+
+    @Test
+    void executeExpiredCallsReleaseActionAndTransitionsStatus() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        when(repository.findTransactionByClientOrderId(transaction.getClientOrderId()))
+                .thenReturn(Optional.of(transaction));
+
+        AtomicInteger releaseCalls = new AtomicInteger();
+        conciliation.execute(
+                orderData(transaction.getClientOrderId(), OrderDataDto.OrderStatus.EXPIRED,
+                        BigDecimal.ZERO, BigDecimal.ZERO),
+                tx -> {
+                },
+                (tx, od, finalFill) -> {
+                },
+                tx -> releaseCalls.incrementAndGet()
+        );
+
+        assertEquals(TransactionStatus.EXPIRED, transaction.getStatus());
+        assertEquals(1, releaseCalls.get());
+    }
+
+    @Test
+    void executeRejectedCallsReleaseActionAndTransitionsStatus() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        EventPublisherPort publisher = mock(EventPublisherPort.class);
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, publisher);
+
+        Transaction transaction = newBuyTransaction();
+        when(repository.findTransactionByClientOrderId(transaction.getClientOrderId()))
+                .thenReturn(Optional.of(transaction));
+
+        AtomicInteger releaseCalls = new AtomicInteger();
+        conciliation.execute(
+                orderData(transaction.getClientOrderId(), OrderDataDto.OrderStatus.REJECTED,
+                        BigDecimal.ZERO, BigDecimal.ZERO, "INSUFFICIENT_BALANCE"),
+                tx -> {
+                },
+                (tx, od, finalFill) -> {
+                },
+                tx -> releaseCalls.incrementAndGet()
+        );
+
+        assertEquals(TransactionStatus.REJECTED, transaction.getStatus());
+        assertEquals("INSUFFICIENT_BALANCE", transaction.getRejectReason());
+        assertEquals(1, releaseCalls.get());
+    }
+
     private static Transaction newBuyTransaction() {
         BigDecimal quantity = new BigDecimal("2.50000000");
         BigDecimal price = new BigDecimal("10.00000000");
@@ -200,6 +369,14 @@ class ConciliationOrderUpdateIdempotencyTest {
                                           OrderDataDto.OrderStatus status,
                                           BigDecimal executedQty,
                                           BigDecimal executedPrice) {
+        return orderData(clientOrderId, status, executedQty, executedPrice, null);
+    }
+
+    private static OrderDataDto orderData(String clientOrderId,
+                                          OrderDataDto.OrderStatus status,
+                                          BigDecimal executedQty,
+                                          BigDecimal executedPrice,
+                                          String rejectReason) {
         return new OrderDataDto(
                 "EX_ORDER_1",
                 clientOrderId,
@@ -212,7 +389,7 @@ class ConciliationOrderUpdateIdempotencyTest {
                 executedPrice,
                 BigDecimal.ZERO,
                 status,
-                null,
+                rejectReason,
                 Instant.now()
         );
     }
@@ -221,4 +398,3 @@ class ConciliationOrderUpdateIdempotencyTest {
         assertEquals(0, new BigDecimal(expected).compareTo(actual));
     }
 }
-


### PR DESCRIPTION
## Contexto
Proximo item da Fase 0: aumentar cobertura de idempotencia e roteamento no fluxo de conciliacao de ordens.

## O que foi alterado
- `core/src/test/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateIdempotencyTest.java`
  - `execute` ignora `clientOrderId` invalido;
  - `NEW` em transacao `PENDING` chama submit e avanca status;
  - `NEW` duplicado em transacao ja `SUBMITTED` e ignorado;
  - `PARTIALLY_FILLED` duplicado (qty nao crescente) e ignorado;
  - `FILLED` duplicado em transacao final e ignorado;
  - transicao invalida `FILLED -> CANCELED` gera erro (regra de monotonicidade).
- `core/build.gradle`
  - adiciona `mockito-core` para testes de use case no modulo core.

## Validacao
- Executado: `./gradlew :core:cleanTest :core:test --rerun-tasks`
- Relatorio inclui `ConciliationOrderUpdateIdempotencyTest`.