### PR TITLE
test(phase2): cover delayed canceled after filled

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -79,7 +79,7 @@ Consolidar os principais critérios para sair do ambiente de simulação (MOCK) 
 - Regra prática: toda evolução desse checklist deve manter rastreabilidade com os conceitos e invariantes já definidos no Blueprint/IG.
 
 
-## Status de Aderencia (2026-04-19)
+## Status de Aderencia (2026-04-24)
 
 - Testing Roadmap Fase 0: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 1A: CONCLUIDA no branch `develop`.
@@ -112,6 +112,6 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Revisar/mergear o PR 6 da Fase 2 com redelivery idempotente apos falha transitoria simulada.
-2. Avancar para os proximos cenarios de falha/retry apos validar que `SELL FILLED` redelivered nao duplica efeito financeiro.
+1. Concluir o PR 7 da Fase 2 com cenarios de evento terminal atrasado (`FILLED -> CANCELED`) sem regressao de estado.
+2. Avancar para os proximos cenarios de falha/retry apos validar monotonicidade de estados terminais em BUY e SELL.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -419,7 +419,7 @@ Fora de escopo da Fase 4:
 - **IG:** cobre os fluxos e decisões operacionais já mapeadas no projeto.
 - Este roadmap deve evoluir junto com mudanças de domínio e novos modos de execução.
 
-## Status de Execucao (2026-04-19)
+## Status de Execucao (2026-04-24)
 
 - Fase 0: CONCLUIDA.
 - Fase 1A: CONCLUIDA.
@@ -473,4 +473,5 @@ Fora de escopo da Fase 4:
 3. PR 3 (concluido): callbacks duplicados de `SELL FILLED` em janela curta sem dupla aplicacao economica.
 4. PR 4 (concluido): reorder controlado com `FILLED` antes de `PARTIAL` para BUY e SELL.
 5. PR 5 (concluido): refatorar a suite deterministica do mock por responsabilidade antes dos cenarios de retry/falha transitoria.
-6. PR 6 (atual): redelivery idempotente apos falha transitoria simulada no processamento de `SELL FILLED`.
+6. PR 6 (concluido): redelivery idempotente apos falha transitoria simulada no processamento de `SELL FILLED`.
+7. PR 7 (atual): eventos terminais fora de ordem (`FILLED -> CANCELED` atrasado) sem regressao de estado ou dupla aplicacao economica.

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockOrderOverrideIntegrationTestSupport.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockOrderOverrideIntegrationTestSupport.java
@@ -72,6 +72,10 @@ abstract class MockOrderOverrideIntegrationTestSupport {
             "phase2 reordered buy filled before partial";
     protected static final String SCENARIO_REORDERED_SELL_FILLED_BEFORE_PARTIAL =
             "phase2 reordered sell filled before partial";
+    protected static final String SCENARIO_LATE_CANCELED_AFTER_BUY_FILLED =
+            "phase2 late canceled after buy filled";
+    protected static final String SCENARIO_LATE_CANCELED_AFTER_SELL_FILLED =
+            "phase2 late canceled after sell filled";
     protected static final String SCENARIO_REJECTED_FINANCIAL = "phase1b rejected financial";
     protected static final String SCENARIO_EXPIRED_FINANCIAL = "phase1b expired financial";
 

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTerminalOrderOverrideIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTerminalOrderOverrideIntegrationTest.java
@@ -20,6 +20,82 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MockTerminalOrderOverrideIntegrationTest extends MockOrderOverrideIntegrationTestSupport {
 
     @Test
+    void lateCanceledAfterBuyFilledShouldNotRegressFilledState() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        UUID runnerId = runner.getId();
+
+        BigDecimal quantity = new BigDecimal("0.00200000");
+        BigDecimal price = new BigDecimal("65600.00000000");
+        String clientOrderId = ClientOrderId.generate(runner.getShortCode(), TransactionType.BUY);
+
+        Transaction pendingBuy = new Transaction(
+                runnerId,
+                clientOrderId,
+                TransactionType.BUY,
+                SYMBOL,
+                quantity,
+                price,
+                quantity.multiply(price),
+                new BigDecimal("0.90"),
+                SCENARIO_LATE_CANCELED_AFTER_BUY_FILLED,
+                null
+        );
+        strategyRunnerRepository.saveTransaction(pendingBuy);
+        assertNoInitialPositionOrMatch(pendingBuy.getId());
+
+        MockExchangeAdapter mockExchangeAdapter = getMockExchangeAdapter();
+        mockExchangeAdapter.registerOrderScenarioOverride(clientOrderId, new MockOrderScenarioOverride(
+                List.of(
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.FILLED,
+                                quantity,
+                                price,
+                                BigDecimal.ZERO,
+                                null,
+                                INITIAL_CALLBACK_DELAY_MS,
+                                0
+                        ),
+                        new MockOrderScenarioOverride.PlannedEvent(
+                                com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.CANCELED,
+                                quantity,
+                                price,
+                                BigDecimal.ZERO,
+                                null,
+                                INITIAL_CALLBACK_DELAY_MS + NEAR_SIMULTANEOUS_CALLBACK_GAP_MS,
+                                0
+                        )
+                ),
+                MockOrderScenarioOverride.EventOrdering.AS_IS
+        ));
+
+        submitOrderToMock(clientOrderId, TransactionType.BUY, quantity, price);
+
+        BuyStateSnapshot stable = awaitStableFilledState(pendingBuy.getId(), WAIT_TIMEOUT, quantity);
+        OrderDataDto lateCanceled = awaitMockOrderStatus(
+                clientOrderId,
+                OrderDataDto.OrderStatus.CANCELED,
+                WAIT_TIMEOUT
+        );
+        BuyStateSnapshot afterLateCancel = awaitCondition(
+                WAIT_TIMEOUT,
+                DEFAULT_POLL_INTERVAL_MS,
+                () -> readBuyState(pendingBuy.getId()),
+                snapshot -> isExpectedFilledState(snapshot, quantity),
+                "Timeout waiting BUY state to remain FILLED after delayed CANCELED"
+        );
+
+        assertEquals(OrderDataDto.OrderStatus.CANCELED, lateCanceled.status(),
+                "Mock must emit delayed BUY CANCELED after FILLED to prove terminal reorder coverage");
+        assertEquals(TransactionStatus.FILLED, stable.status());
+        assertEquals(TransactionStatus.FILLED, afterLateCancel.status());
+        assertEquals(0, afterLateCancel.executedQuantity().compareTo(quantity));
+        assertEquals(0, afterLateCancel.positionQuantity().compareTo(quantity));
+        assertEquals(1, afterLateCancel.openRows());
+        assertEquals(0, afterLateCancel.matchCount());
+    }
+
+    @Test
     void rejectedBuyShouldReleaseReservedBalanceWithoutCreatingPosition() {
         UUID portfolioId = createPortfolio();
         StrategyRunner runner = createAndActivateRunner(portfolioId);
@@ -121,5 +197,94 @@ class MockTerminalOrderOverrideIntegrationTest extends MockOrderOverrideIntegrat
         awaitBalanceState(portfolioId, INITIAL_CAPITAL, BigDecimal.ZERO, WAIT_TIMEOUT);
         assertEquals(0, countOpenPositionsByOpenedByTransactionId(pendingBuy.getId()));
         assertEquals(0, countMatchesByTransactionId(pendingBuy.getId()));
+    }
+
+    @Test
+    void lateCanceledAfterSellFilledShouldNotRegressClosedState() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+
+        BigDecimal quantity = new BigDecimal("0.00200000");
+        BigDecimal buyPrice = new BigDecimal("65000.00000000");
+        BigDecimal sellPrice = new BigDecimal("66200.00000000");
+        BigDecimal expectedPnl = quantity.multiply(sellPrice.subtract(buyPrice));
+
+        SellSetup sellSetup = createFilledBuyAndLockedSell(
+                portfolioId,
+                runner,
+                quantity,
+                buyPrice,
+                sellPrice,
+                SCENARIO_LATE_CANCELED_AFTER_SELL_FILLED
+        );
+
+        MockExchangeAdapter mockExchangeAdapter = getMockExchangeAdapter();
+        mockExchangeAdapter.registerOrderScenarioOverride(
+                sellSetup.sellTransaction().getClientOrderId(),
+                new MockOrderScenarioOverride(
+                        List.of(
+                                new MockOrderScenarioOverride.PlannedEvent(
+                                        com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.FILLED,
+                                        quantity,
+                                        sellPrice,
+                                        BigDecimal.ZERO,
+                                        null,
+                                        INITIAL_CALLBACK_DELAY_MS,
+                                        0
+                                ),
+                                new MockOrderScenarioOverride.PlannedEvent(
+                                        com.marmitt.core.dto.websocket.data.OrderDataDto.OrderStatus.CANCELED,
+                                        quantity,
+                                        sellPrice,
+                                        BigDecimal.ZERO,
+                                        null,
+                                        INITIAL_CALLBACK_DELAY_MS + NEAR_SIMULTANEOUS_CALLBACK_GAP_MS,
+                                        0
+                                )
+                        ),
+                        MockOrderScenarioOverride.EventOrdering.AS_IS
+                )
+        );
+
+        submitOrderToMock(
+                sellSetup.sellTransaction().getClientOrderId(),
+                TransactionType.SELL,
+                quantity,
+                sellPrice
+        );
+
+        SellStateSnapshot stable = awaitStableSellState(
+                portfolioId,
+                sellSetup.sellTransaction().getId(),
+                sellSetup.position().id(),
+                WAIT_TIMEOUT,
+                quantity,
+                expectedPnl
+        );
+        OrderDataDto lateCanceled = awaitMockOrderStatus(
+                sellSetup.sellTransaction().getClientOrderId(),
+                OrderDataDto.OrderStatus.CANCELED,
+                WAIT_TIMEOUT
+        );
+        SellStateSnapshot afterLateCancel = awaitCondition(
+                WAIT_TIMEOUT,
+                DEFAULT_POLL_INTERVAL_MS,
+                () -> readSellState(portfolioId, sellSetup.sellTransaction().getId(), sellSetup.position().id()),
+                snapshot -> isExpectedSellFilledState(snapshot, quantity, expectedPnl),
+                "Timeout waiting SELL state to remain FILLED after delayed CANCELED"
+        );
+
+        assertEquals(OrderDataDto.OrderStatus.CANCELED, lateCanceled.status(),
+                "Mock must emit delayed SELL CANCELED after FILLED to prove terminal reorder coverage");
+        assertEquals(TransactionStatus.FILLED, stable.status());
+        assertEquals(TransactionStatus.FILLED, afterLateCancel.status());
+        assertEquals(1, afterLateCancel.matchCount());
+        assertEquals(0, afterLateCancel.matchedQuantity().compareTo(quantity));
+        assertEquals(0, afterLateCancel.pnlRealized().compareTo(expectedPnl));
+        assertEquals("CLOSED", afterLateCancel.positionStatus());
+        assertEquals(0, afterLateCancel.positionQuantity().compareTo(BigDecimal.ZERO));
+        assertEquals(0, afterLateCancel.availableBalance().compareTo(INITIAL_CAPITAL.add(expectedPnl)));
+        assertEquals(0, afterLateCancel.reservedBalance().compareTo(BigDecimal.ZERO));
+        assertEquals(0, afterLateCancel.realizedBalance().compareTo(expectedPnl));
     }
 }


### PR DESCRIPTION
## Summary
- add deterministic terminal reorder scenarios for delayed `CANCELED` after `FILLED`
- verify BUY state stays `FILLED` and SELL state stays closed/financially stable
- update Testing Roadmap and Go Live checklist to mark PR 6 complete and PR 7 in progress

## Tests
- `:spring-application:compileTestJava`
- `:spring-application:test --tests com.marmitt.application.spring.bootstrap.MockTerminalOrderOverrideIntegrationTest`