### PR TITLE
test(phase2): validar lock concorrente de SELL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.gradle-local/
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ ctrade/
 ./gradlew :core:build
 ```
 
+### Padrao local para Gradle
+
+Para execucao local e pelos agentes, o projeto passa a usar um unico cache Gradle do repositorio:
+
+- `GRADLE_USER_HOME=.gradle-local`
+- nao criar diretorios paralelos como `.gradle-local-pr`, `.gradle-local-ci` ou equivalentes
+- em caso de lock transitório, reutilizar o mesmo cache com retry
+
+Use o wrapper documentado abaixo no PowerShell:
+
+```powershell
+./scripts/gradle-run.ps1 -q :core:compileJava
+./scripts/gradle-run.ps1 -q :spring-application:test
+./scripts/gradle-run.ps1 build
+```
+
+O script `scripts/gradle-run.ps1` fixa `GRADLE_USER_HOME` em `.gradle-local` e faz retry curto quando encontrar lock de execucao concorrente.
+
 ### Configuração
 
 - **Porta**: 8080

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -79,10 +79,12 @@ Consolidar os principais critérios para sair do ambiente de simulação (MOCK) 
 - Regra prática: toda evolução desse checklist deve manter rastreabilidade com os conceitos e invariantes já definidos no Blueprint/IG.
 
 
-## Status de Aderencia (2026-03-07)
+## Status de Aderencia (2026-04-19)
 
 - Testing Roadmap Fase 0: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 1A: CONCLUIDA no branch `develop`.
+- Testing Roadmap Fase 1B: CONCLUIDA no branch `develop`.
+- Testing Roadmap Fase 2: EM ANDAMENTO no branch de feature.
 
 Evidencias de Fase 0 em testes automatizados:
 - `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
@@ -97,14 +99,17 @@ Evidencias de Fase 1A em testes automatizados:
 - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderTerminationConciliationIntegrationTest.java`
 - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java`
 
+Evidencias de Fase 1B em testes automatizados:
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java`
+
 ### Impacto no Go-Live
 
 - Item 1 (Testes automatizados minimos): PARCIAL (AVANCADO).
-- Baseline de invariantes e integracao core com MOCK cobertos (Fases 0 e 1A).
-- Ainda faltam fases de robustez e operacao (Fases 1B, 2, 3 e 4) e integracao real com exchange.
+- Baseline de invariantes, integracao core com MOCK e controles deterministicos do MOCK cobertos (Fases 0, 1A e 1B).
+- Ainda faltam fases de robustez e operacao (Fases 2, 3 e 4) e integracao real com exchange.
 
 ### Proximo passo recomendado
 
-1. Avancar Fase 1B (controles deterministicos no MOCK para duplicidade/concorrencia/falha).
-2. Entrar na Fase 2 (resiliencia sob concorrencia e eventos repetidos).
+1. Concluir o primeiro PR da Fase 2 com `SELL` concorrente no mesmo lote/posicao.
+2. Avancar para mensagens duplicadas em janela curta.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -419,17 +419,19 @@ Fora de escopo da Fase 4:
 - **IG:** cobre os fluxos e decisões operacionais já mapeadas no projeto.
 - Este roadmap deve evoluir junto com mudanças de domínio e novos modos de execução.
 
-## Status de Execucao (2026-03-07)
+## Status de Execucao (2026-04-19)
 
 - Fase 0: CONCLUIDA.
 - Fase 1A: CONCLUIDA.
-- Fase 1B: EM ANDAMENTO.
+- Fase 1B: CONCLUIDA.
+- Fase 2: EM ANDAMENTO.
 
-### Fase 1B em progresso (1 PR por item)
+### Evidencias de conclusao da Fase 1B
 
 - PR 1 (concluído): `PARTIAL + FILLED` quase simultâneos com convergência.
 - PR 2 (concluído): `FILLED` duplicado sem dupla aplicação econômica.
-- PR 3 (atual): `REJECTED/EXPIRED` determinístico com validação de efeitos financeiros.
+- PR 3 (concluído): `REJECTED/EXPIRED` determinístico com validação de efeitos financeiros.
+- PR 4 (concluído): refinamento de manutenibilidade do teste determinístico da Fase 1B.
 
 ### Evidencias de conclusao da Fase 0
 
@@ -450,8 +452,20 @@ Fora de escopo da Fase 4:
 - Boot recovery basico (zombie, limbo, DLQ -> HALTED):
   - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java`
 
+### Evidencias de conclusao da Fase 1B
+
+- Controles determinísticos e cenarios de duplicidade/concorrencia/rejeicao no MOCK:
+  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java`
+- Refinamentos de legibilidade e reuso no teste deterministico ja incorporados na `develop` via PR #46.
+
 ### Relacao com Go-Live
 
 - O Testing Roadmap e o Go-Live devem evoluir em paralelo.
 - Ao concluir cada fase do roadmap, atualizar o status do Item 1 do Go-Live.
-- Go-live completo depende da conclusao das Fases 1B, 2, 3 e 4, e da integracao real de exchange.
+- Go-live completo depende da conclusao das Fases 2, 3 e 4, e da integracao real de exchange.
+
+### Fase 2 em progresso
+
+1. PR 1 (atual): `SELL` concorrente tentando lock no mesmo lote/posicao.
+2. Validar que apenas uma tentativa consegue aplicar `locked_by_transaction_id`.
+3. Validar snapshot final e delta financeiro para detectar dupla aplicacao economica.

--- a/scripts/gradle-run.ps1
+++ b/scripts/gradle-run.ps1
@@ -1,0 +1,80 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$GradleArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$gradleUserHome = Join-Path $repoRoot ".gradle-local"
+$gradleWrapper = Join-Path $repoRoot "gradlew.bat"
+
+if (-not (Test-Path $gradleWrapper)) {
+    throw "Gradle wrapper not found at $gradleWrapper"
+}
+
+if (-not (Test-Path $gradleUserHome)) {
+    New-Item -ItemType Directory -Path $gradleUserHome | Out-Null
+}
+
+$env:GRADLE_USER_HOME = $gradleUserHome
+
+$maxAttempts = 5
+$retryDelaySeconds = 5
+$lockPatterns = @(
+    "Could not create parent directory for lock file",
+    "Timeout waiting to lock",
+    "already locked by this process",
+    "The process cannot access the file because it is being used by another process"
+)
+
+for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+    Write-Host "gradle-run: attempt $attempt/$maxAttempts using GRADLE_USER_HOME=$gradleUserHome"
+
+    $stdoutFile = New-TemporaryFile
+    $stderrFile = New-TemporaryFile
+    $process = Start-Process `
+        -FilePath $gradleWrapper `
+        -ArgumentList $GradleArgs `
+        -NoNewWindow `
+        -Wait `
+        -PassThru `
+        -RedirectStandardOutput $stdoutFile.FullName `
+        -RedirectStandardError $stderrFile.FullName
+    $exitCode = $process.ExitCode
+
+    $output = @()
+    if (Test-Path $stdoutFile.FullName) {
+        $output += Get-Content $stdoutFile.FullName
+    }
+    if (Test-Path $stderrFile.FullName) {
+        $output += Get-Content $stderrFile.FullName
+    }
+
+    Remove-Item -LiteralPath $stdoutFile.FullName -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stderrFile.FullName -Force -ErrorAction SilentlyContinue
+
+    $output | ForEach-Object { $_ }
+
+    if ($exitCode -eq 0) {
+        exit 0
+    }
+
+    $combinedOutput = ($output | Out-String)
+    $isLockFailure = $false
+    foreach ($pattern in $lockPatterns) {
+        if ($combinedOutput -like "*$pattern*") {
+            $isLockFailure = $true
+            break
+        }
+    }
+
+    if (-not $isLockFailure -or $attempt -eq $maxAttempts) {
+        exit $exitCode
+    }
+
+    Write-Host "gradle-run: lock detected, waiting ${retryDelaySeconds}s before retry"
+    Start-Sleep -Seconds $retryDelaySeconds
+}
+
+exit 1

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
@@ -10,6 +10,7 @@ import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
 import com.marmitt.core.enums.PositionStatus;
+import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.enums.TransactionType;
 import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
 import com.marmitt.core.ports.inbound.runner.CreateRunnerPort;
@@ -39,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
@@ -105,6 +107,8 @@ class ConcurrentSellLockIntegrationTest {
         position.associateBuyTransaction(buy.getId());
         strategyRunnerRepository.savePosition(position);
 
+        // This test isolates the database lock primitive, so both competing SELL intents
+        // are pre-created before the race. The full signal pipeline is covered elsewhere.
         Transaction firstSell = newSellTransaction(runner, position.getId());
         Transaction secondSell = newSellTransaction(runner, position.getId());
         strategyRunnerRepository.saveTransaction(firstSell);
@@ -115,12 +119,12 @@ class ConcurrentSellLockIntegrationTest {
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
             CountDownLatch startSignal = new CountDownLatch(1);
-            Future<LockResult> firstAttempt = executor.submit(() -> tryLockWhenReleased(
+            Future<LockResult> firstAttempt = executor.submit(() -> attemptLockConcurrently(
                     startSignal,
                     position.getId(),
                     firstSell.getId()
             ));
-            Future<LockResult> secondAttempt = executor.submit(() -> tryLockWhenReleased(
+            Future<LockResult> secondAttempt = executor.submit(() -> attemptLockConcurrently(
                     startSignal,
                     position.getId(),
                     secondSell.getId()
@@ -131,7 +135,7 @@ class ConcurrentSellLockIntegrationTest {
             firstResult = firstAttempt.get(LOCK_ATTEMPT_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
             secondResult = secondAttempt.get(LOCK_ATTEMPT_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
         } finally {
-            executor.shutdownNow();
+            shutdownExecutor(executor);
         }
 
         long winners = List.of(firstResult, secondResult).stream()
@@ -148,19 +152,36 @@ class ConcurrentSellLockIntegrationTest {
         assertEquals(0, lockedPosition.getLockedQuantity().compareTo(POSITION_QUANTITY));
         assertNotNull(lockedPosition.getLockedAt());
         assertEquals(1, countLockedPositions(position.getId()));
+
+        LockResult loser = firstResult.locked() ? secondResult : firstResult;
+        Transaction loserTransaction = strategyRunnerRepository.findTransactionById(loser.transactionId())
+                .orElseThrow(() -> new AssertionError("Loser transaction not found: " + loser.transactionId()));
+        assertEquals(TransactionStatus.PENDING, loserTransaction.getStatus());
+        assertNull(loserTransaction.getRejectReason());
     }
 
-    private LockResult tryLockWhenReleased(CountDownLatch startSignal,
-                                           UUID positionId,
-                                           UUID transactionId) throws InterruptedException {
-        assertTrue(startSignal.await(LOCK_ATTEMPT_TIMEOUT.toSeconds(), TimeUnit.SECONDS),
-                "Timed out waiting concurrent lock start signal");
+    private LockResult attemptLockConcurrently(CountDownLatch startSignal,
+                                               UUID positionId,
+                                               UUID transactionId) throws InterruptedException {
+        awaitLatch(startSignal, LOCK_ATTEMPT_TIMEOUT);
         boolean locked = strategyRunnerRepository.tryLockPositionForSell(
                 positionId,
                 transactionId,
                 POSITION_QUANTITY
         );
         return new LockResult(transactionId, locked);
+    }
+
+    private static void awaitLatch(CountDownLatch latch, Duration timeout) throws InterruptedException {
+        assertTrue(latch.await(timeout.toMillis(), TimeUnit.MILLISECONDS),
+                "Timed out waiting latch after " + timeout);
+    }
+
+    private static void shutdownExecutor(ExecutorService executor) throws InterruptedException {
+        executor.shutdown();
+        if (!executor.awaitTermination(LOCK_ATTEMPT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+            executor.shutdownNow();
+        }
     }
 
     private UUID createPortfolio() {

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
@@ -1,0 +1,245 @@
+package com.marmitt.application.spring.bootstrap;
+
+import com.marmitt.application.spring.CTradeApplication;
+import com.marmitt.core.domain.runner.ClientOrderId;
+import com.marmitt.core.domain.runner.Position;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.runner.CreateRunnerRequest;
+import com.marmitt.core.dto.runner.CreateRunnerResponse;
+import com.marmitt.core.enums.PositionStatus;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
+import com.marmitt.core.ports.inbound.runner.CreateRunnerPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Testcontainers
+@SpringBootTest(
+        classes = CTradeApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class ConcurrentSellLockIntegrationTest {
+
+    private static final UUID SMA_STRATEGY_ID =
+            UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    private static final String SYMBOL = "BTCUSDT";
+    private static final String MOCK_EXCHANGE = "MOCK";
+    private static final String MARKET_DATA_EXCHANGE = "BINANCE";
+    private static final BigDecimal INITIAL_CAPITAL = new BigDecimal("10000.00");
+    private static final BigDecimal POSITION_QUANTITY = new BigDecimal("0.00200000");
+    private static final BigDecimal POSITION_PRICE = new BigDecimal("65000.00000000");
+    private static final Duration LOCK_ATTEMPT_TIMEOUT = Duration.ofSeconds(5);
+
+    @Container
+    @SuppressWarnings("resource")
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("ctrade")
+            .withUsername("ctrade")
+            .withPassword("ctrade123");
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("runner.boot.orchestrator-enabled", () -> "false");
+    }
+
+    @Autowired
+    private CreatePortfolioPort createPortfolioPort;
+
+    @Autowired
+    private CreateRunnerPort createRunnerPort;
+
+    @Autowired
+    private StrategyRunnerRepositoryPort strategyRunnerRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute("TRUNCATE TABLE portfolios CASCADE");
+        jdbcTemplate.execute("TRUNCATE TABLE capital_event_ledger");
+    }
+
+    @Test
+    void concurrentSellLocksShouldAllowOnlyOneWinnerForSamePosition() throws Exception {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+
+        Transaction buy = newBuyTransaction(runner);
+        strategyRunnerRepository.saveTransaction(buy);
+
+        Position position = new Position(runner.getId(), SYMBOL, POSITION_QUANTITY, POSITION_PRICE);
+        position.associateBuyTransaction(buy.getId());
+        strategyRunnerRepository.savePosition(position);
+
+        Transaction firstSell = newSellTransaction(runner, position.getId());
+        Transaction secondSell = newSellTransaction(runner, position.getId());
+        strategyRunnerRepository.saveTransaction(firstSell);
+        strategyRunnerRepository.saveTransaction(secondSell);
+
+        LockResult firstResult;
+        LockResult secondResult;
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            CountDownLatch startSignal = new CountDownLatch(1);
+            Future<LockResult> firstAttempt = executor.submit(() -> tryLockWhenReleased(
+                    startSignal,
+                    position.getId(),
+                    firstSell.getId()
+            ));
+            Future<LockResult> secondAttempt = executor.submit(() -> tryLockWhenReleased(
+                    startSignal,
+                    position.getId(),
+                    secondSell.getId()
+            ));
+
+            startSignal.countDown();
+
+            firstResult = firstAttempt.get(LOCK_ATTEMPT_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            secondResult = secondAttempt.get(LOCK_ATTEMPT_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        long winners = List.of(firstResult, secondResult).stream()
+                .filter(LockResult::locked)
+                .count();
+        assertEquals(1, winners, "Only one concurrent SELL lock can win for the same position");
+
+        LockResult winner = firstResult.locked() ? firstResult : secondResult;
+        Position lockedPosition = strategyRunnerRepository.findPositionById(position.getId())
+                .orElseThrow(() -> new AssertionError("Position not found after lock: " + position.getId()));
+
+        assertEquals(PositionStatus.CLOSING, lockedPosition.getStatus());
+        assertEquals(winner.transactionId(), lockedPosition.getLockedByTransactionId());
+        assertEquals(0, lockedPosition.getLockedQuantity().compareTo(POSITION_QUANTITY));
+        assertNotNull(lockedPosition.getLockedAt());
+        assertEquals(1, countLockedPositions(position.getId()));
+    }
+
+    private LockResult tryLockWhenReleased(CountDownLatch startSignal,
+                                           UUID positionId,
+                                           UUID transactionId) throws InterruptedException {
+        assertTrue(startSignal.await(LOCK_ATTEMPT_TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                "Timed out waiting concurrent lock start signal");
+        boolean locked = strategyRunnerRepository.tryLockPositionForSell(
+                positionId,
+                transactionId,
+                POSITION_QUANTITY
+        );
+        return new LockResult(transactionId, locked);
+    }
+
+    private UUID createPortfolio() {
+        CreatePortfolioResponse response = createPortfolioPort.execute(
+                CreatePortfolioRequest.builder()
+                        .name("phase2-lock-" + UUID.randomUUID())
+                        .initialCapitalAmount(INITIAL_CAPITAL)
+                        .currency("USDT")
+                        .build()
+        );
+        assertNotNull(response.portfolioId(), "Portfolio creation failed: " + response.message());
+        return response.portfolioId();
+    }
+
+    private StrategyRunner createAndActivateRunner(UUID portfolioId) {
+        CreateRunnerResponse response = createRunnerPort.execute(
+                CreateRunnerRequest.builder()
+                        .portfolioId(portfolioId)
+                        .strategyId(SMA_STRATEGY_ID)
+                        .symbol(SYMBOL)
+                        .exchangeName(MOCK_EXCHANGE)
+                        .allowedMarketDataSources(Set.of(MARKET_DATA_EXCHANGE))
+                        .build()
+        );
+        assertNotNull(response.runnerId(), "Runner creation failed: " + response.message());
+
+        StrategyRunner runner = strategyRunnerRepository.findById(response.runnerId())
+                .orElseThrow(() -> new IllegalStateException("Runner not found: " + response.runnerId()));
+        runner.startInitializing();
+        runner.activate();
+        strategyRunnerRepository.save(runner);
+        return runner;
+    }
+
+    private Transaction newBuyTransaction(StrategyRunner runner) {
+        return new Transaction(
+                runner.getId(),
+                ClientOrderId.generate(runner.getShortCode(), TransactionType.BUY),
+                TransactionType.BUY,
+                SYMBOL,
+                POSITION_QUANTITY,
+                POSITION_PRICE,
+                POSITION_QUANTITY.multiply(POSITION_PRICE),
+                new BigDecimal("0.90"),
+                "phase2 seed buy position",
+                null
+        );
+    }
+
+    private Transaction newSellTransaction(StrategyRunner runner, UUID targetLotId) {
+        return new Transaction(
+                runner.getId(),
+                ClientOrderId.generate(runner.getShortCode(), TransactionType.SELL),
+                TransactionType.SELL,
+                SYMBOL,
+                POSITION_QUANTITY,
+                POSITION_PRICE,
+                POSITION_QUANTITY.multiply(POSITION_PRICE),
+                new BigDecimal("0.90"),
+                "phase2 concurrent sell lock",
+                targetLotId
+        );
+    }
+
+    private int countLockedPositions(UUID positionId) {
+        Integer count = jdbcTemplate.queryForObject(
+                """
+                        SELECT COUNT(*)
+                          FROM positions
+                         WHERE id = ?
+                           AND status = 'CLOSING'
+                           AND locked_by_transaction_id IS NOT NULL
+                        """,
+                Integer.class,
+                positionId
+        );
+        return count == null ? 0 : count;
+    }
+
+    private record LockResult(UUID transactionId, boolean locked) {
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
@@ -157,6 +157,12 @@ class ConcurrentSellLockIntegrationTest {
         assertNotNull(lockedPosition.getLockedAt());
         assertEquals(1, countLockedPositions(position.getId()));
 
+        Transaction winnerTransaction = strategyRunnerRepository.findTransactionById(winner.transactionId())
+                .orElseThrow(() -> new AssertionError("Winner transaction not found: " + winner.transactionId()));
+        assertEquals(TransactionType.SELL, winnerTransaction.getType());
+        assertEquals(TransactionStatus.PENDING, winnerTransaction.getStatus());
+        assertEquals(position.getId(), winnerTransaction.getTargetLotId());
+
         LockResult loser = firstResult.locked() ? secondResult : firstResult;
         Transaction loserTransaction = strategyRunnerRepository.findTransactionById(loser.transactionId())
                 .orElseThrow(() -> new AssertionError("Loser transaction not found: " + loser.transactionId()));

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
@@ -118,18 +118,22 @@ class ConcurrentSellLockIntegrationTest {
         LockResult secondResult;
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
+            CountDownLatch readySignal = new CountDownLatch(2);
             CountDownLatch startSignal = new CountDownLatch(1);
             Future<LockResult> firstAttempt = executor.submit(() -> attemptLockConcurrently(
+                    readySignal,
                     startSignal,
                     position.getId(),
                     firstSell.getId()
             ));
             Future<LockResult> secondAttempt = executor.submit(() -> attemptLockConcurrently(
+                    readySignal,
                     startSignal,
                     position.getId(),
                     secondSell.getId()
             ));
 
+            awaitLatch(readySignal, LOCK_ATTEMPT_TIMEOUT);
             startSignal.countDown();
 
             firstResult = firstAttempt.get(LOCK_ATTEMPT_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
@@ -160,9 +164,11 @@ class ConcurrentSellLockIntegrationTest {
         assertNull(loserTransaction.getRejectReason());
     }
 
-    private LockResult attemptLockConcurrently(CountDownLatch startSignal,
+    private LockResult attemptLockConcurrently(CountDownLatch readySignal,
+                                               CountDownLatch startSignal,
                                                UUID positionId,
                                                UUID transactionId) throws InterruptedException {
+        readySignal.countDown();
         awaitLatch(startSignal, LOCK_ATTEMPT_TIMEOUT);
         boolean locked = strategyRunnerRepository.tryLockPositionForSell(
                 positionId,


### PR DESCRIPTION
## Resumo
- inicia a Fase 2 do roadmap com teste de concorrencia no lock de SELL
- adiciona ConcurrentSellLockIntegrationTest validando que apenas uma tentativa concorrente aplica locked_by_transaction_id na mesma position
- padroniza execucao local do Gradle via scripts/gradle-run.ps1 usando um unico GRADLE_USER_HOME=.gradle-local
- atualiza roadmap/go-live para marcar Fase 1B concluida e Fase 2 em andamento

## Validacao
- powershell -ExecutionPolicy Bypass -File scripts/gradle-run.ps1 --no-daemon --console=plain :spring-application:compileTestJava ✅
- powershell -ExecutionPolicy Bypass -File scripts/gradle-run.ps1 --no-daemon --console=plain :spring-application:test --tests com.marmitt.application.spring.bootstrap.ConcurrentSellLockIntegrationTest ⚠️ falhou neste ambiente por Docker/Testcontainers indisponivel (Could not find a valid Docker environment)