### PR TITLE
docs(phase3): close testing roadmap phase 3

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -79,13 +79,14 @@ Consolidar os principais critérios para sair do ambiente de simulação (MOCK) 
 - Regra prática: toda evolução desse checklist deve manter rastreabilidade com os conceitos e invariantes já definidos no Blueprint/IG.
 
 
-## Status de Aderencia (2026-04-24)
+## Status de Aderencia (2026-04-25)
 
 - Testing Roadmap Fase 0: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 1A: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 1B: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 2: CONCLUIDA no branch `develop`.
-- Testing Roadmap Fase 3: EM ANDAMENTO.
+- Testing Roadmap Fase 3: CONCLUIDA no branch `develop`.
+- Testing Roadmap Fase 4: EM PLANEJAMENTO.
 
 Evidencias de Fase 0 em testes automatizados:
 - `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
@@ -108,11 +109,22 @@ Evidencias de Fase 1B em testes automatizados:
 ### Impacto no Go-Live
 
 - Item 1 (Testes automatizados minimos): PARCIAL (AVANCADO).
-- Baseline de invariantes, integracao core com MOCK, controles deterministicos do MOCK e robustez contra duplicidade/concorrencia cobertos (Fases 0, 1A, 1B e 2).
-- Ainda faltam boot recovery completo, operacao e integracao real com exchange (Fases 3 e 4).
+- Baseline de invariantes, integracao core com MOCK, controles deterministicos do MOCK, robustez contra duplicidade/concorrencia e boot recovery completo cobertos (Fases 0, 1A, 1B, 2 e 3).
+- Ainda faltam observabilidade operacional, DLQ operacional e integracao real com exchange (Fase 4 + integracoes reais).
+
+### Evidencias adicionais de Fase 3
+
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java`
+- Cobertura consolidada de:
+  - zombie `PENDING` com TTL
+  - limbo com query positiva
+  - limbo `not found`
+  - `query unsupported`
+  - `query transient failure + retry`
+  - `query retry exhausted`
 
 ### Proximo passo recomendado
 
-1. Concluir o PR 5 da Fase 3 com cobertura de falha transitoria esgotada (`retry exhausted`) no boot recovery.
-2. Reavaliar se a Fase 3 fica concluida ou se ainda resta algum gap real de recovery antes de avancar para a Fase 4.
+1. Iniciar a Fase 4 pelo PR 1 de observabilidade validada por teste.
+2. Cobrir evento de fail-fast e metricas minimas de boot por fase/resultado.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -419,13 +419,14 @@ Fora de escopo da Fase 4:
 - **IG:** cobre os fluxos e decisões operacionais já mapeadas no projeto.
 - Este roadmap deve evoluir junto com mudanças de domínio e novos modos de execução.
 
-## Status de Execucao (2026-04-24)
+## Status de Execucao (2026-04-25)
 
 - Fase 0: CONCLUIDA.
 - Fase 1A: CONCLUIDA.
 - Fase 1B: CONCLUIDA.
 - Fase 2: CONCLUIDA.
-- Fase 3: EM ANDAMENTO.
+- Fase 3: CONCLUIDA.
+- Fase 4: EM PLANEJAMENTO.
 
 ### Evidencias de conclusao da Fase 1B
 
@@ -478,10 +479,23 @@ Fora de escopo da Fase 4:
 7. PR 7 (concluido): eventos terminais fora de ordem (`FILLED -> CANCELED` atrasado) sem regressao de estado ou dupla aplicacao economica.
 8. PR 8 (concluido): repeticao controlada dos cenarios mais frageis para validar monotonicidade terminal e estabilidade sem flakiness.
 
-### Fase 3 em progresso
+### Fase 3 concluida
 
 1. PR 1 (concluido): zombies `PENDING` sem `exchangeOrderId` dentro do TTL e reexecucao idempotente do recovery para zombies vencidos.
 2. PR 2 (concluido): limbo `SUBMITTED/PARTIAL` reconciliado via query positiva do MOCK (`SUBMITTED -> FILLED` e `PARTIAL -> FILLED`) sem drift financeiro.
 3. PR 3 (concluido): limbo nao encontrado na exchange com fallback sintetico (`SUBMITTED -> EXPIRED`, `PARTIAL -> CANCELED`) e reexecucao idempotente do recovery.
 4. PR 4 (concluido): falha de query no boot recovery cobrindo `query unsupported` e `query transient failure + retry/backoff` com recuperacao sem drift.
-5. PR 5 (atual): falha transitoria esgotada no boot recovery (`retry exhausted`) preservando limbo sem persistencia parcial indevida e levando o runner a `HALTED`.
+5. PR 5 (concluido): falha transitoria esgotada no boot recovery (`retry exhausted`) preservando limbo sem persistencia parcial indevida e levando o runner a `HALTED`.
+
+### Evidencias de conclusao da Fase 3
+
+- Boot recovery completo consolidado em:
+  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java`
+- Cobertura funcional consolidada:
+  - zombie `PENDING` dentro e fora do TTL
+  - limbo `SUBMITTED/PARTIAL` com query positiva
+  - limbo `SUBMITTED/PARTIAL` nao encontrado na exchange
+  - `query unsupported`
+  - `query transient failure + retry/backoff`
+  - `query retry exhausted`
+  - reexecucao idempotente do recovery nos cenarios relevantes


### PR DESCRIPTION
## Resumo
- fecha formalmente a Fase 3 no roadmap de testes
- atualiza o go-live para refletir que o boot recovery completo ja esta coberto no `develop`
- posiciona a Fase 4 como proxima frente de trabalho

## Ajustes principais
- marca Fase 3 como `CONCLUIDA`
- registra evidencias consolidadas do boot recovery
- atualiza o impacto no go-live
- define a Fase 4 como proximo passo recomendado

## Escopo
- apenas documentacao
