### PR TITLE
test(phase2): tornar lock de SELL idempotente

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -84,7 +84,7 @@ Consolidar os principais critérios para sair do ambiente de simulação (MOCK) 
 - Testing Roadmap Fase 0: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 1A: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 1B: CONCLUIDA no branch `develop`.
-- Testing Roadmap Fase 2: EM ANDAMENTO no branch de feature.
+- Testing Roadmap Fase 2: EM ANDAMENTO.
 
 Evidencias de Fase 0 em testes automatizados:
 - `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
@@ -110,6 +110,6 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Concluir o primeiro PR da Fase 2 com `SELL` concorrente no mesmo lote/posicao.
+1. Concluir o PR 2 da Fase 2 com retry idempotente do mesmo `SELL` lock.
 2. Avancar para mensagens duplicadas em janela curta.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -466,6 +466,6 @@ Fora de escopo da Fase 4:
 
 ### Fase 2 em progresso
 
-1. PR 1 (atual): `SELL` concorrente tentando lock no mesmo lote/posicao.
-2. Validar que apenas uma tentativa consegue aplicar `locked_by_transaction_id`.
+1. PR 1 (concluido): `SELL` concorrente tentando lock no mesmo lote/posicao.
+2. PR 2 (atual): retry idempotente do mesmo `SELL` lock sem permitir tomada por outra transacao.
 3. Validar snapshot final e delta financeiro para detectar dupla aplicacao economica.

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @Slf4j
 @Repository
@@ -296,8 +297,9 @@ public class JdbcStrategyRunnerRepositoryAdapter implements StrategyRunnerReposi
     @Transactional
     public boolean tryLockPositionForSell(UUID positionId, UUID transactionId, BigDecimal quantity) {
         long start = System.nanoTime();
-        int updated = positionRepo.tryLockPositionForSell(positionId, transactionId, quantity);
-        boolean locked = updated == 1 || positionRepo.isLockedByTransaction(positionId, transactionId, quantity);
+        BigDecimal normalizedQuantity = quantity.setScale(8, RoundingMode.HALF_UP);
+        int updated = positionRepo.tryLockPositionForSell(positionId, transactionId, normalizedQuantity);
+        boolean locked = updated == 1 || positionRepo.isLockedByTransaction(positionId, transactionId, normalizedQuantity);
         log.trace("[REPO] position.tryLockForSell(pos={}, tx={}, locked={}, updated={}) - {}ms",
                 positionId, transactionId, locked, updated, RepoTiming.elapsedMs(start));
         return locked;

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
@@ -297,9 +297,9 @@ public class JdbcStrategyRunnerRepositoryAdapter implements StrategyRunnerReposi
     public boolean tryLockPositionForSell(UUID positionId, UUID transactionId, BigDecimal quantity) {
         long start = System.nanoTime();
         int updated = positionRepo.tryLockPositionForSell(positionId, transactionId, quantity);
-        boolean locked = updated == 1;
-        log.trace("[REPO] position.tryLockForSell(pos={}, tx={}, locked={}) - {}ms",
-                positionId, transactionId, locked, RepoTiming.elapsedMs(start));
+        boolean locked = updated == 1 || positionRepo.isLockedByTransaction(positionId, transactionId, quantity);
+        log.trace("[REPO] position.tryLockForSell(pos={}, tx={}, locked={}, updated={}) - {}ms",
+                positionId, transactionId, locked, updated, RepoTiming.elapsedMs(start));
         return locked;
     }
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerPositionJdbcRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerPositionJdbcRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.math.BigDecimal;
 
 @Repository
 public interface RunnerPositionJdbcRepository extends CrudRepository<RunnerPositionEntity, UUID> {
@@ -83,6 +84,20 @@ public interface RunnerPositionJdbcRepository extends CrudRepository<RunnerPosit
     int tryLockPositionForSell(
             @Param("positionId") UUID positionId,
             @Param("transactionId") UUID transactionId,
-            @Param("quantity") java.math.BigDecimal quantity
+            @Param("quantity") BigDecimal quantity
+    );
+
+    @Query("""
+            SELECT COUNT(*) > 0
+              FROM positions
+             WHERE id = :positionId
+               AND status = 'CLOSING'
+               AND locked_by_transaction_id = :transactionId
+               AND locked_quantity = :quantity
+            """)
+    boolean isLockedByTransaction(
+            @Param("positionId") UUID positionId,
+            @Param("transactionId") UUID transactionId,
+            @Param("quantity") BigDecimal quantity
     );
 }

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
@@ -59,6 +59,8 @@ class ConcurrentSellLockIntegrationTest {
     private static final String MARKET_DATA_EXCHANGE = "BINANCE";
     private static final BigDecimal INITIAL_CAPITAL = new BigDecimal("10000.00");
     private static final BigDecimal POSITION_QUANTITY = new BigDecimal("0.00200000");
+    private static final BigDecimal HIGH_PRECISION_LOCK_QUANTITY = new BigDecimal("0.002000004");
+    private static final BigDecimal NORMALIZED_HIGH_PRECISION_LOCK_QUANTITY = new BigDecimal("0.00200000");
     private static final BigDecimal POSITION_PRICE = new BigDecimal("65000.00000000");
     private static final Duration LOCK_ATTEMPT_TIMEOUT = Duration.ofSeconds(5);
 
@@ -170,27 +172,27 @@ class ConcurrentSellLockIntegrationTest {
     void sellLockRetryForSameTransactionShouldBeIdempotent() {
         UUID portfolioId = createPortfolio();
         StrategyRunner runner = createAndActivateRunner(portfolioId);
-        Position position = createOpenPosition(runner);
+        Position position = createOpenPosition(runner, HIGH_PRECISION_LOCK_QUANTITY);
 
-        Transaction sell = newSellTransaction(runner, position.getId());
-        Transaction competingSell = newSellTransaction(runner, position.getId());
+        Transaction sell = newSellTransaction(runner, position.getId(), HIGH_PRECISION_LOCK_QUANTITY);
+        Transaction competingSell = newSellTransaction(runner, position.getId(), HIGH_PRECISION_LOCK_QUANTITY);
         strategyRunnerRepository.saveTransaction(sell);
         strategyRunnerRepository.saveTransaction(competingSell);
 
         boolean firstAttempt = strategyRunnerRepository.tryLockPositionForSell(
                 position.getId(),
                 sell.getId(),
-                POSITION_QUANTITY
+                sell.getQuantity()
         );
         boolean retryAttempt = strategyRunnerRepository.tryLockPositionForSell(
                 position.getId(),
                 sell.getId(),
-                POSITION_QUANTITY
+                sell.getQuantity()
         );
         boolean competingAttempt = strategyRunnerRepository.tryLockPositionForSell(
                 position.getId(),
                 competingSell.getId(),
-                POSITION_QUANTITY
+                competingSell.getQuantity()
         );
 
         assertTrue(firstAttempt, "Initial SELL lock should succeed");
@@ -201,7 +203,7 @@ class ConcurrentSellLockIntegrationTest {
                 .orElseThrow(() -> new AssertionError("Position not found after lock: " + position.getId()));
         assertEquals(PositionStatus.CLOSING, lockedPosition.getStatus());
         assertEquals(sell.getId(), lockedPosition.getLockedByTransactionId());
-        assertEquals(0, lockedPosition.getLockedQuantity().compareTo(POSITION_QUANTITY));
+        assertEquals(0, lockedPosition.getLockedQuantity().compareTo(NORMALIZED_HIGH_PRECISION_LOCK_QUANTITY));
         assertEquals(1, countLockedPositions(position.getId()));
     }
 
@@ -264,10 +266,14 @@ class ConcurrentSellLockIntegrationTest {
     }
 
     private Position createOpenPosition(StrategyRunner runner) {
+        return createOpenPosition(runner, POSITION_QUANTITY);
+    }
+
+    private Position createOpenPosition(StrategyRunner runner, BigDecimal quantity) {
         Transaction buy = newBuyTransaction(runner);
         strategyRunnerRepository.saveTransaction(buy);
 
-        Position position = new Position(runner.getId(), SYMBOL, POSITION_QUANTITY, POSITION_PRICE);
+        Position position = new Position(runner.getId(), SYMBOL, quantity, POSITION_PRICE);
         position.associateBuyTransaction(buy.getId());
         strategyRunnerRepository.savePosition(position);
         return position;
@@ -289,14 +295,18 @@ class ConcurrentSellLockIntegrationTest {
     }
 
     private Transaction newSellTransaction(StrategyRunner runner, UUID targetLotId) {
+        return newSellTransaction(runner, targetLotId, POSITION_QUANTITY);
+    }
+
+    private Transaction newSellTransaction(StrategyRunner runner, UUID targetLotId, BigDecimal quantity) {
         return new Transaction(
                 runner.getId(),
                 ClientOrderId.generate(runner.getShortCode(), TransactionType.SELL),
                 TransactionType.SELL,
                 SYMBOL,
-                POSITION_QUANTITY,
+                quantity,
                 POSITION_PRICE,
-                POSITION_QUANTITY.multiply(POSITION_PRICE),
+                quantity.multiply(POSITION_PRICE),
                 new BigDecimal("0.90"),
                 "phase2 concurrent sell lock",
                 targetLotId

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -100,12 +101,7 @@ class ConcurrentSellLockIntegrationTest {
         UUID portfolioId = createPortfolio();
         StrategyRunner runner = createAndActivateRunner(portfolioId);
 
-        Transaction buy = newBuyTransaction(runner);
-        strategyRunnerRepository.saveTransaction(buy);
-
-        Position position = new Position(runner.getId(), SYMBOL, POSITION_QUANTITY, POSITION_PRICE);
-        position.associateBuyTransaction(buy.getId());
-        strategyRunnerRepository.savePosition(position);
+        Position position = createOpenPosition(runner);
 
         // This test isolates the database lock primitive, so both competing SELL intents
         // are pre-created before the race. The full signal pipeline is covered elsewhere.
@@ -170,6 +166,45 @@ class ConcurrentSellLockIntegrationTest {
         assertNull(loserTransaction.getRejectReason());
     }
 
+    @Test
+    void sellLockRetryForSameTransactionShouldBeIdempotent() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        Position position = createOpenPosition(runner);
+
+        Transaction sell = newSellTransaction(runner, position.getId());
+        Transaction competingSell = newSellTransaction(runner, position.getId());
+        strategyRunnerRepository.saveTransaction(sell);
+        strategyRunnerRepository.saveTransaction(competingSell);
+
+        boolean firstAttempt = strategyRunnerRepository.tryLockPositionForSell(
+                position.getId(),
+                sell.getId(),
+                POSITION_QUANTITY
+        );
+        boolean retryAttempt = strategyRunnerRepository.tryLockPositionForSell(
+                position.getId(),
+                sell.getId(),
+                POSITION_QUANTITY
+        );
+        boolean competingAttempt = strategyRunnerRepository.tryLockPositionForSell(
+                position.getId(),
+                competingSell.getId(),
+                POSITION_QUANTITY
+        );
+
+        assertTrue(firstAttempt, "Initial SELL lock should succeed");
+        assertTrue(retryAttempt, "Retry by the same SELL transaction should be idempotent");
+        assertFalse(competingAttempt, "Different SELL transaction must not take an existing lock");
+
+        Position lockedPosition = strategyRunnerRepository.findPositionById(position.getId())
+                .orElseThrow(() -> new AssertionError("Position not found after lock: " + position.getId()));
+        assertEquals(PositionStatus.CLOSING, lockedPosition.getStatus());
+        assertEquals(sell.getId(), lockedPosition.getLockedByTransactionId());
+        assertEquals(0, lockedPosition.getLockedQuantity().compareTo(POSITION_QUANTITY));
+        assertEquals(1, countLockedPositions(position.getId()));
+    }
+
     private LockResult attemptLockConcurrently(CountDownLatch readySignal,
                                                CountDownLatch startSignal,
                                                UUID positionId,
@@ -226,6 +261,16 @@ class ConcurrentSellLockIntegrationTest {
         runner.activate();
         strategyRunnerRepository.save(runner);
         return runner;
+    }
+
+    private Position createOpenPosition(StrategyRunner runner) {
+        Transaction buy = newBuyTransaction(runner);
+        strategyRunnerRepository.saveTransaction(buy);
+
+        Position position = new Position(runner.getId(), SYMBOL, POSITION_QUANTITY, POSITION_PRICE);
+        position.associateBuyTransaction(buy.getId());
+        strategyRunnerRepository.savePosition(position);
+        return position;
     }
 
     private Transaction newBuyTransaction(StrategyRunner runner) {


### PR DESCRIPTION
## Resumo
- ajusta 	ryLockPositionForSell para considerar sucesso quando a position ja esta lockada pela mesma transaction e mesma quantidade
- mantem bloqueio contra outra SELL tentando tomar lock existente
- adiciona cobertura em ConcurrentSellLockIntegrationTest para retry idempotente da mesma SELL
- atualiza roadmap/go-live marcando PR 1 da Fase 2 como concluido e PR 2 como atual

## Validacao
- powershell -ExecutionPolicy Bypass -File scripts/gradle-run.ps1 --no-daemon --console=plain :spring-application:compileTestJava ✅
- powershell -ExecutionPolicy Bypass -File scripts/gradle-run.ps1 --no-daemon --console=plain :spring-application:test --tests com.marmitt.application.spring.bootstrap.ConcurrentSellLockIntegrationTest ✅