### PR TITLE
test(phase4): cover dead letter management flow

### DIFF
--- a/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
@@ -1,0 +1,134 @@
+package com.marmitt.core.application.usecase.portfolio;
+
+import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
+import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ManageDeadLetterUseCaseTest {
+
+    @Test
+    void listUnresolvedShouldApplyDefaultLimitWhenRequestIsNonPositive() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        UUID portfolioId = UUID.randomUUID();
+        UUID runnerId = UUID.randomUUID();
+        DeadLetterEntry entry = newEntry(portfolioId, runnerId, "client-1");
+        when(repository.findUnresolved(portfolioId, runnerId, 100)).thenReturn(List.of(entry));
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+
+        List<DeadLetterEntryDto> result = useCase.listUnresolved(portfolioId, runnerId, 0);
+
+        assertEquals(1, result.size());
+        assertEquals(entry.getId(), result.getFirst().id());
+        verify(repository).findUnresolved(portfolioId, runnerId, 100);
+    }
+
+    @Test
+    void listUnresolvedShouldCapLimitAtMaximum() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        UUID portfolioId = UUID.randomUUID();
+        when(repository.findUnresolved(portfolioId, null, 500)).thenReturn(List.of());
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+
+        useCase.listUnresolved(portfolioId, null, 999);
+
+        verify(repository).findUnresolved(portfolioId, null, 500);
+    }
+
+    @Test
+    void resolveShouldMarkEntryResolvedAndPersistIt() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterEntry entry = newEntry(UUID.randomUUID(), UUID.randomUUID(), "client-2");
+        when(repository.findById(entry.getId())).thenReturn(Optional.of(entry));
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+
+        ResolveDeadLetterResponse response = useCase.resolve(entry.getId(), "operator@test", "manual review");
+
+        assertTrue(response.resolved());
+        assertEquals("Dead letter entry resolved successfully", response.message());
+        assertNotNull(response.entry());
+        assertEquals(entry.getId(), response.entry().id());
+        assertEquals("operator@test", response.entry().resolvedBy());
+        assertNotNull(response.entry().resolvedAt());
+
+        ArgumentCaptor<DeadLetterEntry> entryCaptor = ArgumentCaptor.forClass(DeadLetterEntry.class);
+        verify(repository).save(entryCaptor.capture());
+        assertTrue(entryCaptor.getValue().isResolved());
+        assertEquals("operator@test", entryCaptor.getValue().getResolvedBy());
+    }
+
+    @Test
+    void resolveShouldRejectBlankOperator() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> useCase.resolve(UUID.randomUUID(), "   ", "manual review")
+        );
+
+        assertEquals("resolvedBy cannot be blank", error.getMessage());
+    }
+
+    @Test
+    void resolveShouldReturnFailureWhenEntryDoesNotExist() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        UUID deadLetterId = UUID.randomUUID();
+        when(repository.findById(deadLetterId)).thenReturn(Optional.empty());
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+
+        ResolveDeadLetterResponse response = useCase.resolve(deadLetterId, "operator@test", "manual review");
+
+        assertFalse(response.resolved());
+        assertEquals("Dead letter entry not found", response.message());
+        assertNull(response.entry());
+    }
+
+    @Test
+    void resolveShouldReturnFailureWhenEntryIsAlreadyResolved() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterEntry entry = newEntry(UUID.randomUUID(), UUID.randomUUID(), "client-3");
+        entry.resolve("operator@test");
+        when(repository.findById(entry.getId())).thenReturn(Optional.of(entry));
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+
+        ResolveDeadLetterResponse response = useCase.resolve(entry.getId(), "another@test", "manual review");
+
+        assertFalse(response.resolved());
+        assertEquals("Dead letter entry is already resolved", response.message());
+        assertNull(response.entry());
+    }
+
+    private static DeadLetterEntry newEntry(UUID portfolioId, UUID runnerId, String clientOrderId) {
+        return new DeadLetterEntry(
+                portfolioId,
+                runnerId,
+                clientOrderId,
+                "EX_" + clientOrderId,
+                "{\"source\":\"test\"}",
+                DlqReason.RECONCILIATION_CONFLICT
+        );
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java
@@ -1,0 +1,160 @@
+package com.marmitt.application.spring.controller;
+
+import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
+import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DeadLetterControllerTest {
+
+    private final ManageDeadLetterPort manageDeadLetter = mock(ManageDeadLetterPort.class);
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new DeadLetterController(manageDeadLetter)).build();
+    }
+
+    @Test
+    void listUnresolvedShouldReturnEntriesAndForwardFilters() throws Exception {
+        UUID portfolioId = UUID.randomUUID();
+        UUID runnerId = UUID.randomUUID();
+        UUID deadLetterId = UUID.randomUUID();
+        when(manageDeadLetter.listUnresolved(portfolioId, runnerId, 25)).thenReturn(List.of(
+                new DeadLetterEntryDto(
+                        deadLetterId,
+                        portfolioId,
+                        runnerId,
+                        "client-1",
+                        "EX_1",
+                        "{\"source\":\"test\"}",
+                        DlqReason.RECONCILIATION_CONFLICT,
+                        false,
+                        null,
+                        null,
+                        Instant.parse("2026-04-25T12:00:00Z")
+                )
+        ));
+
+        mockMvc.perform(get("/api/dead-letters")
+                        .param("portfolioId", portfolioId.toString())
+                        .param("runnerId", runnerId.toString())
+                        .param("limit", "25"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(deadLetterId.toString()))
+                .andExpect(jsonPath("$[0].portfolioId").value(portfolioId.toString()))
+                .andExpect(jsonPath("$[0].runnerId").value(runnerId.toString()))
+                .andExpect(jsonPath("$[0].reason").value("RECONCILIATION_CONFLICT"));
+
+        verify(manageDeadLetter).listUnresolved(portfolioId, runnerId, 25);
+    }
+
+    @Test
+    void resolveShouldReturnOkWhenEntryIsResolved() throws Exception {
+        UUID deadLetterId = UUID.randomUUID();
+        UUID portfolioId = UUID.randomUUID();
+        UUID runnerId = UUID.randomUUID();
+        DeadLetterEntryDto entry = new DeadLetterEntryDto(
+                deadLetterId,
+                portfolioId,
+                runnerId,
+                "client-1",
+                "EX_1",
+                "{\"source\":\"test\"}",
+                DlqReason.RECONCILIATION_CONFLICT,
+                true,
+                "operator@test",
+                Instant.parse("2026-04-25T12:10:00Z"),
+                Instant.parse("2026-04-25T12:00:00Z")
+        );
+        when(manageDeadLetter.resolve(deadLetterId, "operator@test", "manual review"))
+                .thenReturn(ResolveDeadLetterResponse.success(entry, "Dead letter entry resolved successfully"));
+
+        mockMvc.perform(post("/api/dead-letters/{id}/resolve", deadLetterId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "resolvedBy": "operator@test",
+                                  "resolutionNote": "manual review"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resolved").value(true))
+                .andExpect(jsonPath("$.deadLetterId").value(deadLetterId.toString()))
+                .andExpect(jsonPath("$.entry.resolvedBy").value("operator@test"));
+    }
+
+    @Test
+    void resolveShouldReturnNotFoundWhenEntryDoesNotExist() throws Exception {
+        UUID deadLetterId = UUID.randomUUID();
+        when(manageDeadLetter.resolve(deadLetterId, "operator@test", "manual review"))
+                .thenReturn(ResolveDeadLetterResponse.failure(deadLetterId, "Dead letter entry not found"));
+
+        mockMvc.perform(post("/api/dead-letters/{id}/resolve", deadLetterId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "resolvedBy": "operator@test",
+                                  "resolutionNote": "manual review"
+                                }
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resolved").value(false))
+                .andExpect(jsonPath("$.message").value("Dead letter entry not found"));
+    }
+
+    @Test
+    void resolveShouldReturnConflictWhenEntryIsAlreadyResolved() throws Exception {
+        UUID deadLetterId = UUID.randomUUID();
+        when(manageDeadLetter.resolve(deadLetterId, "operator@test", "manual review"))
+                .thenReturn(ResolveDeadLetterResponse.failure(deadLetterId, "Dead letter entry is already resolved"));
+
+        mockMvc.perform(post("/api/dead-letters/{id}/resolve", deadLetterId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "resolvedBy": "operator@test",
+                                  "resolutionNote": "manual review"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.resolved").value(false))
+                .andExpect(jsonPath("$.message").value("Dead letter entry is already resolved"));
+    }
+
+    @Test
+    void resolveShouldReturnBadRequestWhenUseCaseRejectsInput() throws Exception {
+        UUID deadLetterId = UUID.randomUUID();
+        when(manageDeadLetter.resolve(deadLetterId, "", "manual review"))
+                .thenThrow(new IllegalArgumentException("resolvedBy cannot be blank"));
+
+        mockMvc.perform(post("/api/dead-letters/{id}/resolve", deadLetterId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "resolvedBy": "",
+                                  "resolutionNote": "manual review"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resolved").value(false))
+                .andExpect(jsonPath("$.message").value("Invalid request: resolvedBy cannot be blank"));
+    }
+}


### PR DESCRIPTION
## Summary
- add core unit coverage for `ManageDeadLetterUseCase`
- add lightweight controller coverage for `DeadLetterController`
- validate listing, successful resolution, missing entry, already-resolved entry and invalid operator input

## Validation
- `./gradlew -q :core:test --tests com.marmitt.core.application.usecase.portfolio.ManageDeadLetterUseCaseTest :spring-application:test --tests com.marmitt.application.spring.controller.DeadLetterControllerTest`

## Notes
- documentation was intentionally left out of this PR because PR #62 is still under review and already updates the Phase 4 roadmap/checklist in parallel