### PR TITLE
test(phase3): cover exhausted query retries

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -113,6 +113,6 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Concluir o PR 4 da Fase 3 com cobertura de `query unsupported` e `retry/backoff` transitorio no boot recovery.
-2. Avancar para o cenario de falha transitoria esgotada (retry exhausted) na sequencia da Fase 3.
+1. Concluir o PR 5 da Fase 3 com cobertura de falha transitoria esgotada (`retry exhausted`) no boot recovery.
+2. Reavaliar se a Fase 3 fica concluida ou se ainda resta algum gap real de recovery antes de avancar para a Fase 4.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -483,4 +483,5 @@ Fora de escopo da Fase 4:
 1. PR 1 (concluido): zombies `PENDING` sem `exchangeOrderId` dentro do TTL e reexecucao idempotente do recovery para zombies vencidos.
 2. PR 2 (concluido): limbo `SUBMITTED/PARTIAL` reconciliado via query positiva do MOCK (`SUBMITTED -> FILLED` e `PARTIAL -> FILLED`) sem drift financeiro.
 3. PR 3 (concluido): limbo nao encontrado na exchange com fallback sintetico (`SUBMITTED -> EXPIRED`, `PARTIAL -> CANCELED`) e reexecucao idempotente do recovery.
-4. PR 4 (atual): falha de query no boot recovery cobrindo `query unsupported` e `query transient failure + retry/backoff` com recuperacao sem drift.
+4. PR 4 (concluido): falha de query no boot recovery cobrindo `query unsupported` e `query transient failure + retry/backoff` com recuperacao sem drift.
+5. PR 5 (atual): falha transitoria esgotada no boot recovery (`retry exhausted`) preservando limbo sem persistencia parcial indevida e levando o runner a `HALTED`.

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
@@ -455,6 +455,68 @@ class RunnerBootRecoveryIntegrationTest {
     }
 
     @Test
+    void recoveryShouldHaltRunnerWhenTransientQueryFailuresExhaustRetries() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        BigDecimal quantity = new BigDecimal("0.00150000");
+        BigDecimal price = new BigDecimal("60000.00000000");
+        BigDecimal reservedAmount = quantity.multiply(price);
+
+        Transaction submittedBuy = newTransaction(
+                runner,
+                TransactionType.BUY,
+                quantity,
+                price,
+                reservedAmount
+        );
+        submittedBuy.submit("EX_QUERY_RETRY_EXHAUSTED");
+        strategyRunnerRepository.saveTransaction(submittedBuy);
+        assertTrue(globalBalanceRepository.reserveAtomic(portfolioId, reservedAmount));
+
+        MockExchangeAdapter mock = getMockExchangeAdapter();
+        mock.seedQueriedOrderSnapshot(orderData(
+                submittedBuy,
+                OrderDataDto.OrderStatus.FILLED,
+                quantity,
+                price,
+                BigDecimal.ZERO
+        ));
+        mock.registerQueryFailurePlan(
+                submittedBuy.getClientOrderId(),
+                3,
+                ExchangeQueryException.ErrorType.TEMPORARY,
+                "Planned transient query failure exhausted"
+        );
+
+        RunnerBootRecoveryUseCase.RecoverySummary summary = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        Transaction stillSubmitted = awaitTransactionStatus(submittedBuy.getId(), TransactionStatus.SUBMITTED, WAIT_TIMEOUT);
+        assertNotNull(stillSubmitted);
+        assertEquals(1, summary.inFlightCount());
+        assertEquals(0, summary.zombiesCount());
+        assertEquals(1, summary.limboCount());
+        assertTrue(summary.notes().stream().anyMatch(note -> note.contains("transient query failure")),
+                "Recovery summary should record transient query failures");
+        assertTrue(summary.notes().stream().anyMatch(note -> note.contains("Step 4 ERROR")),
+                "Recovery summary should record the exhausted query failure");
+
+        StrategyRunner halted = strategyRunnerRepository.findById(runner.getId())
+                .orElseThrow(() -> new IllegalStateException("Runner not found after exhausted query recovery"));
+        assertEquals(com.marmitt.core.enums.RunnerStatus.HALTED, halted.getStatus());
+        assertTrue(halted.isReconciling());
+
+        assertTrue(strategyRunnerRepository.findPositionByOpenedByTransactionId(submittedBuy.getId()).isEmpty(),
+                "Exhausted query retries must not create a position");
+
+        awaitBalance(
+                portfolioId,
+                INITIAL_CAPITAL.subtract(reservedAmount),
+                reservedAmount,
+                WAIT_TIMEOUT
+        );
+    }
+
+    @Test
     void recoveryShouldReconcileSubmittedBuyFoundAsFilledOnExchange() {
         UUID portfolioId = createPortfolio();
         StrategyRunner runner = createAndActivateRunner(portfolioId);


### PR DESCRIPTION
## Resumo
- cobre o cenario de falha transitoria esgotada no boot recovery
- valida que o runner entra em `HALTED` quando todas as tentativas de query falham
- garante ausencia de persistencia parcial indevida durante `retry exhausted`
- atualiza o roadmap e o checklist de go-live com o andamento da Fase 3

## Cenarios cobertos
- `query transient failure exhausted`: todas as tentativas de `queryOrderByClientOrderId(...)` falham com erro temporario
- runner permanece com a transacao em limbo (`SUBMITTED`)
- nenhuma posicao nova e criada
- saldo reservado permanece coerente
- runner finaliza em `HALTED` com `reconciling=true`

## Validacao
- `./gradlew -q :spring-application:test --tests com.marmitt.application.spring.bootstrap.RunnerBootRecoveryIntegrationTest`
