### PR TITLE
test(phase2): validar redelivery apos falha transitoria

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -112,6 +112,6 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Revisar/mergear o PR 5 da Fase 2 com a refatoracao da suite deterministica do mock.
-2. Avancar para retry/falha transitoria apos estabilizar a organizacao dos testes de BUY, SELL e terminais.
+1. Revisar/mergear o PR 6 da Fase 2 com redelivery idempotente apos falha transitoria simulada.
+2. Avancar para os proximos cenarios de falha/retry apos validar que `SELL FILLED` redelivered nao duplica efeito financeiro.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -472,4 +472,5 @@ Fora de escopo da Fase 4:
 2. PR 2 (concluido): retry idempotente do mesmo `SELL` lock sem permitir tomada por outra transacao.
 3. PR 3 (concluido): callbacks duplicados de `SELL FILLED` em janela curta sem dupla aplicacao economica.
 4. PR 4 (concluido): reorder controlado com `FILLED` antes de `PARTIAL` para BUY e SELL.
-5. PR 5 (atual): refatorar a suite deterministica do mock por responsabilidade antes dos cenarios de retry/falha transitoria.
+5. PR 5 (concluido): refatorar a suite deterministica do mock por responsabilidade antes dos cenarios de retry/falha transitoria.
+6. PR 6 (atual): redelivery idempotente apos falha transitoria simulada no processamento de `SELL FILLED`.

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockBuyOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockBuyOrderOverrideIntegrationTest.java
@@ -53,7 +53,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                                 new BigDecimal("65010.00000000"),
                                 BigDecimal.ZERO,
                                 null,
-                                30L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 1
                         ),
                         new MockOrderScenarioOverride.PlannedEvent(
@@ -62,7 +62,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                                 new BigDecimal("65020.00000000"),
                                 BigDecimal.ZERO,
                                 null,
-                                30L,
+                                INITIAL_CALLBACK_DELAY_MS + NEAR_SIMULTANEOUS_CALLBACK_GAP_MS,
                                 0
                         )
                 ),
@@ -122,7 +122,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                                 new BigDecimal("65110.00000000"),
                                 BigDecimal.ZERO,
                                 null,
-                                0L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 0
                         ),
                         new MockOrderScenarioOverride.PlannedEvent(
@@ -131,7 +131,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                                 new BigDecimal("65120.00000000"),
                                 BigDecimal.ZERO,
                                 null,
-                                100L,
+                                INITIAL_CALLBACK_DELAY_MS + NEAR_SIMULTANEOUS_CALLBACK_GAP_MS,
                                 0
                         )
                 ),
@@ -198,7 +198,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                                 new BigDecimal("65210.00000000"),
                                 BigDecimal.ZERO,
                                 null,
-                                20L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 2
                         )
                 ),
@@ -256,7 +256,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                                 new BigDecimal("65505.00000000"),
                                 BigDecimal.ZERO,
                                 null,
-                                20L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 0
                         ),
                         new MockOrderScenarioOverride.PlannedEvent(
@@ -265,7 +265,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                                 new BigDecimal("65510.00000000"),
                                 BigDecimal.ZERO,
                                 null,
-                                20L,
+                                INITIAL_CALLBACK_DELAY_MS + NEAR_SIMULTANEOUS_CALLBACK_GAP_MS,
                                 0
                         )
                 ),

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockBuyOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockBuyOrderOverrideIntegrationTest.java
@@ -4,7 +4,6 @@ import com.marmitt.application.spring.config.exchange.MockExchangeAdapter;
 import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
-import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.enums.TransactionType;
@@ -70,15 +69,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                 MockOrderScenarioOverride.EventOrdering.AS_IS
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                clientOrderId,
-                runnerId,
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.BUY,
-                quantity,
-                price
-        ));
+        submitOrderToMock(clientOrderId, TransactionType.BUY, quantity, price);
 
         Transaction filled = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.FILLED, WAIT_TIMEOUT);
         assertEquals(0, filled.getEffectiveExecutedQuantity().compareTo(quantity));
@@ -147,15 +138,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                 MockOrderScenarioOverride.EventOrdering.AS_IS
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                clientOrderId,
-                runnerId,
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.BUY,
-                quantity,
-                price
-        ));
+        submitOrderToMock(clientOrderId, TransactionType.BUY, quantity, price);
 
         Transaction filled = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.FILLED, WAIT_TIMEOUT);
         assertEquals(0, filled.getEffectiveExecutedQuantity().compareTo(quantity));
@@ -222,15 +205,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                 MockOrderScenarioOverride.EventOrdering.AS_IS
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                clientOrderId,
-                runnerId,
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.BUY,
-                quantity,
-                price
-        ));
+        submitOrderToMock(clientOrderId, TransactionType.BUY, quantity, price);
 
         BuyStateSnapshot stable = awaitStableFilledState(
                 pendingBuy.getId(),
@@ -297,15 +272,7 @@ class MockBuyOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTe
                 MockOrderScenarioOverride.EventOrdering.REVERSE
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                clientOrderId,
-                runnerId,
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.BUY,
-                quantity,
-                price
-        ));
+        submitOrderToMock(clientOrderId, TransactionType.BUY, quantity, price);
 
         BuyStateSnapshot stable = awaitStableFilledState(pendingBuy.getId(), WAIT_TIMEOUT, quantity);
         OrderDataDto latePartial = awaitMockOrderStatus(

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockOrderOverrideIntegrationTestSupport.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockOrderOverrideIntegrationTestSupport.java
@@ -9,13 +9,14 @@ import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
 import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
-import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
+import com.marmitt.core.enums.OrderSide;
+import com.marmitt.core.enums.OrderType;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.enums.TransactionType;
 import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
 import com.marmitt.core.ports.inbound.runner.CreateRunnerPort;
-import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.GlobalBalanceRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
@@ -104,9 +105,6 @@ abstract class MockOrderOverrideIntegrationTestSupport {
     protected ExchangeAdapterRepositoryPort exchangeAdapterRepository;
 
     @Autowired
-    protected OrderDispatchPort orderDispatchPort;
-
-    @Autowired
     protected JdbcTemplate jdbcTemplate;
 
     @BeforeEach
@@ -154,6 +152,22 @@ abstract class MockOrderOverrideIntegrationTestSupport {
         strategyRunnerRepository.save(runner);
 
         return runner;
+    }
+
+    protected void submitOrderToMock(String clientOrderId,
+                                     TransactionType type,
+                                     BigDecimal quantity,
+                                     BigDecimal price) {
+        OrderSide side = type == TransactionType.BUY ? OrderSide.BUY : OrderSide.SELL;
+        getMockExchangeAdapter().submitOrder(new SendOrderRequest(
+                MOCK_EXCHANGE,
+                SYMBOL,
+                quantity,
+                price,
+                OrderType.LIMIT,
+                side,
+                clientOrderId
+        ));
     }
 
     protected OrderDataDto awaitMockOrderStatus(String clientOrderId,
@@ -212,15 +226,7 @@ abstract class MockOrderOverrideIntegrationTestSupport {
                 MockOrderScenarioOverride.EventOrdering.AS_IS
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                buyClientOrderId,
-                runner.getId(),
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.BUY,
-                quantity,
-                buyPrice
-        ));
+        submitOrderToMock(buyClientOrderId, TransactionType.BUY, quantity, buyPrice);
 
         BuyStateSnapshot buyState = awaitStableFilledState(pendingBuy.getId(), WAIT_TIMEOUT, quantity);
         assertEquals(0, buyState.positionQuantity().compareTo(quantity));

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockOrderOverrideIntegrationTestSupport.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockOrderOverrideIntegrationTestSupport.java
@@ -62,6 +62,8 @@ abstract class MockOrderOverrideIntegrationTestSupport {
     protected static final Duration WAIT_TIMEOUT = Duration.ofSeconds(10);
     protected static final long DEFAULT_POLL_INTERVAL_MS = 80L;
     protected static final long FILLED_STABILITY_POLL_INTERVAL_MS = 50L;
+    protected static final long INITIAL_CALLBACK_DELAY_MS = 120L;
+    protected static final long NEAR_SIMULTANEOUS_CALLBACK_GAP_MS = 20L;
     protected static final String SCENARIO_DUPLICATE_PARTIAL = "phase1b deterministic override";
     protected static final String SCENARIO_PARTIAL_FILLED_CONVERGENCE = "phase1b partial+filled convergence";
     protected static final String SCENARIO_DUPLICATE_FILLED = "phase1b duplicate filled idempotency";
@@ -219,7 +221,7 @@ abstract class MockOrderOverrideIntegrationTestSupport {
                                 buyPrice,
                                 BigDecimal.ZERO,
                                 null,
-                                20L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 0
                         )
                 ),

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockSellOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockSellOrderOverrideIntegrationTest.java
@@ -4,7 +4,6 @@ import com.marmitt.application.spring.config.exchange.MockExchangeAdapter;
 import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
-import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.enums.TransactionType;
@@ -66,15 +65,7 @@ class MockSellOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationT
                 MockOrderScenarioOverride.EventOrdering.AS_IS
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                buyClientOrderId,
-                runnerId,
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.BUY,
-                quantity,
-                buyPrice
-        ));
+        submitOrderToMock(buyClientOrderId, TransactionType.BUY, quantity, buyPrice);
 
         BuyStateSnapshot buyState = awaitStableFilledState(pendingBuy.getId(), WAIT_TIMEOUT, quantity);
         assertEquals(0, buyState.positionQuantity().compareTo(quantity));
@@ -113,15 +104,7 @@ class MockSellOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationT
                 MockOrderScenarioOverride.EventOrdering.AS_IS
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                sellClientOrderId,
-                runnerId,
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.SELL,
-                quantity,
-                sellPrice
-        ));
+        submitOrderToMock(sellClientOrderId, TransactionType.SELL, quantity, sellPrice);
 
         SellStateSnapshot stable = awaitStableSellState(
                 portfolioId,
@@ -199,15 +182,7 @@ class MockSellOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationT
                 )
         );
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                sellSetup.sellTransaction().getClientOrderId(),
-                runner.getId(),
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.SELL,
-                quantity,
-                sellPrice
-        ));
+        submitOrderToMock(sellSetup.sellTransaction().getClientOrderId(), TransactionType.SELL, quantity, sellPrice);
 
         SellStateSnapshot stable = awaitStableSellState(
                 portfolioId,

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockSellOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockSellOrderOverrideIntegrationTest.java
@@ -58,7 +58,7 @@ class MockSellOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationT
                                 buyPrice,
                                 BigDecimal.ZERO,
                                 null,
-                                20L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 0
                         )
                 ),
@@ -97,7 +97,7 @@ class MockSellOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationT
                                 sellPrice,
                                 BigDecimal.ZERO,
                                 null,
-                                20L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 2
                         )
                 ),
@@ -165,7 +165,7 @@ class MockSellOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationT
                                         new BigDecimal("66090.00000000"),
                                         BigDecimal.ZERO,
                                         null,
-                                        20L,
+                                        INITIAL_CALLBACK_DELAY_MS,
                                         0
                                 ),
                                 new MockOrderScenarioOverride.PlannedEvent(
@@ -174,7 +174,7 @@ class MockSellOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationT
                                         sellPrice,
                                         BigDecimal.ZERO,
                                         null,
-                                        20L,
+                                        INITIAL_CALLBACK_DELAY_MS + NEAR_SIMULTANEOUS_CALLBACK_GAP_MS,
                                         0
                                 )
                         ),

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTerminalOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTerminalOrderOverrideIntegrationTest.java
@@ -54,7 +54,7 @@ class MockTerminalOrderOverrideIntegrationTest extends MockOrderOverrideIntegrat
                                 price,
                                 BigDecimal.ZERO,
                                 "MOCK_REJECT_TEST",
-                                20L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 0
                         )
                 ),
@@ -106,7 +106,7 @@ class MockTerminalOrderOverrideIntegrationTest extends MockOrderOverrideIntegrat
                                 price,
                                 BigDecimal.ZERO,
                                 null,
-                                20L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 0
                         )
                 ),

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTerminalOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTerminalOrderOverrideIntegrationTest.java
@@ -4,7 +4,6 @@ import com.marmitt.application.spring.config.exchange.MockExchangeAdapter;
 import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
-import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.enums.TransactionType;
@@ -62,15 +61,7 @@ class MockTerminalOrderOverrideIntegrationTest extends MockOrderOverrideIntegrat
                 MockOrderScenarioOverride.EventOrdering.AS_IS
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                clientOrderId,
-                runnerId,
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.BUY,
-                quantity,
-                price
-        ));
+        submitOrderToMock(clientOrderId, TransactionType.BUY, quantity, price);
 
         Transaction rejected = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.REJECTED, WAIT_TIMEOUT);
         assertEquals("MOCK_REJECT_TEST", rejected.getRejectReason());
@@ -122,15 +113,7 @@ class MockTerminalOrderOverrideIntegrationTest extends MockOrderOverrideIntegrat
                 MockOrderScenarioOverride.EventOrdering.AS_IS
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                clientOrderId,
-                runnerId,
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.BUY,
-                quantity,
-                price
-        ));
+        submitOrderToMock(clientOrderId, TransactionType.BUY, quantity, price);
 
         Transaction expired = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.EXPIRED, WAIT_TIMEOUT);
         assertEquals(0, expired.getEffectiveExecutedQuantity().compareTo(BigDecimal.ZERO));

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTransientOrderFailureIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTransientOrderFailureIntegrationTest.java
@@ -36,7 +36,7 @@ class MockTransientOrderFailureIntegrationTest extends MockOrderOverrideIntegrat
     private PlannedOrderConciliationFailurePlan failurePlan;
 
     @Test
-    void duplicateSellFilledAfterTransientFailureShouldApplyEconomicEffectsOnce() {
+    void exchangeRedeliveredSellFilledAfterTransientFailureShouldApplyEconomicEffectsOnce() {
         UUID portfolioId = createPortfolio();
         StrategyRunner runner = createAndActivateRunner(portfolioId);
 
@@ -67,6 +67,9 @@ class MockTransientOrderFailureIntegrationTest extends MockOrderOverrideIntegrat
                                 BigDecimal.ZERO,
                                 null,
                                 20L,
+                                // The order callback path has no internal retry.
+                                // This duplicate intentionally simulates exchange/mock redelivery
+                                // after the first local processing failure.
                                 1
                         )
                 ),

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTransientOrderFailureIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTransientOrderFailureIntegrationTest.java
@@ -65,7 +65,7 @@ class MockTransientOrderFailureIntegrationTest extends MockOrderOverrideIntegrat
                                 sellPrice,
                                 BigDecimal.ZERO,
                                 null,
-                                20L,
+                                INITIAL_CALLBACK_DELAY_MS,
                                 // The order callback path has no internal retry.
                                 // This duplicate intentionally simulates exchange/mock redelivery
                                 // after the first local processing failure.

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTransientOrderFailureIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTransientOrderFailureIntegrationTest.java
@@ -5,7 +5,6 @@ import com.marmitt.core.application.usecase.runner.OrderConciliationUseCase;
 import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdateExecutor;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
-import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.enums.TransactionType;
@@ -76,15 +75,7 @@ class MockTransientOrderFailureIntegrationTest extends MockOrderOverrideIntegrat
                 MockOrderScenarioOverride.EventOrdering.AS_IS
         ));
 
-        orderDispatchPort.dispatch(new OrderDispatchCommand(
-                sellClientOrderId,
-                runner.getId(),
-                SYMBOL,
-                MOCK_EXCHANGE,
-                TransactionType.SELL,
-                quantity,
-                sellPrice
-        ));
+        submitOrderToMock(sellClientOrderId, TransactionType.SELL, quantity, sellPrice);
 
         SellStateSnapshot stable = awaitStableSellState(
                 portfolioId,

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTransientOrderFailureIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTransientOrderFailureIntegrationTest.java
@@ -1,0 +1,204 @@
+package com.marmitt.application.spring.bootstrap;
+
+import com.marmitt.application.spring.config.exchange.MockExchangeAdapter;
+import com.marmitt.core.application.usecase.runner.OrderConciliationUseCase;
+import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdateExecutor;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.runner.OrderDispatchCommand;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.mock.config.MockOrderScenarioOverride;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ContextConfiguration(classes = MockTransientOrderFailureIntegrationTest.TransientFailureTestConfig.class)
+class MockTransientOrderFailureIntegrationTest extends MockOrderOverrideIntegrationTestSupport {
+
+    private static final String SCENARIO_TRANSIENT_SELL_FILLED_REDELIVERY =
+            "phase2 transient sell filled redelivery";
+
+    @Autowired
+    private PlannedOrderConciliationFailurePlan failurePlan;
+
+    @Test
+    void duplicateSellFilledAfterTransientFailureShouldApplyEconomicEffectsOnce() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+
+        BigDecimal quantity = new BigDecimal("0.00200000");
+        BigDecimal buyPrice = new BigDecimal("65000.00000000");
+        BigDecimal sellPrice = new BigDecimal("66200.00000000");
+        BigDecimal expectedPnl = quantity.multiply(sellPrice.subtract(buyPrice));
+
+        SellSetup sellSetup = createFilledBuyAndLockedSell(
+                portfolioId,
+                runner,
+                quantity,
+                buyPrice,
+                sellPrice,
+                SCENARIO_TRANSIENT_SELL_FILLED_REDELIVERY
+        );
+
+        String sellClientOrderId = sellSetup.sellTransaction().getClientOrderId();
+        failurePlan.failOnce(sellClientOrderId, OrderDataDto.OrderStatus.FILLED);
+
+        MockExchangeAdapter mockExchangeAdapter = getMockExchangeAdapter();
+        mockExchangeAdapter.registerOrderScenarioOverride(sellClientOrderId, new MockOrderScenarioOverride(
+                List.of(
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                OrderDataDto.OrderStatus.FILLED,
+                                quantity,
+                                sellPrice,
+                                BigDecimal.ZERO,
+                                null,
+                                20L,
+                                1
+                        )
+                ),
+                MockOrderScenarioOverride.EventOrdering.AS_IS
+        ));
+
+        orderDispatchPort.dispatch(new OrderDispatchCommand(
+                sellClientOrderId,
+                runner.getId(),
+                SYMBOL,
+                MOCK_EXCHANGE,
+                TransactionType.SELL,
+                quantity,
+                sellPrice
+        ));
+
+        SellStateSnapshot stable = awaitStableSellState(
+                portfolioId,
+                sellSetup.sellTransaction().getId(),
+                sellSetup.position().id(),
+                WAIT_TIMEOUT,
+                quantity,
+                expectedPnl
+        );
+
+        assertEquals(1, failurePlan.failureCount(sellClientOrderId, OrderDataDto.OrderStatus.FILLED),
+                "The test must prove the first SELL FILLED delivery failed before redelivery");
+        assertEquals(TransactionStatus.FILLED, stable.status());
+        assertEquals(0, stable.executedQuantity().compareTo(quantity));
+        assertEquals(1, stable.matchCount(),
+                "Redelivered SELL FILLED must persist exactly one transaction_match");
+        assertEquals(0, stable.matchedQuantity().compareTo(quantity));
+        assertEquals(0, stable.pnlRealized().compareTo(expectedPnl));
+        assertEquals("CLOSED", stable.positionStatus());
+        assertEquals(0, stable.positionQuantity().compareTo(BigDecimal.ZERO));
+        assertEquals(0, stable.realizedBalance().compareTo(expectedPnl));
+        assertEquals(0, stable.availableBalance().compareTo(INITIAL_CAPITAL.add(expectedPnl)));
+        assertEquals(0, stable.reservedBalance().compareTo(BigDecimal.ZERO));
+        assertEquals(0, countDeadLetterEntries(),
+                "A successful redelivery must not create dead-letter entries");
+    }
+
+    private int countDeadLetterEntries() {
+        Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM dead_letter_entries", Integer.class);
+        return count == null ? 0 : count;
+    }
+
+    static class TransientFailureTestConfig {
+
+        @Bean
+        PlannedOrderConciliationFailurePlan plannedOrderConciliationFailurePlan() {
+            return new PlannedOrderConciliationFailurePlan();
+        }
+
+        @Bean
+        @Primary
+        OrderConciliationUseCase failingOrderConciliationUseCase(
+                ConciliationOrderUpdateExecutor delegate,
+                PlannedOrderConciliationFailurePlan failurePlan
+        ) {
+            return new OrderConciliationUseCase(
+                    new FailingOnceConciliationOrderUpdateExecutor(delegate, failurePlan));
+        }
+    }
+
+    static class FailingOnceConciliationOrderUpdateExecutor implements ConciliationOrderUpdateExecutor {
+
+        private final ConciliationOrderUpdateExecutor delegate;
+        private final PlannedOrderConciliationFailurePlan failurePlan;
+
+        FailingOnceConciliationOrderUpdateExecutor(ConciliationOrderUpdateExecutor delegate,
+                                                  PlannedOrderConciliationFailurePlan failurePlan) {
+            this.delegate = delegate;
+            this.failurePlan = failurePlan;
+        }
+
+        @Override
+        public void execute(OrderDataDto orderData) {
+            if (failurePlan.shouldFail(orderData)) {
+                throw new PlannedTransientOrderConciliationException(
+                        "planned transient order conciliation failure for clientOrderId="
+                                + orderData.clientOrderId() + " status=" + orderData.status());
+            }
+            delegate.execute(orderData);
+        }
+
+        @Override
+        public void submitTransaction(Transaction transaction) {
+            delegate.submitTransaction(transaction);
+        }
+
+        @Override
+        public void processFill(Transaction transaction, OrderDataDto orderData, boolean isFinal) {
+            delegate.processFill(transaction, orderData, isFinal);
+        }
+
+        @Override
+        public void releaseMargin(Transaction transaction) {
+            delegate.releaseMargin(transaction);
+        }
+    }
+
+    static class PlannedOrderConciliationFailurePlan {
+
+        private final Set<FailureKey> remainingFailures = ConcurrentHashMap.newKeySet();
+        private final ConcurrentHashMap<FailureKey, AtomicInteger> failures = new ConcurrentHashMap<>();
+
+        void failOnce(String clientOrderId, OrderDataDto.OrderStatus status) {
+            remainingFailures.add(new FailureKey(clientOrderId, status));
+        }
+
+        boolean shouldFail(OrderDataDto orderData) {
+            FailureKey key = new FailureKey(orderData.clientOrderId(), orderData.status());
+            if (!remainingFailures.remove(key)) {
+                return false;
+            }
+            failures.computeIfAbsent(key, ignored -> new AtomicInteger()).incrementAndGet();
+            return true;
+        }
+
+        int failureCount(String clientOrderId, OrderDataDto.OrderStatus status) {
+            AtomicInteger count = failures.get(new FailureKey(clientOrderId, status));
+            return count == null ? 0 : count.get();
+        }
+    }
+
+    static class PlannedTransientOrderConciliationException extends RuntimeException {
+        PlannedTransientOrderConciliationException(String message) {
+            super(message);
+        }
+    }
+
+    private record FailureKey(String clientOrderId, OrderDataDto.OrderStatus status) {
+    }
+}


### PR DESCRIPTION
## Resumo
- adiciona teste de redelivery idempotente para SELL FILLED apos falha transitoria simulada
- usa decorator test-only do OrderConciliationUseCase, sem spy e sem alteracao de producao
- valida que a primeira entrega falha, a segunda entrega processa, e efeitos economicos ocorrem uma unica vez
- atualiza GO_LIVE e TESTING_ROADMAP para refletir PR 6 da Fase 2

## Validacao
- powershell -ExecutionPolicy Bypass -File scripts/gradle-run.ps1 --no-daemon --console=plain :spring-application:compileTestJava
- powershell -ExecutionPolicy Bypass -File scripts/gradle-run.ps1 --no-daemon --console=plain :spring-application:test --tests com.marmitt.application.spring.bootstrap.MockTransientOrderFailureIntegrationTest
- powershell -ExecutionPolicy Bypass -File scripts/gradle-run.ps1 --no-daemon --console=plain :spring-application:test --tests com.marmitt.application.spring.bootstrap.MockBuyOrderOverrideIntegrationTest --tests com.marmitt.application.spring.bootstrap.MockSellOrderOverrideIntegrationTest --tests com.marmitt.application.spring.bootstrap.MockTerminalOrderOverrideIntegrationTest --tests com.marmitt.application.spring.bootstrap.MockTransientOrderFailureIntegrationTest