### PR TITLE
test(phase1b): duplicate FILLED idempotency scenario

### DIFF
--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -427,8 +427,8 @@ Fora de escopo da Fase 4:
 
 ### Fase 1B em progresso (1 PR por item)
 
-- PR 1 (atual): `PARTIAL + FILLED` quase simultâneos com convergência.
-- PR 2 (próximo): `FILLED` duplicado sem dupla aplicação econômica.
+- PR 1 (concluído): `PARTIAL + FILLED` quase simultâneos com convergência.
+- PR 2 (atual): `FILLED` duplicado sem dupla aplicação econômica.
 - PR 3 (próximo): `REJECTED/EXPIRED` determinístico com validação de efeitos financeiros.
 
 ### Evidencias de conclusao da Fase 0

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
@@ -252,6 +252,80 @@ class MockDeterministicOrderOverrideIntegrationTest {
         assertEquals(0, countMatches);
     }
 
+    @Test
+    void duplicateFilledShouldNotDoubleApplyEconomicEffects() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        UUID runnerId = runner.getId();
+
+        BigDecimal quantity = new BigDecimal("0.00200000");
+        BigDecimal price = new BigDecimal("65200.00000000");
+        String clientOrderId = ClientOrderId.generate(runner.getShortCode(), TransactionType.BUY);
+
+        Transaction pendingBuy = new Transaction(
+                runnerId,
+                clientOrderId,
+                TransactionType.BUY,
+                SYMBOL,
+                quantity,
+                price,
+                quantity.multiply(price),
+                new BigDecimal("0.90"),
+                "phase1b duplicate filled idempotency",
+                null
+        );
+        strategyRunnerRepository.saveTransaction(pendingBuy);
+
+        MockExchangeAdapter mockExchangeAdapter = getMockExchangeAdapter();
+        mockExchangeAdapter.registerOrderScenarioOverride(clientOrderId, new MockOrderScenarioOverride(
+                List.of(
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.FILLED,
+                                new BigDecimal("0.00200000"),
+                                new BigDecimal("65210.00000000"),
+                                BigDecimal.ZERO,
+                                null,
+                                20L,
+                                2
+                        )
+                ),
+                MockOrderScenarioOverride.EventOrdering.AS_IS
+        ));
+
+        orderDispatchPort.dispatch(new OrderDispatchCommand(
+                clientOrderId,
+                runnerId,
+                SYMBOL,
+                "MOCK",
+                TransactionType.BUY,
+                quantity,
+                price
+        ));
+
+        Transaction filled = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.FILLED, WAIT_TIMEOUT);
+        assertEquals(0, filled.getEffectiveExecutedQuantity().compareTo(quantity));
+
+        PositionRow position = awaitOpenPositionByOpenedByTransactionId(pendingBuy.getId(), WAIT_TIMEOUT);
+        assertNotNull(position);
+        assertEquals(0, position.quantity().compareTo(quantity),
+                "Duplicate FILLED must not increase position quantity more than once");
+
+        Integer openRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM positions WHERE opened_by_transaction_id = ? AND status = 'OPEN'",
+                Integer.class,
+                pendingBuy.getId()
+        );
+        assertEquals(1, openRows);
+
+        Integer countMatches = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM transaction_matches WHERE buy_transaction_id = ? OR sell_transaction_id = ?",
+                Integer.class,
+                pendingBuy.getId(),
+                pendingBuy.getId()
+        );
+        assertEquals(0, countMatches);
+    }
+
     private MockExchangeAdapter getMockExchangeAdapter() {
         Object adapter = exchangeAdapterRepository.findStreamingByName("MOCK")
                 .orElseThrow(() -> new IllegalStateException("MOCK adapter not found"));

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
@@ -34,7 +34,6 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -303,10 +302,10 @@ class MockDeterministicOrderOverrideIntegrationTest {
                 price
         ));
 
-        BuyStateSnapshot stable = awaitStableFilledBuyState(
+        BuyStateSnapshot stable = awaitNoLateDriftAfterFilledConvergence(
                 pendingBuy.getId(),
                 WAIT_TIMEOUT,
-                Duration.ofMillis(400)
+                quantity
         );
 
         assertEquals(0, stable.executedQuantity().compareTo(quantity),
@@ -408,32 +407,28 @@ class MockDeterministicOrderOverrideIntegrationTest {
         return rows.isEmpty() ? null : rows.getFirst();
     }
 
-    private BuyStateSnapshot awaitStableFilledBuyState(UUID openedByTransactionId,
-                                                       Duration timeout,
-                                                       Duration stableWindow) {
+    private BuyStateSnapshot awaitNoLateDriftAfterFilledConvergence(UUID openedByTransactionId,
+                                                                    Duration timeout,
+                                                                    BigDecimal expectedQuantity) {
         Instant deadline = Instant.now().plus(timeout);
-        BuyStateSnapshot previous = null;
-        Instant stableSince = null;
+        BuyStateSnapshot converged = null;
         while (Instant.now().isBefore(deadline)) {
             BuyStateSnapshot current = readBuyState(openedByTransactionId);
-            if (current.status() == TransactionStatus.FILLED && current.positionQuantity() != null) {
-                if (previous != null && sameState(previous, current)) {
-                    if (stableSince == null) {
-                        stableSince = Instant.now();
-                    }
-                    if (!Instant.now().isBefore(stableSince.plus(stableWindow))) {
-                        return current;
-                    }
-                } else {
-                    stableSince = Instant.now();
+            if (converged == null) {
+                if (isExpectedFilledBuyState(current, expectedQuantity)) {
+                    converged = current;
                 }
-            } else {
-                stableSince = null;
+            } else if (!isExpectedFilledBuyState(current, expectedQuantity)) {
+                throw new AssertionError("Filled buy state drift detected after convergence for openedByTransactionId="
+                        + openedByTransactionId + " current=" + current);
             }
-            previous = current;
             sleep(50);
         }
-        throw new AssertionError("Timeout waiting stable FILLED state for openedByTransactionId=" + openedByTransactionId);
+        if (converged == null) {
+            throw new AssertionError("Timeout waiting FILLED buy convergence for openedByTransactionId="
+                    + openedByTransactionId);
+        }
+        return converged;
     }
 
     private BuyStateSnapshot readBuyState(UUID openedByTransactionId) {
@@ -461,13 +456,12 @@ class MockDeterministicOrderOverrideIntegrationTest {
         );
     }
 
-    private static boolean sameState(BuyStateSnapshot left, BuyStateSnapshot right) {
-        return left.status() == right.status()
-                && compareNullable(left.executedQuantity(), right.executedQuantity()) == 0
-                && compareNullable(left.positionQuantity(), right.positionQuantity()) == 0
-                && Objects.equals(left.version(), right.version())
-                && left.openRows() == right.openRows()
-                && left.matchCount() == right.matchCount();
+    private static boolean isExpectedFilledBuyState(BuyStateSnapshot snapshot, BigDecimal expectedQuantity) {
+        return snapshot.status() == TransactionStatus.FILLED
+                && compareNullable(snapshot.executedQuantity(), expectedQuantity) == 0
+                && compareNullable(snapshot.positionQuantity(), expectedQuantity) == 0
+                && snapshot.openRows() == 1
+                && snapshot.matchCount() == 0;
     }
 
     private static int compareNullable(BigDecimal left, BigDecimal right) {

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
@@ -34,6 +34,7 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -302,28 +303,19 @@ class MockDeterministicOrderOverrideIntegrationTest {
                 price
         ));
 
-        Transaction filled = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.FILLED, WAIT_TIMEOUT);
-        assertEquals(0, filled.getEffectiveExecutedQuantity().compareTo(quantity));
-
-        PositionRow position = awaitOpenPositionByOpenedByTransactionId(pendingBuy.getId(), WAIT_TIMEOUT);
-        assertNotNull(position);
-        assertEquals(0, position.quantity().compareTo(quantity),
-                "Duplicate FILLED must not increase position quantity more than once");
-
-        Integer openRows = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM positions WHERE opened_by_transaction_id = ? AND status = 'OPEN'",
-                Integer.class,
-                pendingBuy.getId()
-        );
-        assertEquals(1, openRows);
-
-        Integer countMatches = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM transaction_matches WHERE buy_transaction_id = ? OR sell_transaction_id = ?",
-                Integer.class,
+        BuyStateSnapshot stable = awaitStableFilledBuyState(
                 pendingBuy.getId(),
-                pendingBuy.getId()
+                WAIT_TIMEOUT,
+                Duration.ofMillis(400)
         );
-        assertEquals(0, countMatches);
+
+        assertEquals(0, stable.executedQuantity().compareTo(quantity),
+                "Duplicate FILLED must not change executed quantity after first finalization");
+        assertNotNull(stable.positionQuantity());
+        assertEquals(0, stable.positionQuantity().compareTo(quantity),
+                "Duplicate FILLED must not increase position quantity more than once");
+        assertEquals(1, stable.openRows());
+        assertEquals(0, stable.matchCount());
     }
 
     private MockExchangeAdapter getMockExchangeAdapter() {
@@ -416,6 +408,78 @@ class MockDeterministicOrderOverrideIntegrationTest {
         return rows.isEmpty() ? null : rows.getFirst();
     }
 
+    private BuyStateSnapshot awaitStableFilledBuyState(UUID openedByTransactionId,
+                                                       Duration timeout,
+                                                       Duration stableWindow) {
+        Instant deadline = Instant.now().plus(timeout);
+        BuyStateSnapshot previous = null;
+        Instant stableSince = null;
+        while (Instant.now().isBefore(deadline)) {
+            BuyStateSnapshot current = readBuyState(openedByTransactionId);
+            if (current.status() == TransactionStatus.FILLED && current.positionQuantity() != null) {
+                if (previous != null && sameState(previous, current)) {
+                    if (stableSince == null) {
+                        stableSince = Instant.now();
+                    }
+                    if (!Instant.now().isBefore(stableSince.plus(stableWindow))) {
+                        return current;
+                    }
+                } else {
+                    stableSince = Instant.now();
+                }
+            } else {
+                stableSince = null;
+            }
+            previous = current;
+            sleep(50);
+        }
+        throw new AssertionError("Timeout waiting stable FILLED state for openedByTransactionId=" + openedByTransactionId);
+    }
+
+    private BuyStateSnapshot readBuyState(UUID openedByTransactionId) {
+        Transaction tx = strategyRunnerRepository.findTransactionById(openedByTransactionId)
+                .orElseThrow(() -> new IllegalStateException("Transaction not found: " + openedByTransactionId));
+        PositionRow position = findOpenPositionByOpenedByTransactionId(openedByTransactionId);
+        Integer openRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM positions WHERE opened_by_transaction_id = ? AND status = 'OPEN'",
+                Integer.class,
+                openedByTransactionId
+        );
+        Integer matchCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM transaction_matches WHERE buy_transaction_id = ? OR sell_transaction_id = ?",
+                Integer.class,
+                openedByTransactionId,
+                openedByTransactionId
+        );
+        return new BuyStateSnapshot(
+                tx.getStatus(),
+                tx.getEffectiveExecutedQuantity(),
+                tx.getVersion(),
+                position == null ? null : position.quantity(),
+                openRows == null ? 0 : openRows,
+                matchCount == null ? 0 : matchCount
+        );
+    }
+
+    private static boolean sameState(BuyStateSnapshot left, BuyStateSnapshot right) {
+        return left.status() == right.status()
+                && compareNullable(left.executedQuantity(), right.executedQuantity()) == 0
+                && compareNullable(left.positionQuantity(), right.positionQuantity()) == 0
+                && Objects.equals(left.version(), right.version())
+                && left.openRows() == right.openRows()
+                && left.matchCount() == right.matchCount();
+    }
+
+    private static int compareNullable(BigDecimal left, BigDecimal right) {
+        if (left == null && right == null) {
+            return 0;
+        }
+        if (left == null || right == null) {
+            return 1;
+        }
+        return left.compareTo(right);
+    }
+
     private static void sleep(long millis) {
         try {
             Thread.sleep(millis);
@@ -426,5 +490,13 @@ class MockDeterministicOrderOverrideIntegrationTest {
     }
 
     private record PositionRow(UUID id, BigDecimal quantity) {
+    }
+
+    private record BuyStateSnapshot(TransactionStatus status,
+                                    BigDecimal executedQuantity,
+                                    Long version,
+                                    BigDecimal positionQuantity,
+                                    int openRows,
+                                    int matchCount) {
     }
 }


### PR DESCRIPTION
## Summary
- add integration scenario for duplicated FILLED events in deterministic mock override
- assert idempotency on BUY path: no quantity drift, single open position row, no transaction_match side effects
- update Testing Roadmap status for Fase 1B PR progression (PR2 as current)

## Validation
- ./gradlew -q :adapter-mock:test
- ./gradlew -q :spring-application:compileTestJava

## Note
- Full integration run with Testcontainers is pending because Docker is unavailable in the current environment (dockerDesktopLinuxEngine pipe not found).
