### PR TITLE
test(phase4): validate boot observability

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -86,7 +86,7 @@ Consolidar os principais critérios para sair do ambiente de simulação (MOCK) 
 - Testing Roadmap Fase 1B: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 2: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 3: CONCLUIDA no branch `develop`.
-- Testing Roadmap Fase 4: EM PLANEJAMENTO.
+- Testing Roadmap Fase 4: EM ANDAMENTO.
 
 Evidencias de Fase 0 em testes automatizados:
 - `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
@@ -125,6 +125,6 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Iniciar a Fase 4 pelo PR 1 de observabilidade validada por teste.
-2. Cobrir evento de fail-fast e metricas minimas de boot por fase/resultado.
+1. Concluir o PR 1 da Fase 4 com observabilidade validada por teste.
+2. Avancar para DLQ operacional e continuidade da observabilidade de boot/recovery.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -426,7 +426,7 @@ Fora de escopo da Fase 4:
 - Fase 1B: CONCLUIDA.
 - Fase 2: CONCLUIDA.
 - Fase 3: CONCLUIDA.
-- Fase 4: EM PLANEJAMENTO.
+- Fase 4: EM ANDAMENTO.
 
 ### Evidencias de conclusao da Fase 1B
 
@@ -499,3 +499,7 @@ Fora de escopo da Fase 4:
   - `query transient failure + retry/backoff`
   - `query retry exhausted`
   - reexecucao idempotente do recovery nos cenarios relevantes
+
+### Fase 4 em progresso
+
+1. PR 1 (atual): observabilidade do boot validada por teste cobrindo evento de fail-fast e metricas minimas por fase/resultado.

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
@@ -1,0 +1,263 @@
+package com.marmitt.application.spring.bootstrap;
+
+import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
+import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
+import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
+import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
+import com.marmitt.core.domain.portfolio.Portfolio;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.dto.portfolio.PortfolioZombieCandidate;
+import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
+import com.marmitt.core.enums.AccountingPolicyType;
+import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.enums.ExecutionPolicy;
+import com.marmitt.core.enums.RunnerStatus;
+import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BootOrchestratorObservabilityTest {
+
+    @Test
+    void warnOnlyShouldRecordBootAndPortfolioMetricsWithoutPublishingFailFastEvent() {
+        Portfolio portfolio = new Portfolio(UUID.randomUUID(), "p1");
+        StrategyRunner runner = activeRunner(portfolio.getId(), "MOCK");
+        PortfolioZombieDetectionResult detected = PortfolioZombieDetectionResult.detected(
+                portfolio.getId(), "MOCK", 1, 1, 0, 0, 0, 0, List.of()
+        );
+
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        CapturingEventPublisher eventPublisher = new CapturingEventPublisher();
+        BootOrchestrator orchestrator = newOrchestrator(
+                Phase2Mode.WARN_ONLY,
+                portfolio,
+                runner,
+                detected,
+                eventPublisher,
+                new BootMetricsRecorder(meterRegistry)
+        );
+
+        orchestrator.onApplicationReady();
+
+        assertEquals(1.0d, meterRegistry.get("boot.run.total")
+                .tag("status", BootRunStatus.SUCCESS.name())
+                .counter()
+                .count());
+        assertEquals(1.0d, meterRegistry.get("boot.phase.total")
+                .tag("phase", "phase2.zombie")
+                .tag("status", BootPhaseStatus.SUCCESS.name())
+                .counter()
+                .count());
+        assertEquals(1L, meterRegistry.get("boot.phase.duration")
+                .tag("phase", "phase2.zombie")
+                .tag("status", BootPhaseStatus.SUCCESS.name())
+                .timer()
+                .count());
+        assertEquals(1.0d, meterRegistry.get("boot.phase.portfolio.total")
+                .tag("phase", "phase2.zombie")
+                .tag("status", "DETECTED")
+                .tag("exchange", "MOCK")
+                .tag("mode", Phase2Mode.WARN_ONLY.name())
+                .counter()
+                .count());
+        assertEquals(1L, meterRegistry.get("boot.phase.portfolio.duration")
+                .tag("phase", "phase2.zombie")
+                .tag("status", "DETECTED")
+                .tag("exchange", "MOCK")
+                .tag("mode", Phase2Mode.WARN_ONLY.name())
+                .timer()
+                .count());
+        assertEquals(0, eventPublisher.events().size());
+    }
+
+    @Test
+    void failFastShouldPublishEventAndRecordFailureMetrics() {
+        Portfolio portfolio = new Portfolio(UUID.randomUUID(), "p1");
+        StrategyRunner runner = activeRunner(portfolio.getId(), "MOCK");
+        PortfolioZombieDetectionResult detected = PortfolioZombieDetectionResult.detected(
+                portfolio.getId(), "MOCK", 1, 1, 0, 0, 0, 0, List.of(
+                        new PortfolioZombieCandidate(
+                                "",
+                                "EX_ORDER_123",
+                                "BTCUSDT",
+                                DlqReason.INVALID_FORMAT,
+                                "INVALID_FORMAT"
+                        )
+                )
+        );
+
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        CapturingEventPublisher eventPublisher = new CapturingEventPublisher();
+        BootOrchestrator orchestrator = newOrchestrator(
+                Phase2Mode.FAIL_FAST,
+                portfolio,
+                runner,
+                detected,
+                eventPublisher,
+                new BootMetricsRecorder(meterRegistry)
+        );
+
+        assertThrows(IllegalStateException.class, orchestrator::onApplicationReady);
+
+        assertEquals(1.0d, meterRegistry.get("boot.run.total")
+                .tag("status", BootRunStatus.FAILED.name())
+                .counter()
+                .count());
+        assertEquals(1.0d, meterRegistry.get("boot.phase.total")
+                .tag("phase", "phase2.zombie")
+                .tag("status", BootPhaseStatus.FAILED.name())
+                .counter()
+                .count());
+        assertEquals(1L, meterRegistry.get("boot.phase.duration")
+                .tag("phase", "phase2.zombie")
+                .tag("status", BootPhaseStatus.FAILED.name())
+                .timer()
+                .count());
+        assertEquals(1.0d, meterRegistry.get("boot.phase.portfolio.total")
+                .tag("phase", "phase2.zombie")
+                .tag("status", "DETECTED")
+                .tag("exchange", "MOCK")
+                .tag("mode", Phase2Mode.FAIL_FAST.name())
+                .counter()
+                .count());
+        assertEquals(1.0d, meterRegistry.get("boot.failfast.total")
+                .tag("phase", "phase2.zombie")
+                .tag("code", "ZOMBIE_DETECTED")
+                .counter()
+                .count());
+
+        assertEquals(1, eventPublisher.events().size());
+        Object published = eventPublisher.events().getFirst();
+        BootFailFastEvent event = assertInstanceOf(BootFailFastEvent.class, published);
+        assertEquals("phase2.zombie", event.phase());
+        assertEquals("ZOMBIE_DETECTED", event.code());
+        assertNotNull(event.runId());
+        assertNotNull(event.timestamp());
+    }
+
+    private static BootOrchestrator newOrchestrator(Phase2Mode mode,
+                                                    Portfolio portfolio,
+                                                    StrategyRunner runner,
+                                                    PortfolioZombieDetectionResult zombieResult,
+                                                    ApplicationEventPublisher eventPublisher,
+                                                    BootMetricsRecorder bootMetricsRecorder) {
+        PortfolioRepositoryPort portfolioRepository = mock(PortfolioRepositoryPort.class);
+        StrategyRunnerRepositoryPort strategyRunnerRepository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeAdapterRepository = mock(ExchangeAdapterRepositoryPort.class);
+        PortfolioBootSanityUseCase portfolioBootSanityUseCase = mock(PortfolioBootSanityUseCase.class);
+        PortfolioReservationTtlUseCase portfolioReservationTtlUseCase = mock(PortfolioReservationTtlUseCase.class);
+        PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase = mock(PortfolioZombieDetectionUseCase.class);
+        DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
+        RunnerBootRecoveryUseCase runnerBootRecoveryUseCase = mock(RunnerBootRecoveryUseCase.class);
+        BootStatusTracker tracker = new BootStatusTracker();
+
+        when(portfolioRepository.findAll()).thenReturn(List.of(portfolio));
+        when(strategyRunnerRepository.findByPortfolioId(portfolio.getId())).thenReturn(List.of(runner));
+        when(portfolioZombieDetectionUseCase.execute(portfolio.getId(), "MOCK", true)).thenReturn(zombieResult);
+
+        RunnerBootPhase1Properties phase1Properties = new RunnerBootPhase1Properties();
+        phase1Properties.setEnabled(false);
+
+        RunnerBootPhase2Properties phase2Properties = new RunnerBootPhase2Properties();
+        phase2Properties.setEnabled(true);
+        phase2Properties.setMode(mode);
+
+        RunnerBootPhase3Properties phase3Properties = new RunnerBootPhase3Properties();
+        phase3Properties.setEnabled(false);
+
+        PortfolioSanityCheckProperties sanityProperties = new PortfolioSanityCheckProperties();
+        sanityProperties.setEnabled(false);
+
+        PortfolioReservationTtlProperties ttlProperties = new PortfolioReservationTtlProperties();
+        ttlProperties.setEnabled(false);
+
+        PortfolioZombieDetectionProperties zombieProperties = new PortfolioZombieDetectionProperties();
+        zombieProperties.setEnabled(true);
+
+        PortfolioCutoffProperties cutoffProperties = new PortfolioCutoffProperties();
+        cutoffProperties.setEnabled(true);
+
+        return new BootOrchestrator(
+                portfolioRepository,
+                strategyRunnerRepository,
+                exchangeAdapterRepository,
+                portfolioBootSanityUseCase,
+                portfolioReservationTtlUseCase,
+                portfolioZombieDetectionUseCase,
+                deadLetterRepository,
+                phase1Properties,
+                phase2Properties,
+                phase3Properties,
+                sanityProperties,
+                ttlProperties,
+                zombieProperties,
+                cutoffProperties,
+                runnerBootRecoveryUseCase,
+                tracker,
+                bootMetricsRecorder,
+                eventPublisher
+        );
+    }
+
+    private static StrategyRunner activeRunner(UUID portfolioId, String exchangeId) {
+        return new StrategyRunner(
+                UUID.randomUUID(),
+                portfolioId,
+                "x1",
+                UUID.randomUUID(),
+                "SimpleMovingAverage",
+                "BTCUSDT",
+                exchangeId,
+                Set.of(exchangeId),
+                RunnerStatus.ACTIVE,
+                ExecutionPolicy.SINGLE,
+                AccountingPolicyType.FIFO,
+                new BigDecimal("0.25"),
+                1,
+                1,
+                null,
+                false,
+                Instant.now(),
+                null,
+                null,
+                0L
+        );
+    }
+
+    private static final class CapturingEventPublisher implements ApplicationEventPublisher {
+        private final List<Object> events = new ArrayList<>();
+
+        @Override
+        public void publishEvent(Object event) {
+            events.add(event);
+        }
+
+        @Override
+        public void publishEvent(ApplicationEvent event) {
+            events.add(event);
+        }
+
+        public List<Object> events() {
+            return events;
+        }
+    }
+}


### PR DESCRIPTION
## Resumo
- inicia a Fase 4 com testes de observabilidade do boot
- valida metricas minimas por fase/resultado e o evento de fail-fast
- atualiza o roadmap e o go-live para marcar a Fase 4 como em andamento

## Cenarios cobertos
- `WARN_ONLY`: run bem-sucedido registra metricas de run, fase e portfolio sem publicar `BootFailFastEvent`
- `FAIL_FAST`: run com zombie detection critica publica `BootFailFastEvent` e registra metricas de falha (`boot.run.total`, `boot.phase.total`, `boot.phase.duration`, `boot.phase.portfolio.total`, `boot.failfast.total`)

## Validacao
- `./gradlew -q :spring-application:test --tests com.marmitt.application.spring.bootstrap.BootOrchestratorObservabilityTest`
