### PR TITLE
test(phase3): cover zombie ttl and repeated recovery

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -84,7 +84,8 @@ Consolidar os principais critérios para sair do ambiente de simulação (MOCK) 
 - Testing Roadmap Fase 0: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 1A: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 1B: CONCLUIDA no branch `develop`.
-- Testing Roadmap Fase 2: EM ANDAMENTO.
+- Testing Roadmap Fase 2: CONCLUIDA no branch `develop`.
+- Testing Roadmap Fase 3: EM ANDAMENTO.
 
 Evidencias de Fase 0 em testes automatizados:
 - `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
@@ -107,11 +108,11 @@ Evidencias de Fase 1B em testes automatizados:
 ### Impacto no Go-Live
 
 - Item 1 (Testes automatizados minimos): PARCIAL (AVANCADO).
-- Baseline de invariantes, integracao core com MOCK e controles deterministicos do MOCK cobertos (Fases 0, 1A e 1B).
-- Ainda faltam fases de robustez e operacao (Fases 2, 3 e 4) e integracao real com exchange.
+- Baseline de invariantes, integracao core com MOCK, controles deterministicos do MOCK e robustez contra duplicidade/concorrencia cobertos (Fases 0, 1A, 1B e 2).
+- Ainda faltam boot recovery completo, operacao e integracao real com exchange (Fases 3 e 4).
 
 ### Proximo passo recomendado
 
-1. Concluir o PR 8 da Fase 2 com repeticao controlada dos cenarios terminais mais frageis para reduzir risco de flakiness residual.
-2. Encerrar a Fase 2 no roadmap e neste checklist apos validar estabilidade repetida dos cenarios de reorder e terminal monotonicity.
+1. Concluir o PR 1 da Fase 3 com cobertura de zombie `PENDING` dentro do TTL e reexecucao idempotente do recovery para zombies vencidos.
+2. Avancar para os cenarios de limbo `SUBMITTED/PARTIAL` com query de exchange/mock na sequencia da Fase 3.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -424,7 +424,8 @@ Fora de escopo da Fase 4:
 - Fase 0: CONCLUIDA.
 - Fase 1A: CONCLUIDA.
 - Fase 1B: CONCLUIDA.
-- Fase 2: EM ANDAMENTO.
+- Fase 2: CONCLUIDA.
+- Fase 3: EM ANDAMENTO.
 
 ### Evidencias de conclusao da Fase 1B
 
@@ -466,7 +467,7 @@ Fora de escopo da Fase 4:
 - Ao concluir cada fase do roadmap, atualizar o status do Item 1 do Go-Live.
 - Go-live completo depende da conclusao das Fases 2, 3 e 4, e da integracao real de exchange.
 
-### Fase 2 em progresso
+### Fase 2 concluida
 
 1. PR 1 (concluido): `SELL` concorrente tentando lock no mesmo lote/posicao.
 2. PR 2 (concluido): retry idempotente do mesmo `SELL` lock sem permitir tomada por outra transacao.
@@ -475,4 +476,8 @@ Fora de escopo da Fase 4:
 5. PR 5 (concluido): refatorar a suite deterministica do mock por responsabilidade antes dos cenarios de retry/falha transitoria.
 6. PR 6 (concluido): redelivery idempotente apos falha transitoria simulada no processamento de `SELL FILLED`.
 7. PR 7 (concluido): eventos terminais fora de ordem (`FILLED -> CANCELED` atrasado) sem regressao de estado ou dupla aplicacao economica.
-8. PR 8 (atual): repeticao controlada dos cenarios mais frageis para validar monotonicidade terminal e estabilidade sem flakiness.
+8. PR 8 (concluido): repeticao controlada dos cenarios mais frageis para validar monotonicidade terminal e estabilidade sem flakiness.
+
+### Fase 3 em progresso
+
+1. PR 1 (atual): zombies `PENDING` sem `exchangeOrderId` dentro do TTL e reexecucao idempotente do recovery para zombies vencidos.

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
@@ -55,6 +55,7 @@ class RunnerBootRecoveryIntegrationTest {
     private static final String SYMBOL = "BTCUSDT";
     private static final BigDecimal INITIAL_CAPITAL = new BigDecimal("1000.00000000");
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(8);
+    private static final long ZOMBIE_TTL_MS = 300_000L;
 
     @Container
     @SuppressWarnings("resource")
@@ -70,6 +71,7 @@ class RunnerBootRecoveryIntegrationTest {
         registry.add("spring.datasource.password", POSTGRES::getPassword);
         registry.add("spring.flyway.enabled", () -> "true");
         registry.add("runner.boot.orchestrator-enabled", () -> "false");
+        registry.add("runner.boot.phase2.portfolio.reservation-ttl.ttl-ms", () -> ZOMBIE_TTL_MS);
     }
 
     @Autowired
@@ -156,7 +158,7 @@ class RunnerBootRecoveryIntegrationTest {
 
         jdbcTemplate.update(
                 "UPDATE transactions SET requested_at = ? WHERE id = ?",
-                Timestamp.from(Instant.now().minus(Duration.ofMinutes(2))),
+                Timestamp.from(Instant.now().minusMillis(ZOMBIE_TTL_MS / 2)),
                 pendingBuy.getId()
         );
 

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
@@ -139,6 +139,91 @@ class RunnerBootRecoveryIntegrationTest {
     }
 
     @Test
+    void recoveryShouldKeepZombiePendingWithinTtlAndPreserveReservedBalance() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        BigDecimal reservedAmount = new BigDecimal("120.00000000");
+
+        Transaction pendingBuy = newTransaction(
+                runner,
+                TransactionType.BUY,
+                new BigDecimal("0.00200000"),
+                new BigDecimal("60000.00000000"),
+                reservedAmount
+        );
+        strategyRunnerRepository.saveTransaction(pendingBuy);
+        assertTrue(globalBalanceRepository.reserveAtomic(portfolioId, reservedAmount));
+
+        jdbcTemplate.update(
+                "UPDATE transactions SET requested_at = ? WHERE id = ?",
+                Timestamp.from(Instant.now().minus(Duration.ofMinutes(2))),
+                pendingBuy.getId()
+        );
+
+        RunnerBootRecoveryUseCase.RecoverySummary summary = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        Transaction stillPending = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.PENDING, WAIT_TIMEOUT);
+        assertNotNull(stillPending);
+        assertEquals(1, summary.inFlightCount());
+        assertEquals(1, summary.zombiesCount());
+        assertEquals(0, summary.limboCount());
+        assertTrue(summary.notes().stream().anyMatch(note -> note.contains("zombie within TTL")),
+                "Recovery summary should record that the zombie stayed pending within TTL");
+
+        awaitBalance(portfolioId, INITIAL_CAPITAL.subtract(reservedAmount), reservedAmount, WAIT_TIMEOUT);
+
+        StrategyRunner latestRunner = strategyRunnerRepository.findById(runner.getId())
+                .orElseThrow(() -> new IllegalStateException("Runner not found after recovery"));
+        assertEquals(com.marmitt.core.enums.RunnerStatus.ACTIVE, latestRunner.getStatus());
+        assertFalse(latestRunner.isReconciling());
+    }
+
+    @Test
+    void recoveryShouldBeIdempotentWhenExpiringTheSameZombieTwice() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        BigDecimal reservedAmount = new BigDecimal("140.00000000");
+
+        Transaction pendingBuy = newTransaction(
+                runner,
+                TransactionType.BUY,
+                new BigDecimal("0.00280000"),
+                new BigDecimal("50000.00000000"),
+                reservedAmount
+        );
+        strategyRunnerRepository.saveTransaction(pendingBuy);
+        assertTrue(globalBalanceRepository.reserveAtomic(portfolioId, reservedAmount));
+
+        jdbcTemplate.update(
+                "UPDATE transactions SET requested_at = ? WHERE id = ?",
+                Timestamp.from(Instant.now().minus(Duration.ofHours(2))),
+                pendingBuy.getId()
+        );
+
+        RunnerBootRecoveryUseCase.RecoverySummary first = runnerBootRecoveryUseCase.recoverRunner(runner);
+        Transaction expired = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.EXPIRED, WAIT_TIMEOUT);
+        assertNotNull(expired);
+        awaitBalance(portfolioId, INITIAL_CAPITAL, BigDecimal.ZERO, WAIT_TIMEOUT);
+
+        RunnerBootRecoveryUseCase.RecoverySummary second = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        Transaction expiredAgain = awaitTransactionStatus(pendingBuy.getId(), TransactionStatus.EXPIRED, WAIT_TIMEOUT);
+        assertNotNull(expiredAgain);
+        assertEquals(1, first.inFlightCount());
+        assertEquals(1, first.zombiesCount());
+        assertEquals(0, first.limboCount());
+        assertEquals(0, second.inFlightCount());
+        assertEquals(0, second.zombiesCount());
+        assertEquals(0, second.limboCount());
+        awaitBalance(portfolioId, INITIAL_CAPITAL, BigDecimal.ZERO, WAIT_TIMEOUT);
+
+        StrategyRunner latestRunner = strategyRunnerRepository.findById(runner.getId())
+                .orElseThrow(() -> new IllegalStateException("Runner not found after repeated recovery"));
+        assertEquals(com.marmitt.core.enums.RunnerStatus.ACTIVE, latestRunner.getStatus());
+        assertFalse(latestRunner.isReconciling());
+    }
+
+    @Test
     void recoveryShouldExpireSubmittedOrderNotFoundOnExchangeAndReleaseBalance() {
         UUID portfolioId = createPortfolio();
         StrategyRunner runner = createAndActivateRunner(portfolioId);


### PR DESCRIPTION
## Summary
- mark Phase 2 as complete and Phase 3 as in progress in the roadmap/checklist
- add boot recovery coverage for zombie `PENDING` orders that are still within TTL
- add repeated recovery coverage to prove expired zombie recovery is idempotent across reruns

## Tests
- `:spring-application:compileTestJava`
- `:spring-application:test --tests com.marmitt.application.spring.bootstrap.RunnerBootRecoveryIntegrationTest`