### PR TITLE
test(phase3): cover not-found limbo recovery

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -113,6 +113,6 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Concluir o PR 2 da Fase 3 com cobertura de limbo `SUBMITTED/PARTIAL` reconciliado via query positiva da exchange/mock.
-2. Avancar para os cenarios de limbo `SUBMITTED/PARTIAL` nao encontrados na exchange e fallback terminal sintetico.
+1. Concluir o PR 3 da Fase 3 com cobertura de limbo `SUBMITTED/PARTIAL` nao encontrado na exchange e fallback terminal sintetico idempotente.
+2. Avancar para cenarios de query unsupported e retry/backoff transitorio na sequencia da Fase 3.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -481,4 +481,5 @@ Fora de escopo da Fase 4:
 ### Fase 3 em progresso
 
 1. PR 1 (concluido): zombies `PENDING` sem `exchangeOrderId` dentro do TTL e reexecucao idempotente do recovery para zombies vencidos.
-2. PR 2 (atual): limbo `SUBMITTED/PARTIAL` reconciliado via query positiva do MOCK (`SUBMITTED -> FILLED` e `PARTIAL -> FILLED`) sem drift financeiro.
+2. PR 2 (concluido): limbo `SUBMITTED/PARTIAL` reconciliado via query positiva do MOCK (`SUBMITTED -> FILLED` e `PARTIAL -> FILLED`) sem drift financeiro.
+3. PR 3 (atual): limbo nao encontrado na exchange com fallback sintetico (`SUBMITTED -> EXPIRED`, `PARTIAL -> CANCELED`) e reexecucao idempotente do recovery.

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
@@ -259,6 +259,83 @@ class RunnerBootRecoveryIntegrationTest {
         assertEquals(1, summary.limboCount());
 
         awaitBalance(portfolioId, INITIAL_CAPITAL, BigDecimal.ZERO, WAIT_TIMEOUT);
+
+        RunnerBootRecoveryUseCase.RecoverySummary second = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        assertEquals(0, second.inFlightCount());
+        assertEquals(0, second.zombiesCount());
+        assertEquals(0, second.limboCount());
+
+        Transaction expiredAgain = strategyRunnerRepository.findTransactionById(submittedBuy.getId())
+                .orElseThrow(() -> new IllegalStateException("Transaction not found after repeated recovery"));
+        assertEquals(TransactionStatus.EXPIRED, expiredAgain.getStatus());
+
+        awaitBalance(portfolioId, INITIAL_CAPITAL, BigDecimal.ZERO, WAIT_TIMEOUT);
+    }
+
+    @Test
+    void recoveryShouldCancelPartialBuyNotFoundOnExchangeAndReleaseOutstandingReserveOnly() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        BigDecimal totalQuantity = new BigDecimal("1.00000000");
+        BigDecimal totalReserved = new BigDecimal("112.00000000");
+        BigDecimal partialQuantity = new BigDecimal("0.40000000");
+        BigDecimal partialPrice = new BigDecimal("100.00000000");
+        BigDecimal partialExecutedCost = partialQuantity.multiply(partialPrice);
+
+        Transaction partialBuy = newTransaction(
+                runner,
+                TransactionType.BUY,
+                totalQuantity,
+                new BigDecimal("112.00000000"),
+                totalReserved
+        );
+        partialBuy.submit("EX_PARTIAL_MISSING_ON_EXCHANGE");
+        partialBuy.partialFill(partialQuantity, partialPrice);
+        strategyRunnerRepository.saveTransaction(partialBuy);
+        assertTrue(globalBalanceRepository.reserveAtomic(portfolioId, totalReserved));
+
+        Position partialPosition = new Position(runner.getId(), SYMBOL, partialQuantity, partialPrice);
+        partialPosition.associateBuyTransaction(partialBuy.getId());
+        strategyRunnerRepository.savePosition(partialPosition);
+
+        GlobalBalance balanceAfterPartial = globalBalanceRepository.findByPortfolioId(portfolioId)
+                .orElseThrow(() -> new IllegalStateException("GlobalBalance not found"));
+        balanceAfterPartial.confirmExecution(partialExecutedCost, BigDecimal.ZERO, BigDecimal.ZERO);
+        globalBalanceRepository.save(balanceAfterPartial);
+
+        RunnerBootRecoveryUseCase.RecoverySummary summary = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        Transaction canceled = awaitTransactionStatus(partialBuy.getId(), TransactionStatus.CANCELED, WAIT_TIMEOUT);
+        assertNotNull(canceled);
+        assertEquals(1, summary.inFlightCount());
+        assertEquals(0, summary.zombiesCount());
+        assertEquals(1, summary.limboCount());
+
+        Position position = strategyRunnerRepository.findPositionByOpenedByTransactionId(partialBuy.getId())
+                .orElseThrow(() -> new IllegalStateException("Position not found for openedByTransactionId="
+                        + partialBuy.getId()));
+        assertEquals(0, position.getQuantity().compareTo(partialQuantity));
+        assertEquals(0, position.getAveragePrice().compareTo(partialPrice));
+
+        awaitBalance(portfolioId, INITIAL_CAPITAL, BigDecimal.ZERO, WAIT_TIMEOUT);
+
+        RunnerBootRecoveryUseCase.RecoverySummary second = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        assertEquals(0, second.inFlightCount());
+        assertEquals(0, second.zombiesCount());
+        assertEquals(0, second.limboCount());
+
+        Transaction canceledAgain = strategyRunnerRepository.findTransactionById(partialBuy.getId())
+                .orElseThrow(() -> new IllegalStateException("Transaction not found after repeated recovery"));
+        assertEquals(TransactionStatus.CANCELED, canceledAgain.getStatus());
+
+        Position positionAgain = strategyRunnerRepository.findPositionByOpenedByTransactionId(partialBuy.getId())
+                .orElseThrow(() -> new IllegalStateException("Position not found after repeated recovery"));
+        assertEquals(0, positionAgain.getQuantity().compareTo(partialQuantity));
+        assertEquals(0, positionAgain.getAveragePrice().compareTo(partialPrice));
+
+        awaitBalance(portfolioId, INITIAL_CAPITAL, BigDecimal.ZERO, WAIT_TIMEOUT);
     }
 
     @Test


### PR DESCRIPTION
## Resumo
- cobre fallback de boot recovery quando a ordem em limbo nao e encontrada na exchange
- valida os dois caminhos sinteticos esperados no dominio atual
- atualiza o roadmap e o checklist de go-live com o andamento da Fase 3

## Cenarios cobertos
- `SUBMITTED -> EXPIRED` quando `queryOrderByClientOrderId(...)` retorna vazio
- `PARTIAL -> CANCELED` quando `queryOrderByClientOrderId(...)` retorna vazio
- reexecucao idempotente do recovery nos dois cenarios acima

## Validacao
- `./gradlew -q :spring-application:test --tests com.marmitt.application.spring.bootstrap.RunnerBootRecoveryIntegrationTest`
