### PR TITLE
test(phase2): validar eventos de ordem fora de ordem

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -110,6 +110,6 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Revisar/mergear o PR 3 da Fase 2 com callbacks duplicados de `SELL FILLED` em janela curta.
-2. Avancar para o proximo item da Fase 2 apos validar ausencia de dupla criacao de `transaction_matches`, PnL e liberacao de capital.
+1. Revisar/mergear o PR 4 da Fase 2 com reorder controlado de eventos (`FILLED` antes de `PARTIAL`).
+2. Avancar para retry/falha transitoria apos validar convergencia sem drift financeiro em eventos fora de ordem.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -468,4 +468,5 @@ Fora de escopo da Fase 4:
 
 1. PR 1 (concluido): `SELL` concorrente tentando lock no mesmo lote/posicao.
 2. PR 2 (concluido): retry idempotente do mesmo `SELL` lock sem permitir tomada por outra transacao.
-3. PR 3 (atual): callbacks duplicados de `SELL FILLED` em janela curta sem dupla aplicacao economica.
+3. PR 3 (concluido): callbacks duplicados de `SELL FILLED` em janela curta sem dupla aplicacao economica.
+4. PR 4 (atual): reorder controlado com `FILLED` antes de `PARTIAL` para BUY e SELL.

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
@@ -10,6 +10,7 @@ import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
 import com.marmitt.core.dto.runner.OrderDispatchCommand;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.enums.TransactionType;
 import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
@@ -534,7 +535,14 @@ class MockDeterministicOrderOverrideIntegrationTest {
         ));
 
         BuyStateSnapshot stable = awaitStableFilledState(pendingBuy.getId(), WAIT_TIMEOUT, quantity);
+        OrderDataDto latePartial = awaitMockOrderStatus(
+                clientOrderId,
+                OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                WAIT_TIMEOUT
+        );
 
+        assertEquals(OrderDataDto.OrderStatus.PARTIALLY_FILLED, latePartial.status(),
+                "Mock must emit the delayed BUY PARTIAL after FILLED to prove reorder coverage");
         assertEquals(TransactionStatus.FILLED, stable.status());
         assertEquals(0, stable.executedQuantity().compareTo(quantity),
                 "Late BUY PARTIAL after FILLED must not reduce executed quantity");
@@ -610,7 +618,14 @@ class MockDeterministicOrderOverrideIntegrationTest {
                 quantity,
                 expectedPnl
         );
+        OrderDataDto latePartial = awaitMockOrderStatus(
+                sellSetup.sellTransaction().getClientOrderId(),
+                OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                WAIT_TIMEOUT
+        );
 
+        assertEquals(OrderDataDto.OrderStatus.PARTIALLY_FILLED, latePartial.status(),
+                "Mock must emit the delayed SELL PARTIAL after FILLED to prove reorder coverage");
         assertEquals(TransactionStatus.FILLED, stable.status());
         assertEquals(0, stable.executedQuantity().compareTo(quantity),
                 "Late SELL PARTIAL after FILLED must not reduce executed quantity");
@@ -786,6 +801,21 @@ class MockDeterministicOrderOverrideIntegrationTest {
         strategyRunnerRepository.save(runner);
 
         return runner;
+    }
+
+    private OrderDataDto awaitMockOrderStatus(String clientOrderId,
+                                              OrderDataDto.OrderStatus expectedStatus,
+                                              Duration timeout) {
+        return awaitCondition(
+                timeout,
+                DEFAULT_POLL_INTERVAL_MS,
+                () -> getMockExchangeAdapter()
+                        .queryOrderByClientOrderId(SYMBOL, clientOrderId)
+                        .orElse(null),
+                order -> order != null && order.status() == expectedStatus,
+                "Timeout waiting mock emitted order status " + expectedStatus
+                        + " for clientOrderId=" + clientOrderId
+        );
     }
 
     private SellSetup createFilledBuyAndLockedSell(UUID portfolioId,

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockDeterministicOrderOverrideIntegrationTest.java
@@ -64,6 +64,10 @@ class MockDeterministicOrderOverrideIntegrationTest {
     private static final String SCENARIO_PARTIAL_FILLED_CONVERGENCE = "phase1b partial+filled convergence";
     private static final String SCENARIO_DUPLICATE_FILLED = "phase1b duplicate filled idempotency";
     private static final String SCENARIO_DUPLICATE_SELL_FILLED = "phase2 duplicate sell filled idempotency";
+    private static final String SCENARIO_REORDERED_BUY_FILLED_BEFORE_PARTIAL =
+            "phase2 reordered buy filled before partial";
+    private static final String SCENARIO_REORDERED_SELL_FILLED_BEFORE_PARTIAL =
+            "phase2 reordered sell filled before partial";
     private static final String SCENARIO_REJECTED_FINANCIAL = "phase1b rejected financial";
     private static final String SCENARIO_EXPIRED_FINANCIAL = "phase1b expired financial";
 
@@ -470,6 +474,160 @@ class MockDeterministicOrderOverrideIntegrationTest {
     }
 
     @Test
+    void reorderedBuyFilledBeforePartialShouldIgnoreLatePartial() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        UUID runnerId = runner.getId();
+
+        BigDecimal quantity = new BigDecimal("0.00200000");
+        BigDecimal price = new BigDecimal("65500.00000000");
+        String clientOrderId = ClientOrderId.generate(runner.getShortCode(), TransactionType.BUY);
+
+        Transaction pendingBuy = new Transaction(
+                runnerId,
+                clientOrderId,
+                TransactionType.BUY,
+                SYMBOL,
+                quantity,
+                price,
+                quantity.multiply(price),
+                new BigDecimal("0.90"),
+                SCENARIO_REORDERED_BUY_FILLED_BEFORE_PARTIAL,
+                null
+        );
+        strategyRunnerRepository.saveTransaction(pendingBuy);
+        assertNoInitialPositionOrMatch(pendingBuy.getId());
+
+        MockExchangeAdapter mockExchangeAdapter = getMockExchangeAdapter();
+        mockExchangeAdapter.registerOrderScenarioOverride(clientOrderId, new MockOrderScenarioOverride(
+                List.of(
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                                new BigDecimal("0.00100000"),
+                                new BigDecimal("65505.00000000"),
+                                BigDecimal.ZERO,
+                                null,
+                                20L,
+                                0
+                        ),
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.FILLED,
+                                quantity,
+                                new BigDecimal("65510.00000000"),
+                                BigDecimal.ZERO,
+                                null,
+                                20L,
+                                0
+                        )
+                ),
+                MockOrderScenarioOverride.EventOrdering.REVERSE
+        ));
+
+        orderDispatchPort.dispatch(new OrderDispatchCommand(
+                clientOrderId,
+                runnerId,
+                SYMBOL,
+                MOCK_EXCHANGE,
+                TransactionType.BUY,
+                quantity,
+                price
+        ));
+
+        BuyStateSnapshot stable = awaitStableFilledState(pendingBuy.getId(), WAIT_TIMEOUT, quantity);
+
+        assertEquals(TransactionStatus.FILLED, stable.status());
+        assertEquals(0, stable.executedQuantity().compareTo(quantity),
+                "Late BUY PARTIAL after FILLED must not reduce executed quantity");
+        assertEquals(1, stable.openRows(),
+                "Late BUY PARTIAL after FILLED must not create another position");
+        assertEquals(0, stable.positionQuantity().compareTo(quantity),
+                "Late BUY PARTIAL after FILLED must not drift position quantity");
+        assertEquals(0, stable.matchCount());
+    }
+
+    @Test
+    void reorderedSellFilledBeforePartialShouldIgnoreLatePartial() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+
+        BigDecimal quantity = new BigDecimal("0.00200000");
+        BigDecimal buyPrice = new BigDecimal("65000.00000000");
+        BigDecimal sellPrice = new BigDecimal("66100.00000000");
+        BigDecimal expectedPnl = quantity.multiply(sellPrice.subtract(buyPrice));
+
+        SellSetup sellSetup = createFilledBuyAndLockedSell(
+                portfolioId,
+                runner,
+                quantity,
+                buyPrice,
+                sellPrice,
+                SCENARIO_REORDERED_SELL_FILLED_BEFORE_PARTIAL
+        );
+
+        MockExchangeAdapter mockExchangeAdapter = getMockExchangeAdapter();
+        mockExchangeAdapter.registerOrderScenarioOverride(
+                sellSetup.sellTransaction().getClientOrderId(),
+                new MockOrderScenarioOverride(
+                        List.of(
+                                new MockOrderScenarioOverride.PlannedEvent(
+                                        com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                                        new BigDecimal("0.00100000"),
+                                        new BigDecimal("66090.00000000"),
+                                        BigDecimal.ZERO,
+                                        null,
+                                        20L,
+                                        0
+                                ),
+                                new MockOrderScenarioOverride.PlannedEvent(
+                                        com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.FILLED,
+                                        quantity,
+                                        sellPrice,
+                                        BigDecimal.ZERO,
+                                        null,
+                                        20L,
+                                        0
+                                )
+                        ),
+                        MockOrderScenarioOverride.EventOrdering.REVERSE
+                )
+        );
+
+        orderDispatchPort.dispatch(new OrderDispatchCommand(
+                sellSetup.sellTransaction().getClientOrderId(),
+                runner.getId(),
+                SYMBOL,
+                MOCK_EXCHANGE,
+                TransactionType.SELL,
+                quantity,
+                sellPrice
+        ));
+
+        SellStateSnapshot stable = awaitStableSellState(
+                portfolioId,
+                sellSetup.sellTransaction().getId(),
+                sellSetup.position().id(),
+                WAIT_TIMEOUT,
+                quantity,
+                expectedPnl
+        );
+
+        assertEquals(TransactionStatus.FILLED, stable.status());
+        assertEquals(0, stable.executedQuantity().compareTo(quantity),
+                "Late SELL PARTIAL after FILLED must not reduce executed quantity");
+        assertEquals(1, stable.matchCount(),
+                "Late SELL PARTIAL after FILLED must not create another transaction_match");
+        assertEquals(0, stable.matchedQuantity().compareTo(quantity),
+                "Late SELL PARTIAL after FILLED must not drift matched quantity");
+        assertEquals(0, stable.pnlRealized().compareTo(expectedPnl),
+                "Late SELL PARTIAL after FILLED must not change realized PnL");
+        assertEquals("CLOSED", stable.positionStatus());
+        assertEquals(0, stable.positionQuantity().compareTo(BigDecimal.ZERO));
+        assertEquals(0, stable.realizedBalance().compareTo(expectedPnl));
+        assertEquals(0, stable.availableBalance().compareTo(INITIAL_CAPITAL.add(expectedPnl)));
+        assertEquals(0, stable.reservedBalance().compareTo(BigDecimal.ZERO));
+    }
+
+    @Test
     void rejectedBuyShouldReleaseReservedBalanceWithoutCreatingPosition() {
         UUID portfolioId = createPortfolio();
         StrategyRunner runner = createAndActivateRunner(portfolioId);
@@ -628,6 +786,82 @@ class MockDeterministicOrderOverrideIntegrationTest {
         strategyRunnerRepository.save(runner);
 
         return runner;
+    }
+
+    private SellSetup createFilledBuyAndLockedSell(UUID portfolioId,
+                                                   StrategyRunner runner,
+                                                   BigDecimal quantity,
+                                                   BigDecimal buyPrice,
+                                                   BigDecimal sellPrice,
+                                                   String reason) {
+        BigDecimal buyCost = quantity.multiply(buyPrice);
+        String buyClientOrderId = ClientOrderId.generate(runner.getShortCode(), TransactionType.BUY);
+        Transaction pendingBuy = new Transaction(
+                runner.getId(),
+                buyClientOrderId,
+                TransactionType.BUY,
+                SYMBOL,
+                quantity,
+                buyPrice,
+                buyCost,
+                new BigDecimal("0.90"),
+                reason + " setup buy",
+                null
+        );
+        strategyRunnerRepository.saveTransaction(pendingBuy);
+        assertTrue(globalBalanceRepository.reserveAtomic(portfolioId, buyCost),
+                "Seeded BUY must reserve capital like ProcessTradeSignalUseCase would");
+        assertNoInitialPositionOrMatch(pendingBuy.getId());
+
+        MockExchangeAdapter mockExchangeAdapter = getMockExchangeAdapter();
+        mockExchangeAdapter.registerOrderScenarioOverride(buyClientOrderId, new MockOrderScenarioOverride(
+                List.of(
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.FILLED,
+                                quantity,
+                                buyPrice,
+                                BigDecimal.ZERO,
+                                null,
+                                20L,
+                                0
+                        )
+                ),
+                MockOrderScenarioOverride.EventOrdering.AS_IS
+        ));
+
+        orderDispatchPort.dispatch(new OrderDispatchCommand(
+                buyClientOrderId,
+                runner.getId(),
+                SYMBOL,
+                MOCK_EXCHANGE,
+                TransactionType.BUY,
+                quantity,
+                buyPrice
+        ));
+
+        BuyStateSnapshot buyState = awaitStableFilledState(pendingBuy.getId(), WAIT_TIMEOUT, quantity);
+        assertEquals(0, buyState.positionQuantity().compareTo(quantity));
+
+        PositionRow openedPosition = awaitOpenPositionByOpenedByTransactionId(pendingBuy.getId(), WAIT_TIMEOUT);
+        String sellClientOrderId = ClientOrderId.generate(runner.getShortCode(), TransactionType.SELL);
+        Transaction pendingSell = new Transaction(
+                runner.getId(),
+                sellClientOrderId,
+                TransactionType.SELL,
+                SYMBOL,
+                quantity,
+                sellPrice,
+                quantity.multiply(sellPrice),
+                new BigDecimal("0.90"),
+                reason,
+                openedPosition.id()
+        );
+        strategyRunnerRepository.saveTransaction(pendingSell);
+        assertEquals(0, countMatchesByTransactionId(pendingSell.getId()));
+        assertTrue(strategyRunnerRepository.tryLockPositionForSell(openedPosition.id(), pendingSell.getId(), quantity),
+                "Seeded SELL must lock the target position like ProcessTradeSignalUseCase would");
+
+        return new SellSetup(pendingBuy, pendingSell, openedPosition);
     }
 
     private Transaction awaitTransactionStatus(UUID transactionId,
@@ -940,6 +1174,11 @@ class MockDeterministicOrderOverrideIntegrationTest {
     private record MatchAggregateRow(int matchCount,
                                      BigDecimal matchedQuantity,
                                      BigDecimal pnlRealized) {
+    }
+
+    private record SellSetup(Transaction buyTransaction,
+                             Transaction sellTransaction,
+                             PositionRow position) {
     }
 
     private record BuyStateSnapshot(TransactionStatus status,


### PR DESCRIPTION
## Resumo
- adiciona cenário BUY com FILLED chegando antes de PARTIAL atrasado
- adiciona cenário SELL com FILLED chegando antes de PARTIAL atrasado
- valida convergência sem drift de quantidade, transaction_matches, PnL e global_balance
- atualiza GO_LIVE e TESTING_ROADMAP para refletir PR 4 da Fase 2

## Validacao
- powershell -ExecutionPolicy Bypass -File scripts/gradle-run.ps1 --no-daemon --console=plain :spring-application:compileTestJava
- powershell -ExecutionPolicy Bypass -File scripts/gradle-run.ps1 --no-daemon --console=plain :spring-application:test --tests com.marmitt.application.spring.bootstrap.MockDeterministicOrderOverrideIntegrationTest