### PR TITLE
feat(mock): deterministic per-order scenario overrides for integration tests

### DIFF
--- a/adapter-mock/src/main/java/com/marmitt/mock/config/MockOrderScenarioOverride.java
+++ b/adapter-mock/src/main/java/com/marmitt/mock/config/MockOrderScenarioOverride.java
@@ -1,0 +1,66 @@
+package com.marmitt.mock.config;
+
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Deterministic, per-order override for mock order execution.
+ *
+ * <p>Used mainly by integration tests to force specific lifecycle sequences
+ * without relying on random mock behavior.
+ */
+public record MockOrderScenarioOverride(
+        List<PlannedEvent> events,
+        EventOrdering ordering
+) {
+
+    public MockOrderScenarioOverride {
+        Objects.requireNonNull(events, "events cannot be null");
+        if (events.isEmpty()) {
+            throw new IllegalArgumentException("events cannot be empty");
+        }
+        for (PlannedEvent event : events) {
+            Objects.requireNonNull(event, "planned event cannot be null");
+        }
+        ordering = ordering == null ? EventOrdering.AS_IS : ordering;
+    }
+
+    public enum EventOrdering {
+        AS_IS,
+        REVERSE
+    }
+
+    /**
+     * Planned event for one order update.
+     *
+     * @param status           order status to emit.
+     * @param executedQuantity cumulative executed quantity (nullable; defaults by status).
+     * @param executedPrice    executed price (nullable -> request price).
+     * @param fee              fee for this event (nullable -> computed from increment for fill events, ZERO otherwise).
+     * @param rejectReason     reject reason for REJECTED events.
+     * @param delayBeforeMs    delay before publishing this event.
+     * @param duplicates       number of duplicated emissions for this same payload.
+     */
+    public record PlannedEvent(
+            OrderDataDto.OrderStatus status,
+            BigDecimal executedQuantity,
+            BigDecimal executedPrice,
+            BigDecimal fee,
+            String rejectReason,
+            long delayBeforeMs,
+            int duplicates
+    ) {
+        public PlannedEvent {
+            Objects.requireNonNull(status, "status cannot be null");
+            if (delayBeforeMs < 0) {
+                throw new IllegalArgumentException("delayBeforeMs cannot be negative");
+            }
+            if (duplicates < 0) {
+                throw new IllegalArgumentException("duplicates cannot be negative");
+            }
+        }
+    }
+}

--- a/adapter-mock/src/main/java/com/marmitt/mock/runtime/MockExchangeRuntime.java
+++ b/adapter-mock/src/main/java/com/marmitt/mock/runtime/MockExchangeRuntime.java
@@ -11,10 +11,12 @@ import com.marmitt.core.enums.StreamAction;
 import com.marmitt.core.exceptions.ExchangeQueryException;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
 import com.marmitt.mock.balance.MockBalanceStore;
+import com.marmitt.mock.config.MockOrderScenarioOverride;
 import com.marmitt.mock.config.MockScenarioConfig;
 import com.marmitt.mock.processor.MockRawMessagePublisher;
 import com.marmitt.mock.simulator.MockMarketDataFeedEngine;
 import com.marmitt.mock.simulator.MockOrderExecutionSimulator;
+import com.marmitt.mock.simulator.MockScheduledOrderEvent;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -43,6 +45,7 @@ public class MockExchangeRuntime {
     private final MockLifecycle lifecycle;
     private final Map<String, String> orderIdByClientOrderId = new ConcurrentHashMap<>();
     private final Map<String, OrderDataDto> latestEventByOrderId = new ConcurrentHashMap<>();
+    private final Map<String, MockOrderScenarioOverride> orderScenarioOverrideByClientOrderId = new ConcurrentHashMap<>();
     private Random random;
     private MockBalanceStore balanceStore;
 
@@ -211,19 +214,47 @@ public class MockExchangeRuntime {
         return lifecycle.isRunning();
     }
 
+    /**
+     * Registers a one-shot deterministic scenario for an order.
+     * The override is consumed when that clientOrderId is submitted.
+     */
+    public void registerOrderScenarioOverride(String clientOrderId, MockOrderScenarioOverride override) {
+        if (clientOrderId == null || clientOrderId.isBlank()) {
+            throw new IllegalArgumentException("clientOrderId cannot be null or blank");
+        }
+        if (override == null) {
+            throw new IllegalArgumentException("override cannot be null");
+        }
+        orderScenarioOverrideByClientOrderId.put(clientOrderId, override);
+        log.info("Mock scenario override registered - ClientOrderId: {}, events: {}",
+                clientOrderId, override.events().size());
+    }
+
+    public void clearOrderScenarioOverride(String clientOrderId) {
+        if (clientOrderId == null || clientOrderId.isBlank()) {
+            return;
+        }
+        orderScenarioOverrideByClientOrderId.remove(clientOrderId);
+    }
+
+    public void clearOrderScenarioOverrides() {
+        orderScenarioOverrideByClientOrderId.clear();
+    }
+
     private void simulateOrderExecutionAsync(SendOrderRequest orderRequest, String orderId) {
         try {
             Random localRandom = this.random;
             MockBalanceStore localBalanceStore = this.balanceStore;
-            List<OrderDataDto> events = simulator.buildScenarioEvents(
-                    orderRequest, orderId, config, localRandom, localBalanceStore);
+            MockOrderScenarioOverride override = orderScenarioOverrideByClientOrderId.remove(orderRequest.getClientOrderId());
+            List<MockScheduledOrderEvent> scheduledEvents = simulator.buildScenarioSchedule(
+                    orderRequest, orderId, config, localRandom, localBalanceStore, override);
 
-            for (OrderDataDto event : events) {
-                sleepLatency();
-                publishMockOrderResponse(event);
+            for (MockScheduledOrderEvent scheduledEvent : scheduledEvents) {
+                sleepForEvent(scheduledEvent);
+                publishMockOrderResponse(scheduledEvent.orderData());
             }
 
-            OrderDataDto last = events.isEmpty() ? null : events.get(events.size() - 1);
+            OrderDataDto last = scheduledEvents.isEmpty() ? null : scheduledEvents.get(scheduledEvents.size() - 1).orderData();
             log.info("Mock order simulation completed - ClientOrderId: {}, OrderId: {}, Status: {}",
                     orderRequest.getClientOrderId(), orderId, last != null ? last.status() : "NONE");
 
@@ -235,6 +266,17 @@ public class MockExchangeRuntime {
             log.error("Error simulating order execution - ClientOrderId: {}, Error: {}",
                     orderRequest.getClientOrderId(), e.getMessage(), e);
         }
+    }
+
+    private void sleepForEvent(MockScheduledOrderEvent scheduledEvent) throws InterruptedException {
+        long plannedDelay = scheduledEvent.delayBeforeMs();
+        if (plannedDelay >= 0) {
+            if (plannedDelay > 0) {
+                Thread.sleep(plannedDelay);
+            }
+            return;
+        }
+        sleepLatency();
     }
 
     private void sleepLatency() throws InterruptedException {
@@ -265,6 +307,7 @@ public class MockExchangeRuntime {
         this.balanceStore = new MockBalanceStore(config.balances().initialBalances());
         this.orderIdByClientOrderId.clear();
         this.latestEventByOrderId.clear();
+        this.orderScenarioOverrideByClientOrderId.clear();
     }
 
     private void ensureLifecycleForQuery() {

--- a/adapter-mock/src/main/java/com/marmitt/mock/simulator/MockOrderExecutionSimulator.java
+++ b/adapter-mock/src/main/java/com/marmitt/mock/simulator/MockOrderExecutionSimulator.java
@@ -4,6 +4,7 @@ import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.mock.balance.MockBalanceStore;
+import com.marmitt.mock.config.MockOrderScenarioOverride;
 import com.marmitt.mock.config.MockScenarioConfig;
 import lombok.extern.slf4j.Slf4j;
 
@@ -107,6 +108,67 @@ public class MockOrderExecutionSimulator {
         events.add(simulateFilled(request, orderId, finalPrice, finalFee));
         applyBalanceForFill(request, balanceStore, finalPrice, finalIncrement, finalFee);
         return applyOrderingAndDuplicates(events, config, random);
+    }
+
+    /**
+     * Builds a deterministic schedule when an order-level override is provided.
+     * Falls back to current random scenario behavior otherwise.
+     */
+    public List<MockScheduledOrderEvent> buildScenarioSchedule(SendOrderRequest request,
+                                                               String orderId,
+                                                               MockScenarioConfig config,
+                                                               Random random,
+                                                               MockBalanceStore balanceStore,
+                                                               MockOrderScenarioOverride override) {
+        if (override == null) {
+            return buildScenarioEvents(request, orderId, config, random, balanceStore)
+                    .stream()
+                    .map(event -> new MockScheduledOrderEvent(event, -1L))
+                    .toList();
+        }
+
+        OrderValidationResult validation = orderValidator.validate(request, config, balanceStore);
+        if (!validation.accepted()) {
+            OrderDataDto rejected = simulateRejected(request, orderId, validation.rejectReason());
+            return List.of(new MockScheduledOrderEvent(rejected, 0L));
+        }
+
+        List<MockScheduledOrderEvent> scheduled = new ArrayList<>();
+        scheduled.add(new MockScheduledOrderEvent(simulateAccepted(request, orderId), 0L));
+
+        BigDecimal previousExecuted = BigDecimal.ZERO;
+        boolean reservationReleased = false;
+        for (MockOrderScenarioOverride.PlannedEvent planned : override.events()) {
+            ScheduledComputation computed = computeEventFromPlan(
+                    request,
+                    orderId,
+                    config,
+                    planned,
+                    previousExecuted
+            );
+            previousExecuted = computed.executedQuantity();
+
+            if (computed.increment().compareTo(BigDecimal.ZERO) > 0
+                    && (computed.event().status() == OrderDataDto.OrderStatus.PARTIALLY_FILLED
+                    || computed.event().status() == OrderDataDto.OrderStatus.FILLED)) {
+                applyBalanceForFill(request, balanceStore, computed.executedPrice(), computed.increment(), computed.fee());
+            }
+
+            if (!reservationReleased && isFailedTerminal(computed.event().status())) {
+                releaseReservation(request, balanceStore, config);
+                reservationReleased = true;
+            }
+
+            scheduled.add(new MockScheduledOrderEvent(computed.event(), planned.delayBeforeMs()));
+            for (int i = 0; i < planned.duplicates(); i++) {
+                scheduled.add(new MockScheduledOrderEvent(computed.event(), 0L));
+            }
+        }
+
+        if (override.ordering() == MockOrderScenarioOverride.EventOrdering.REVERSE) {
+            Collections.reverse(scheduled);
+        }
+        return scheduled;
     }
 
     public OrderDataDto simulateAccepted(SendOrderRequest request, String orderId) {
@@ -239,6 +301,119 @@ public class MockOrderExecutionSimulator {
         return null;
     }
 
+    private ScheduledComputation computeEventFromPlan(SendOrderRequest request,
+                                                      String orderId,
+                                                      MockScenarioConfig config,
+                                                      MockOrderScenarioOverride.PlannedEvent planned,
+                                                      BigDecimal previousExecuted) {
+        OrderDataDto.OrderStatus status = planned.status();
+        BigDecimal requestQty = request.getQuantity();
+        BigDecimal executedPrice = planned.executedPrice() != null ? planned.executedPrice() : request.getPrice();
+        if (executedPrice == null || executedPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            executedPrice = request.getPrice() != null ? request.getPrice() : BigDecimal.ONE;
+        }
+
+        BigDecimal executedQty = resolveExecutedQuantity(status, planned.executedQuantity(), requestQty, previousExecuted);
+        if (executedQty.compareTo(previousExecuted) < 0) {
+            executedQty = previousExecuted;
+        }
+        if (executedQty.compareTo(requestQty) > 0) {
+            executedQty = requestQty;
+        }
+
+        BigDecimal increment = executedQty.subtract(previousExecuted);
+        if (increment.compareTo(BigDecimal.ZERO) < 0) {
+            increment = BigDecimal.ZERO;
+        }
+
+        BigDecimal fee = planned.fee();
+        if (fee == null) {
+            if (status == OrderDataDto.OrderStatus.PARTIALLY_FILLED || status == OrderDataDto.OrderStatus.FILLED) {
+                fee = feeModel.calculateFee(increment, executedPrice, config);
+            } else {
+                fee = BigDecimal.ZERO;
+            }
+        }
+
+        OrderDataDto event = switch (status) {
+            case NEW -> simulateAccepted(request, orderId);
+            case PARTIALLY_FILLED -> simulatePartial(request, orderId, executedQty, executedPrice, fee);
+            case FILLED -> new OrderDataDto(
+                    orderId,
+                    request.getClientOrderId(),
+                    Symbol.of(request.getSymbol()),
+                    convertOrderSide(request.getOrderSide()),
+                    convertOrderType(request.getOrderType()),
+                    request.getQuantity(),
+                    executedQty,
+                    request.getPrice(),
+                    executedPrice,
+                    fee,
+                    OrderDataDto.OrderStatus.FILLED,
+                    null,
+                    Instant.now()
+            );
+            case CANCELED -> new OrderDataDto(
+                    orderId,
+                    request.getClientOrderId(),
+                    Symbol.of(request.getSymbol()),
+                    convertOrderSide(request.getOrderSide()),
+                    convertOrderType(request.getOrderType()),
+                    request.getQuantity(),
+                    executedQty,
+                    request.getPrice(),
+                    executedPrice,
+                    BigDecimal.ZERO,
+                    OrderDataDto.OrderStatus.CANCELED,
+                    null,
+                    Instant.now()
+            );
+            case EXPIRED -> new OrderDataDto(
+                    orderId,
+                    request.getClientOrderId(),
+                    Symbol.of(request.getSymbol()),
+                    convertOrderSide(request.getOrderSide()),
+                    convertOrderType(request.getOrderType()),
+                    request.getQuantity(),
+                    executedQty,
+                    request.getPrice(),
+                    executedPrice,
+                    BigDecimal.ZERO,
+                    OrderDataDto.OrderStatus.EXPIRED,
+                    null,
+                    Instant.now()
+            );
+            case REJECTED -> simulateRejected(
+                    request,
+                    orderId,
+                    planned.rejectReason() != null ? planned.rejectReason() : "MOCK_REJECTED"
+            );
+        };
+
+        return new ScheduledComputation(event, executedQty, executedPrice, increment, fee);
+    }
+
+    private BigDecimal resolveExecutedQuantity(OrderDataDto.OrderStatus status,
+                                               BigDecimal plannedExecutedQuantity,
+                                               BigDecimal requestQuantity,
+                                               BigDecimal previousExecuted) {
+        if (plannedExecutedQuantity != null) {
+            return plannedExecutedQuantity.setScale(8, RoundingMode.HALF_UP);
+        }
+        return switch (status) {
+            case PARTIALLY_FILLED -> previousExecuted;
+            case FILLED -> requestQuantity.setScale(8, RoundingMode.HALF_UP);
+            case CANCELED, EXPIRED -> previousExecuted;
+            case NEW, REJECTED -> BigDecimal.ZERO.setScale(8, RoundingMode.HALF_UP);
+        };
+    }
+
+    private boolean isFailedTerminal(OrderDataDto.OrderStatus status) {
+        return status == OrderDataDto.OrderStatus.CANCELED
+                || status == OrderDataDto.OrderStatus.EXPIRED
+                || status == OrderDataDto.OrderStatus.REJECTED;
+    }
+
     private List<OrderDataDto> applyOrderingAndDuplicates(List<OrderDataDto> baseEvents,
                                                           MockScenarioConfig config,
                                                           Random random) {
@@ -355,5 +530,12 @@ public class MockOrderExecutionSimulator {
             case STOP_LOSS, STOP_LOSS_LIMIT -> OrderDataDto.OrderType.STOP;
             case TAKE_PROFIT, TAKE_PROFIT_LIMIT -> OrderDataDto.OrderType.STOP_LIMIT;
         };
+    }
+
+    private record ScheduledComputation(OrderDataDto event,
+                                        BigDecimal executedQuantity,
+                                        BigDecimal executedPrice,
+                                        BigDecimal increment,
+                                        BigDecimal fee) {
     }
 }

--- a/adapter-mock/src/main/java/com/marmitt/mock/simulator/MockScheduledOrderEvent.java
+++ b/adapter-mock/src/main/java/com/marmitt/mock/simulator/MockScheduledOrderEvent.java
@@ -1,0 +1,12 @@
+package com.marmitt.mock.simulator;
+
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+
+/**
+ * Event wrapper with explicit delay control for deterministic mock scenarios.
+ */
+public record MockScheduledOrderEvent(
+        OrderDataDto orderData,
+        long delayBeforeMs
+) {
+}

--- a/adapter-mock/src/test/java/com/marmitt/mock/simulator/MockOrderExecutionSimulatorDeterministicScenarioTest.java
+++ b/adapter-mock/src/test/java/com/marmitt/mock/simulator/MockOrderExecutionSimulatorDeterministicScenarioTest.java
@@ -1,0 +1,167 @@
+package com.marmitt.mock.simulator;
+
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
+import com.marmitt.core.enums.OrderSide;
+import com.marmitt.core.enums.OrderType;
+import com.marmitt.mock.balance.MockBalanceStore;
+import com.marmitt.mock.config.MockOrderScenarioOverride;
+import com.marmitt.mock.config.MockScenarioConfig;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MockOrderExecutionSimulatorDeterministicScenarioTest {
+
+    @Test
+    void buildScenarioScheduleShouldRespectDeterministicEventPlan() {
+        MockOrderExecutionSimulator simulator = new MockOrderExecutionSimulator();
+        MockScenarioConfig config = scenarioConfig();
+        MockBalanceStore balanceStore = new MockBalanceStore(Map.of(
+                "USDT", new BigDecimal("1000.00000000"),
+                "BTC", BigDecimal.ZERO
+        ));
+        SendOrderRequest request = new SendOrderRequest(
+                "MOCK",
+                "BTCUSDT",
+                new BigDecimal("1.00000000"),
+                new BigDecimal("100.00000000"),
+                OrderType.LIMIT,
+                OrderSide.BUY,
+                "client-order-1"
+        );
+
+        MockOrderScenarioOverride override = new MockOrderScenarioOverride(
+                List.of(
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                                new BigDecimal("0.40000000"),
+                                new BigDecimal("101.00000000"),
+                                BigDecimal.ZERO,
+                                null,
+                                120L,
+                                1
+                        ),
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                OrderDataDto.OrderStatus.FILLED,
+                                new BigDecimal("1.00000000"),
+                                new BigDecimal("102.00000000"),
+                                BigDecimal.ZERO,
+                                null,
+                                80L,
+                                0
+                        )
+                ),
+                MockOrderScenarioOverride.EventOrdering.AS_IS
+        );
+
+        List<MockScheduledOrderEvent> schedule = simulator.buildScenarioSchedule(
+                request,
+                "MOCK_TEST_1",
+                config,
+                new Random(42L),
+                balanceStore,
+                override
+        );
+
+        assertEquals(4, schedule.size());
+
+        assertEquals(OrderDataDto.OrderStatus.NEW, schedule.get(0).orderData().status());
+        assertEquals(0L, schedule.get(0).delayBeforeMs());
+
+        assertEquals(OrderDataDto.OrderStatus.PARTIALLY_FILLED, schedule.get(1).orderData().status());
+        assertEquals(120L, schedule.get(1).delayBeforeMs());
+        assertEquals(0, schedule.get(1).orderData().executedQuantity().compareTo(new BigDecimal("0.40000000")));
+
+        assertEquals(OrderDataDto.OrderStatus.PARTIALLY_FILLED, schedule.get(2).orderData().status());
+        assertEquals(0L, schedule.get(2).delayBeforeMs());
+
+        assertEquals(OrderDataDto.OrderStatus.FILLED, schedule.get(3).orderData().status());
+        assertEquals(80L, schedule.get(3).delayBeforeMs());
+        assertEquals(0, schedule.get(3).orderData().executedQuantity().compareTo(new BigDecimal("1.00000000")));
+    }
+
+    @Test
+    void buildScenarioScheduleShouldApplyReverseOrderingWhenConfigured() {
+        MockOrderExecutionSimulator simulator = new MockOrderExecutionSimulator();
+        MockScenarioConfig config = scenarioConfig();
+        MockBalanceStore balanceStore = new MockBalanceStore(Map.of(
+                "USDT", new BigDecimal("1000.00000000"),
+                "BTC", BigDecimal.ZERO
+        ));
+        SendOrderRequest request = new SendOrderRequest(
+                "MOCK",
+                "BTCUSDT",
+                new BigDecimal("1.00000000"),
+                new BigDecimal("100.00000000"),
+                OrderType.LIMIT,
+                OrderSide.BUY,
+                "client-order-2"
+        );
+
+        MockOrderScenarioOverride override = new MockOrderScenarioOverride(
+                List.of(
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                                new BigDecimal("0.50000000"),
+                                null,
+                                BigDecimal.ZERO,
+                                null,
+                                10L,
+                                0
+                        ),
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                OrderDataDto.OrderStatus.FILLED,
+                                new BigDecimal("1.00000000"),
+                                null,
+                                BigDecimal.ZERO,
+                                null,
+                                20L,
+                                0
+                        )
+                ),
+                MockOrderScenarioOverride.EventOrdering.REVERSE
+        );
+
+        List<MockScheduledOrderEvent> schedule = simulator.buildScenarioSchedule(
+                request,
+                "MOCK_TEST_2",
+                config,
+                new Random(42L),
+                balanceStore,
+                override
+        );
+
+        assertEquals(3, schedule.size());
+        assertEquals(OrderDataDto.OrderStatus.FILLED, schedule.get(0).orderData().status());
+        assertEquals(OrderDataDto.OrderStatus.PARTIALLY_FILLED, schedule.get(1).orderData().status());
+        assertEquals(OrderDataDto.OrderStatus.NEW, schedule.get(2).orderData().status());
+    }
+
+    private static MockScenarioConfig scenarioConfig() {
+        return new MockScenarioConfig(
+                42L,
+                new MockScenarioConfig.Timing(1L, 1L),
+                new MockScenarioConfig.Flow(0, null),
+                new MockScenarioConfig.Duplicates(0.0, 0),
+                new MockScenarioConfig.OutOfOrder(0.0),
+                new MockScenarioConfig.Failures(0.0, 0.0),
+                new MockScenarioConfig.FeeSettings(MockScenarioConfig.FeeMode.NONE, BigDecimal.ZERO),
+                new MockScenarioConfig.SlippageSettings(MockScenarioConfig.SlippageMode.NONE, 0, 0.0, 0),
+                new MockScenarioConfig.ValidationSettings(
+                        new BigDecimal("0.000001"),
+                        new BigDecimal("0.00000001"),
+                        new BigDecimal("1.0")
+                ),
+                new MockScenarioConfig.BalanceSettings(Map.of(
+                        "USDT", new BigDecimal("1000.00000000"),
+                        "BTC", BigDecimal.ZERO
+                ))
+        );
+    }
+}

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -79,23 +79,32 @@ Consolidar os principais critérios para sair do ambiente de simulação (MOCK) 
 - Regra prática: toda evolução desse checklist deve manter rastreabilidade com os conceitos e invariantes já definidos no Blueprint/IG.
 
 
-## Status de Aderencia (2026-03-05)
+## Status de Aderencia (2026-03-07)
 
 - Testing Roadmap Fase 0: CONCLUIDA no branch `develop`.
-- Evidencias de Fase 0 em testes automatizados:
-  - `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
-  - `core/src/test/java/com/marmitt/core/domain/runner/StrategyRunnerInvariantsTest.java`
-  - `core/src/test/java/com/marmitt/core/domain/runner/TransactionInvariantsTest.java`
-  - `core/src/test/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateIdempotencyTest.java`
-  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java`
+- Testing Roadmap Fase 1A: CONCLUIDA no branch `develop`.
+
+Evidencias de Fase 0 em testes automatizados:
+- `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
+- `core/src/test/java/com/marmitt/core/domain/runner/StrategyRunnerInvariantsTest.java`
+- `core/src/test/java/com/marmitt/core/domain/runner/TransactionInvariantsTest.java`
+- `core/src/test/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateIdempotencyTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java`
+
+Evidencias de Fase 1A em testes automatizados:
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ProcessTradeSignalMockIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderLifecycleMockIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderTerminationConciliationIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java`
 
 ### Impacto no Go-Live
 
-- Item 1 (Testes automatizados minimos): PARCIAL
-- O baseline de invariantes e boot minimo foi coberto (Fase 0).
-- Ainda faltam as fases de integracao e resiliencia (Fases 1 a 4).
+- Item 1 (Testes automatizados minimos): PARCIAL (AVANCADO).
+- Baseline de invariantes e integracao core com MOCK cobertos (Fases 0 e 1A).
+- Ainda faltam fases de robustez e operacao (Fases 1B, 2, 3 e 4) e integracao real com exchange.
 
 ### Proximo passo recomendado
 
-1. Iniciar Fase 1A (integracao com capacidade atual do MOCK).
-2. Atualizar este checklist a cada fase concluida do Testing Roadmap.
+1. Avancar Fase 1B (controles deterministicos no MOCK para duplicidade/concorrencia/falha).
+2. Entrar na Fase 2 (resiliencia sob concorrencia e eventos repetidos).
+3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -414,10 +414,11 @@ Fora de escopo da Fase 4:
 - **IG:** cobre os fluxos e decisões operacionais já mapeadas no projeto.
 - Este roadmap deve evoluir junto com mudanças de domínio e novos modos de execução.
 
-## Status de Execucao (2026-03-05)
+## Status de Execucao (2026-03-07)
 
 - Fase 0: CONCLUIDA.
-- Fase 1A: PROXIMA ETAPA.
+- Fase 1A: CONCLUIDA.
+- Fase 1B: EM ANDAMENTO.
 
 ### Evidencias de conclusao da Fase 0
 
@@ -427,8 +428,19 @@ Fora de escopo da Fase 4:
   - `WARN_ONLY` sem bloqueio indevido.
   - `FAIL_FAST` com preservacao da fase especifica de falha.
 
+### Evidencias de conclusao da Fase 1A
+
+- Fluxo BUY/PARTIAL/FILLED com MOCK e persistencia:
+  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ProcessTradeSignalMockIntegrationTest.java`
+- Fluxo ponta a ponta BUY -> SELL com conciliacao e matches:
+  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderLifecycleMockIntegrationTest.java`
+- Fluxos de terminacao e liberacao de margem (REJECTED/EXPIRED/CANCELED):
+  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderTerminationConciliationIntegrationTest.java`
+- Boot recovery basico (zombie, limbo, DLQ -> HALTED):
+  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java`
+
 ### Relacao com Go-Live
 
 - O Testing Roadmap e o Go-Live devem evoluir em paralelo.
 - Ao concluir cada fase do roadmap, atualizar o status do Item 1 do Go-Live.
-- Go-live completo depende da conclusao das Fases 1 a 4 e da integracao real de exchange.
+- Go-live completo depende da conclusao das Fases 1B, 2, 3 e 4, e da integracao real de exchange.

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockExchangeAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockExchangeAdapter.java
@@ -19,6 +19,7 @@ import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
 import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
 import com.marmitt.mock.adapter.LocalEventWebSocketAdapter;
 import com.marmitt.mock.config.MockBootReadinessConfig;
+import com.marmitt.mock.config.MockOrderScenarioOverride;
 import com.marmitt.mock.config.MockMarketDataFeedConfig;
 import com.marmitt.mock.config.MockScenarioConfig;
 import com.marmitt.mock.processor.MockReceivedMessageProcessor;
@@ -159,6 +160,22 @@ public class MockExchangeAdapter implements ExchangeStreamingPort,
             case TIMEOUT -> ExchangeBootReadiness.notReady(
                     "MOCK", "TIMEOUT", bootReadinessConfig.message());
         };
+    }
+
+    /**
+     * Registers a deterministic one-shot scenario for a specific clientOrderId.
+     * Useful for integration tests that need strict control over order events.
+     */
+    public void registerOrderScenarioOverride(String clientOrderId, MockOrderScenarioOverride override) {
+        runtime.registerOrderScenarioOverride(clientOrderId, override);
+    }
+
+    public void clearOrderScenarioOverride(String clientOrderId) {
+        runtime.clearOrderScenarioOverride(clientOrderId);
+    }
+
+    public void clearOrderScenarioOverrides() {
+        runtime.clearOrderScenarioOverrides();
     }
 
     private static void simulateDelayIfNeeded(long delayMs) {

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
@@ -1,0 +1,273 @@
+package com.marmitt.application.spring.bootstrap;
+
+import com.marmitt.application.spring.CTradeApplication;
+import com.marmitt.application.spring.config.exchange.MockExchangeAdapter;
+import com.marmitt.core.domain.runner.ClientOrderId;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.runner.CreateRunnerRequest;
+import com.marmitt.core.dto.runner.CreateRunnerResponse;
+import com.marmitt.core.dto.runner.OrderDispatchCommand;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
+import com.marmitt.core.ports.inbound.runner.CreateRunnerPort;
+import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import com.marmitt.mock.config.MockOrderScenarioOverride;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Testcontainers
+@SpringBootTest(
+        classes = CTradeApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class MockDeterministicOrderOverrideIntegrationTest {
+
+    private static final UUID SMA_STRATEGY_ID =
+            UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    private static final String SYMBOL = "BTCUSDT";
+    private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(10);
+
+    @Container
+    @SuppressWarnings("resource")
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("ctrade")
+            .withUsername("ctrade")
+            .withPassword("ctrade123");
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("runner.boot.orchestrator-enabled", () -> "false");
+    }
+
+    @Autowired
+    private CreatePortfolioPort createPortfolioPort;
+
+    @Autowired
+    private CreateRunnerPort createRunnerPort;
+
+    @Autowired
+    private StrategyRunnerRepositoryPort strategyRunnerRepository;
+
+    @Autowired
+    private ExchangeAdapterRepositoryPort exchangeAdapterRepository;
+
+    @Autowired
+    private OrderDispatchPort orderDispatchPort;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute("TRUNCATE TABLE portfolios CASCADE");
+        jdbcTemplate.execute("TRUNCATE TABLE capital_event_ledger");
+    }
+
+    @Test
+    void deterministicOverrideShouldConvergeWithoutDoubleApplyingDuplicatePartial() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        UUID runnerId = runner.getId();
+
+        BigDecimal quantity = new BigDecimal("0.00200000");
+        BigDecimal price = new BigDecimal("65000.00000000");
+        String clientOrderId = ClientOrderId.generate(runner.getShortCode(), TransactionType.BUY);
+
+        Transaction pendingBuy = new Transaction(
+                runnerId,
+                clientOrderId,
+                TransactionType.BUY,
+                SYMBOL,
+                quantity,
+                price,
+                quantity.multiply(price),
+                new BigDecimal("0.90"),
+                "phase1b deterministic override",
+                null
+        );
+        strategyRunnerRepository.saveTransaction(pendingBuy);
+
+        MockExchangeAdapter mockExchangeAdapter = getMockExchangeAdapter();
+        mockExchangeAdapter.registerOrderScenarioOverride(clientOrderId, new MockOrderScenarioOverride(
+                List.of(
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                                new BigDecimal("0.00100000"),
+                                new BigDecimal("65010.00000000"),
+                                BigDecimal.ZERO,
+                                null,
+                                30L,
+                                1
+                        ),
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.FILLED,
+                                new BigDecimal("0.00200000"),
+                                new BigDecimal("65020.00000000"),
+                                BigDecimal.ZERO,
+                                null,
+                                30L,
+                                0
+                        )
+                ),
+                MockOrderScenarioOverride.EventOrdering.AS_IS
+        ));
+
+        orderDispatchPort.dispatch(new OrderDispatchCommand(
+                clientOrderId,
+                runnerId,
+                SYMBOL,
+                "MOCK",
+                TransactionType.BUY,
+                quantity,
+                price
+        ));
+
+        Transaction filled = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.FILLED, WAIT_TIMEOUT);
+        assertEquals(0, filled.getEffectiveExecutedQuantity().compareTo(quantity));
+
+        PositionRow position = awaitOpenPositionByOpenedByTransactionId(pendingBuy.getId(), WAIT_TIMEOUT);
+        assertNotNull(position);
+        assertEquals(0, position.quantity().compareTo(quantity),
+                "Duplicate PARTIAL must not double-apply quantity");
+
+        Integer countMatches = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM transaction_matches WHERE buy_transaction_id = ? OR sell_transaction_id = ?",
+                Integer.class,
+                pendingBuy.getId(),
+                pendingBuy.getId()
+        );
+        assertEquals(0, countMatches);
+    }
+
+    private MockExchangeAdapter getMockExchangeAdapter() {
+        Object adapter = exchangeAdapterRepository.findStreamingByName("MOCK")
+                .orElseThrow(() -> new IllegalStateException("MOCK adapter not found"));
+        if (!(adapter instanceof MockExchangeAdapter mock)) {
+            throw new IllegalStateException("MOCK adapter has unexpected type: " + adapter.getClass().getName());
+        }
+        return mock;
+    }
+
+    private UUID createPortfolio() {
+        CreatePortfolioResponse response = createPortfolioPort.execute(
+                CreatePortfolioRequest.builder()
+                        .name("phase1b-det-" + UUID.randomUUID())
+                        .initialCapitalAmount(new BigDecimal("10000.00"))
+                        .currency("USDT")
+                        .build()
+        );
+        assertNotNull(response.portfolioId(), "Portfolio creation failed: " + response.message());
+        return response.portfolioId();
+    }
+
+    private StrategyRunner createAndActivateRunner(UUID portfolioId) {
+        CreateRunnerResponse response = createRunnerPort.execute(
+                CreateRunnerRequest.builder()
+                        .portfolioId(portfolioId)
+                        .strategyId(SMA_STRATEGY_ID)
+                        .symbol(SYMBOL)
+                        .exchangeName("MOCK")
+                        .allowedMarketDataSources(Set.of("BINANCE"))
+                        .build()
+        );
+        assertNotNull(response.runnerId(), "Runner creation failed: " + response.message());
+
+        StrategyRunner runner = strategyRunnerRepository.findById(response.runnerId())
+                .orElseThrow(() -> new IllegalStateException("Runner not found: " + response.runnerId()));
+        runner.startInitializing();
+        runner.activate();
+        strategyRunnerRepository.save(runner);
+
+        return runner;
+    }
+
+    private Transaction awaitTransactionStatus(UUID transactionId,
+                                               TransactionStatus expectedStatus,
+                                               Duration timeout) {
+        Instant deadline = Instant.now().plus(timeout);
+        Transaction last = null;
+        while (Instant.now().isBefore(deadline)) {
+            last = strategyRunnerRepository.findTransactionById(transactionId).orElse(null);
+            if (last != null && last.getStatus() == expectedStatus) {
+                return last;
+            }
+            sleep(80);
+        }
+        throw new AssertionError("Timeout waiting transaction status " + expectedStatus
+                + " for transactionId=" + transactionId + " last=" + (last == null ? "null" : last.getStatus()));
+    }
+
+    private PositionRow awaitOpenPositionByOpenedByTransactionId(UUID openedByTransactionId, Duration timeout) {
+        Instant deadline = Instant.now().plus(timeout);
+        PositionRow last = null;
+        while (Instant.now().isBefore(deadline)) {
+            last = findOpenPositionByOpenedByTransactionId(openedByTransactionId);
+            if (last != null) {
+                return last;
+            }
+            sleep(80);
+        }
+        throw new AssertionError("Timeout waiting OPEN position for openedByTransactionId="
+                + openedByTransactionId + " last=" + last);
+    }
+
+    private PositionRow findOpenPositionByOpenedByTransactionId(UUID openedByTransactionId) {
+        List<PositionRow> rows = jdbcTemplate.query(
+                """
+                        SELECT id, quantity
+                          FROM positions
+                         WHERE opened_by_transaction_id = ?
+                           AND status = 'OPEN'
+                         LIMIT 1
+                        """,
+                (rs, rowNum) -> new PositionRow(
+                        UUID.fromString(rs.getString("id")),
+                        rs.getBigDecimal("quantity")
+                ),
+                openedByTransactionId
+        );
+        return rows.isEmpty() ? null : rows.getFirst();
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting async processing", e);
+        }
+    }
+
+    private record PositionRow(UUID id, BigDecimal quantity) {
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic one-shot scenario override by clientOrderId in MOCK runtime
- support planned event ordering/delay/duplicates for deterministic order lifecycle simulation
- expose override registration in MockExchangeAdapter for integration tests
- add adapter-mock unit tests for deterministic schedule behavior
- add spring integration test covering duplicate PARTIALLY_FILLED + FILLED convergence without double-applying quantity
- update testing roadmap/go-live docs status for phase tracking

## Validation
- ./gradlew -q :adapter-mock:test :spring-application:test --tests com.marmitt.application.spring.bootstrap.MockDeterministicOrderOverrideIntegrationTest
- ./gradlew -q :spring-application:test
