### PR TITLE
test(phase3): cover query failure recovery

### DIFF
--- a/adapter-mock/src/main/java/com/marmitt/mock/runtime/MockExchangeRuntime.java
+++ b/adapter-mock/src/main/java/com/marmitt/mock/runtime/MockExchangeRuntime.java
@@ -9,6 +9,7 @@ import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.core.dto.websocket.request.StreamSubscriptionRequest;
 import com.marmitt.core.enums.StreamAction;
 import com.marmitt.core.exceptions.ExchangeQueryException;
+import com.marmitt.core.exceptions.ExchangeQueryException.ErrorType;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
 import com.marmitt.mock.balance.MockBalanceStore;
 import com.marmitt.mock.config.MockOrderScenarioOverride;
@@ -46,6 +47,7 @@ public class MockExchangeRuntime {
     private final Map<String, String> orderIdByClientOrderId = new ConcurrentHashMap<>();
     private final Map<String, OrderDataDto> latestEventByOrderId = new ConcurrentHashMap<>();
     private final Map<String, MockOrderScenarioOverride> orderScenarioOverrideByClientOrderId = new ConcurrentHashMap<>();
+    private final Map<String, QueryFailurePlan> queryFailurePlanByClientOrderId = new ConcurrentHashMap<>();
     private Random random;
     private MockBalanceStore balanceStore;
 
@@ -141,6 +143,7 @@ public class MockExchangeRuntime {
 
     public Optional<OrderDataDto> queryOrderByClientOrderId(String symbol, String clientOrderId) {
         ensureLifecycleForQuery();
+        maybeFailQuery(clientOrderId);
         String orderId = orderIdByClientOrderId.get(clientOrderId);
         if (orderId == null) {
             return Optional.empty();
@@ -242,6 +245,32 @@ public class MockExchangeRuntime {
     }
 
     /**
+     * Registers a deterministic fail-N-times plan for REST order queries by clientOrderId.
+     * Used by boot recovery integration tests to validate retry/backoff behavior.
+     */
+    public void registerQueryFailurePlan(String clientOrderId,
+                                         int failuresBeforeSuccess,
+                                         ErrorType errorType,
+                                         String message) {
+        if (clientOrderId == null || clientOrderId.isBlank()) {
+            throw new IllegalArgumentException("clientOrderId cannot be null or blank");
+        }
+        if (failuresBeforeSuccess <= 0) {
+            throw new IllegalArgumentException("failuresBeforeSuccess must be > 0");
+        }
+        queryFailurePlanByClientOrderId.put(
+                clientOrderId,
+                new QueryFailurePlan(failuresBeforeSuccess, errorType, message)
+        );
+        log.info("Mock query failure plan registered - ClientOrderId: {}, failuresBeforeSuccess: {}, errorType: {}",
+                clientOrderId, failuresBeforeSuccess, errorType);
+    }
+
+    public void clearQueryFailurePlans() {
+        queryFailurePlanByClientOrderId.clear();
+    }
+
+    /**
      * Seeds the latest queried order snapshot without publishing websocket callbacks.
      *
      * <p>Used by integration tests that need deterministic REST query responses for
@@ -332,6 +361,7 @@ public class MockExchangeRuntime {
         this.orderIdByClientOrderId.clear();
         this.latestEventByOrderId.clear();
         this.orderScenarioOverrideByClientOrderId.clear();
+        this.queryFailurePlanByClientOrderId.clear();
     }
 
     private void ensureLifecycleForQuery() {
@@ -342,6 +372,28 @@ public class MockExchangeRuntime {
                 "MOCK",
                 ExchangeQueryException.ErrorType.TEMPORARY,
                 "Mock lifecycle is stopped for order query"
+        );
+    }
+
+    private void maybeFailQuery(String clientOrderId) {
+        QueryFailurePlan plan = queryFailurePlanByClientOrderId.get(clientOrderId);
+        if (plan == null) {
+            return;
+        }
+
+        if (plan.remainingFailures() <= 1) {
+            queryFailurePlanByClientOrderId.remove(clientOrderId);
+        } else {
+            queryFailurePlanByClientOrderId.put(
+                    clientOrderId,
+                    new QueryFailurePlan(plan.remainingFailures() - 1, plan.errorType(), plan.message())
+            );
+        }
+
+        throw new ExchangeQueryException(
+                "MOCK",
+                plan.errorType(),
+                plan.message() != null ? plan.message() : "Planned mock query failure"
         );
     }
 
@@ -403,5 +455,10 @@ public class MockExchangeRuntime {
                 reason,
                 java.time.Instant.now()
         );
+    }
+
+    private record QueryFailurePlan(int remainingFailures,
+                                    ErrorType errorType,
+                                    String message) {
     }
 }

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -113,6 +113,6 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Concluir o PR 3 da Fase 3 com cobertura de limbo `SUBMITTED/PARTIAL` nao encontrado na exchange e fallback terminal sintetico idempotente.
-2. Avancar para cenarios de query unsupported e retry/backoff transitorio na sequencia da Fase 3.
+1. Concluir o PR 4 da Fase 3 com cobertura de `query unsupported` e `retry/backoff` transitorio no boot recovery.
+2. Avancar para o cenario de falha transitoria esgotada (retry exhausted) na sequencia da Fase 3.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -482,4 +482,5 @@ Fora de escopo da Fase 4:
 
 1. PR 1 (concluido): zombies `PENDING` sem `exchangeOrderId` dentro do TTL e reexecucao idempotente do recovery para zombies vencidos.
 2. PR 2 (concluido): limbo `SUBMITTED/PARTIAL` reconciliado via query positiva do MOCK (`SUBMITTED -> FILLED` e `PARTIAL -> FILLED`) sem drift financeiro.
-3. PR 3 (atual): limbo nao encontrado na exchange com fallback sintetico (`SUBMITTED -> EXPIRED`, `PARTIAL -> CANCELED`) e reexecucao idempotente do recovery.
+3. PR 3 (concluido): limbo nao encontrado na exchange com fallback sintetico (`SUBMITTED -> EXPIRED`, `PARTIAL -> CANCELED`) e reexecucao idempotente do recovery.
+4. PR 4 (atual): falha de query no boot recovery cobrindo `query unsupported` e `query transient failure + retry/backoff` com recuperacao sem drift.

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockExchangeAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockExchangeAdapter.java
@@ -7,6 +7,7 @@ import com.marmitt.core.dto.websocket.request.SendCancelOrderRequest;
 import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.core.dto.websocket.request.StreamSubscriptionRequest;
 import com.marmitt.core.dto.exchange.boot.ExchangeBootReadiness;
+import com.marmitt.core.exceptions.ExchangeQueryException.ErrorType;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
 import com.marmitt.core.ports.outbound.exchange.adapter.ExchangeUrlBuilderPort;
 import com.marmitt.core.ports.outbound.exchange.adapter.ReceivedMessageProcessorPort;
@@ -184,6 +185,21 @@ public class MockExchangeAdapter implements ExchangeStreamingPort,
      */
     public void seedQueriedOrderSnapshot(OrderDataDto orderData) {
         runtime.seedQueriedOrderSnapshot(orderData);
+    }
+
+    /**
+     * Registers a deterministic fail-N-times plan for query-by-clientOrderId.
+     * Intended for boot recovery retry/backoff integration tests.
+     */
+    public void registerQueryFailurePlan(String clientOrderId,
+                                         int failuresBeforeSuccess,
+                                         ErrorType errorType,
+                                         String message) {
+        runtime.registerQueryFailurePlan(clientOrderId, failuresBeforeSuccess, errorType, message);
+    }
+
+    public void clearQueryFailurePlans() {
+        runtime.clearQueryFailurePlans();
     }
 
     private static void simulateDelayIfNeeded(long delayMs) {

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
@@ -17,6 +17,7 @@ import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.exceptions.ExchangeQueryException;
 import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
 import com.marmitt.core.ports.inbound.runner.CreateRunnerPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
@@ -77,6 +78,11 @@ class RunnerBootRecoveryIntegrationTest {
         registry.add("spring.flyway.enabled", () -> "true");
         registry.add("runner.boot.orchestrator-enabled", () -> "false");
         registry.add("runner.boot.phase2.portfolio.reservation-ttl.ttl-ms", () -> ZOMBIE_TTL_MS);
+        registry.add("runner.boot.phase3.exchange-query-timeout-ms", () -> 500L);
+        registry.add("runner.boot.phase3.exchange-query-max-attempts", () -> 3);
+        registry.add("runner.boot.phase3.exchange-query-initial-backoff-ms", () -> 10L);
+        registry.add("runner.boot.phase3.exchange-query-backoff-multiplier", () -> 1.0d);
+        registry.add("runner.boot.phase3.exchange-query-max-backoff-ms", () -> 10L);
     }
 
     @Autowired
@@ -336,6 +342,116 @@ class RunnerBootRecoveryIntegrationTest {
         assertEquals(0, positionAgain.getAveragePrice().compareTo(partialPrice));
 
         awaitBalance(portfolioId, INITIAL_CAPITAL, BigDecimal.ZERO, WAIT_TIMEOUT);
+    }
+
+    @Test
+    void recoveryShouldHaltRunnerWhenLimboExistsButQueryCapabilityIsUnavailable() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner created = createAndActivateRunner(portfolioId);
+        BigDecimal reservedAmount = new BigDecimal("90.00000000");
+
+        jdbcTemplate.update(
+                "UPDATE strategy_runners SET exchange_id = ? WHERE id = ?",
+                "MOCK_NO_QUERY",
+                created.getId()
+        );
+        StrategyRunner runner = strategyRunnerRepository.findById(created.getId())
+                .orElseThrow(() -> new IllegalStateException("Runner not found after exchange override"));
+
+        Transaction submittedBuy = newTransaction(
+                runner,
+                TransactionType.BUY,
+                new BigDecimal("0.00150000"),
+                new BigDecimal("60000.00000000"),
+                reservedAmount
+        );
+        submittedBuy.submit("EX_UNSUPPORTED_QUERY");
+        strategyRunnerRepository.saveTransaction(submittedBuy);
+        assertTrue(globalBalanceRepository.reserveAtomic(portfolioId, reservedAmount));
+
+        RunnerBootRecoveryUseCase.RecoverySummary summary = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        Transaction stillSubmitted = awaitTransactionStatus(submittedBuy.getId(), TransactionStatus.SUBMITTED, WAIT_TIMEOUT);
+        assertNotNull(stillSubmitted);
+        assertEquals(1, summary.inFlightCount());
+        assertEquals(0, summary.zombiesCount());
+        assertEquals(1, summary.limboCount());
+        assertTrue(summary.notes().stream().anyMatch(note -> note.contains("Step 2 ERROR")),
+                "Recovery summary should record missing query capability");
+        assertTrue(summary.notes().stream().anyMatch(note -> note.contains("Step 4 ERROR")),
+                "Recovery summary should record limbo without query capability");
+
+        StrategyRunner halted = strategyRunnerRepository.findById(runner.getId())
+                .orElseThrow(() -> new IllegalStateException("Runner not found after unsupported query recovery"));
+        assertEquals(com.marmitt.core.enums.RunnerStatus.HALTED, halted.getStatus());
+        assertTrue(halted.isReconciling());
+
+        awaitBalance(
+                portfolioId,
+                INITIAL_CAPITAL.subtract(reservedAmount),
+                reservedAmount,
+                WAIT_TIMEOUT
+        );
+    }
+
+    @Test
+    void recoveryShouldRetryTransientQueryFailureAndReconcileOnNextAttempt() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        BigDecimal quantity = new BigDecimal("0.00150000");
+        BigDecimal fillPrice = new BigDecimal("60000.00000000");
+        BigDecimal reservedAmount = quantity.multiply(fillPrice);
+
+        Transaction submittedBuy = newTransaction(
+                runner,
+                TransactionType.BUY,
+                quantity,
+                fillPrice,
+                reservedAmount
+        );
+        submittedBuy.submit("EX_QUERY_RETRY_FILLED");
+        strategyRunnerRepository.saveTransaction(submittedBuy);
+        assertTrue(globalBalanceRepository.reserveAtomic(portfolioId, reservedAmount));
+
+        MockExchangeAdapter mock = getMockExchangeAdapter();
+        mock.seedQueriedOrderSnapshot(orderData(
+                submittedBuy,
+                OrderDataDto.OrderStatus.FILLED,
+                quantity,
+                fillPrice,
+                BigDecimal.ZERO
+        ));
+        mock.registerQueryFailurePlan(
+                submittedBuy.getClientOrderId(),
+                1,
+                ExchangeQueryException.ErrorType.TEMPORARY,
+                "Planned transient query failure"
+        );
+
+        RunnerBootRecoveryUseCase.RecoverySummary summary = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        Transaction filled = awaitTransactionStatus(submittedBuy.getId(), TransactionStatus.FILLED, WAIT_TIMEOUT);
+        assertNotNull(filled);
+        assertEquals(1, summary.inFlightCount());
+        assertEquals(0, summary.zombiesCount());
+        assertEquals(1, summary.limboCount());
+        assertTrue(summary.notes().stream().anyMatch(note -> note.contains("transient query failure")),
+                "Recovery summary should record the transient query failure");
+        assertTrue(summary.notes().stream().anyMatch(note -> note.contains("exchange query recovered")),
+                "Recovery summary should record recovery after retry");
+
+        Position position = strategyRunnerRepository.findPositionByOpenedByTransactionId(submittedBuy.getId())
+                .orElseThrow(() -> new IllegalStateException("Position not found for openedByTransactionId="
+                        + submittedBuy.getId()));
+        assertEquals(0, position.getQuantity().compareTo(quantity));
+        assertEquals(0, position.getAveragePrice().compareTo(fillPrice));
+
+        awaitBalance(
+                portfolioId,
+                INITIAL_CAPITAL.subtract(reservedAmount),
+                reservedAmount,
+                WAIT_TIMEOUT
+        );
     }
 
     @Test


### PR DESCRIPTION
## Resumo
- cobre falhas de query no boot recovery
- valida o comportamento com capacidade de query indisponivel e com falha transitoria recuperavel
- adiciona um gancho test-only no MOCK para falhar consultas REST de forma deterministica
- atualiza o roadmap e o checklist de go-live com o andamento da Fase 3

## Cenarios cobertos
- `query unsupported`: runner com limbo e sem `ExchangeOrderQueryPort` deve registrar erro e ir para `HALTED`
- `query transient failure + retry`: primeira query falha com erro temporario, a tentativa seguinte recupera e reconcilia `SUBMITTED -> FILLED`

## Validacao
- `./gradlew -q :spring-application:test --tests com.marmitt.application.spring.bootstrap.RunnerBootRecoveryIntegrationTest`
