### PR TITLE
feat(phase4): add safe dead letter reprocessing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+# AGENTS.md
+
+## Objetivo
+
+Este repositorio utiliza o Codex principalmente como agente de implementacao e de review. Em tarefas de review, priorize correcao, limites arquiteturais, regressao e falta de validacao acima de comentarios apenas de estilo.
+
+Ao revisar um pull request:
+
+- Comece pelos achados, ordenados por severidade.
+- Foque em risco comportamental e desvio arquitetural antes de nomenclatura ou formatacao.
+- Aponte violacoes de fronteira mesmo quando o codigo estiver tecnicamente funcional.
+- Se nenhum problema for encontrado, diga isso explicitamente e registre riscos residuais ou lacunas de teste.
+
+## Principios de Arquitetura
+
+Espera-se que este codebase siga clean code, clean architecture e arquitetura hexagonal.
+
+Expectativas centrais:
+
+- As dependencias devem apontar para dentro, em direcao as regras de negocio.
+- Decisoes de negocio devem permanecer isoladas de frameworks, transporte, persistencia e detalhes especificos de provedores.
+- Cada modulo deve manter uma responsabilidade unica e clara; rejeite mudancas que embaralhem a responsabilidade de cada modulo.
+
+Use essas regras arquiteturais como invariantes de review.
+
+## Responsabilidades dos Modulos
+
+### `core/`
+
+O modulo `core` e o dono das regras de negocio e deve permanecer independente de detalhes de implementacao.
+
+Revise considerando que:
+
+- Entidades de dominio, value objects, ports e use cases pertencem aqui.
+- Regras de negocio e orquestracao do comportamento de dominio pertencem aqui.
+- Detalhes de framework nao pertencem aqui.
+
+Considere problema quando houver:
+
+- Anotacoes do Spring ou abstracoes especificas do Spring.
+- Preocupacoes de HTTP, WebSocket, mensageria, banco de dados ou SDK de provedor.
+- DTOs especificos de exchange ou estruturas de payload vazando para dentro do modulo.
+- Decisoes tecnologicas embutidas na logica de dominio.
+- Codigo que decide como uma ferramenta externa funciona, em vez de expressar o que o negocio precisa.
+
+### `spring-application/`
+
+O modulo `spring-application` e a camada de entrega e de composicao da aplicacao. O papel dele e disponibilizar as ferramentas necessarias para o `core` funcionar, como PostgreSQL, OkHttp, mensageria, configuracao, agendamento e exposicao REST.
+
+Revise considerando que:
+
+- Wiring de dependencias, configuracao de beans, adapters, controllers e setup de execucao pertencem aqui.
+- Mapeamento entre entradas externas e use cases do core pertence aqui.
+- Implementacoes de infraestrutura para ports do core pertencem aqui.
+- DTOs nao devem ser criados nem mantidos nesta camada.
+
+Considere problema quando houver:
+
+- Regras de negocio sendo decididas aqui em vez de no `core`.
+- Calculo de estrategia sendo implementado aqui em vez de no `strategy`.
+- Controllers ou services acumulando decisoes de dominio em vez de delegarem para os use cases.
+- Detalhes de payload de provedores subindo de camada quando deveriam permanecer isolados nos modulos adapter.
+- DTOs declarados no `spring-application`, mesmo quando usados apenas para request/response.
+
+### `strategy/`
+
+O modulo `strategy` deve focar apenas em decidir ou calcular uma acao a partir de uma entrada.
+
+Revise considerando que:
+
+- Logica deterministica de estrategia, regras de decisao e fluxo de calculo pertencem aqui.
+- Entradas e saidas devem ser explicitas e faceis de avaliar.
+
+Considere problema quando houver:
+
+- Preocupacoes de rede, persistencia, mensageria ou framework.
+- Controllers, repositories, clientes HTTP ou wiring de infraestrutura.
+- Efeitos colaterais ocultos que nao estejam relacionados ao calculo do resultado da estrategia.
+- Orquestracao de negocio que deveria estar no `core`.
+
+### `adapter-*`
+
+Os modulos adapter sao as bordas voltadas ao provedor. Eles devem focar em payloads, mapeamento e tratamento de schemas especificos do provedor, e nao em regras de negocio.
+
+Revise considerando que:
+
+- DTOs de request/response, parsing, traducao e representacoes especificas do provedor pertencem aqui.
+- Os detalhes do provedor devem permanecer isolados do `core`.
+
+Considere problema quando houver:
+
+- Regras de negocio ou decisoes de estrategia dentro de modulos adapter.
+- Vazamento de payloads de exchange/provedor para dentro do `core`.
+- Orquestracao da aplicacao ou decisoes de dominio implementadas aqui.
+- Acoplamento forte entre detalhes internos do adapter e modulos nao relacionados.
+
+## Heuristicas de Review
+
+Priorize estas perguntas durante o review:
+
+1. A mudanca preserva a fronteira pretendida do modulo?
+2. Alguma regra de negocio esta vazando para codigo de infraestrutura ou transporte?
+3. Algum detalhe especifico de provedor esta vazando para o `core`?
+4. O `strategy` continua sendo logica pura de decisao/calculo?
+5. O `spring-application` esta atuando como wiring em vez de virar uma segunda camada de negocio?
+6. Os adapters continuam focados em traducao de payload, e nao em politica de dominio?
+7. Nomes, DTOs e interfaces estao expressando o dominio com clareza suficiente para manter mudancas futuras seguras?
+
+## Validacao
+
+Use o wrapper do repositorio para comandos Gradle, para manter consistente o cache local compartilhado:
+
+```powershell
+./scripts/gradle-run.ps1 -q :core:compileJava
+./scripts/gradle-run.ps1 -q :strategy:compileJava
+./scripts/gradle-run.ps1 -q :spring-application:compileJava
+```
+
+Orientacao de validacao:
+
+- Execute o compile ou teste mais restrito possivel para os modulos tocados pela mudanca.
+- Se a mudanca atravessar fronteiras entre modulos, prefira compilar todos os modulos afetados.
+- Se o review encontrar ausencia de testes para um comportamento arriscado, explicite isso.
+
+## Orientacao para Review de Pull Request
+
+Quando o Codex for solicitado a revisar um PR, prefira comentarios que expliquem:
+
+- qual fronteira ou invariante foi violado
+- por que isso aumenta o risco de longo prazo ou o potencial de regressao
+- qual modulo deveria ser o dono daquela responsabilidade
+
+Evite comentarios de baixo valor que apenas repitam preferencia de estilo, a menos que isso afete legibilidade, manutenibilidade ou intencao arquitetural.

--- a/core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java
@@ -2,6 +2,7 @@ package com.marmitt.core.application.usecase.portfolio;
 
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
 import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.DeadLetterReprocessingResult;
 import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
@@ -87,7 +88,11 @@ public class ManageDeadLetterUseCase implements ManageDeadLetterPort {
             );
         }
 
-        deadLetterReprocessingPort.reprocess(entry);
+        DeadLetterReprocessingResult reprocessingResult = deadLetterReprocessingPort.reprocess(entry);
+        if (!reprocessingResult.applied()) {
+            return ReprocessDeadLetterResponse.failure(deadLetterId, reprocessingResult.message());
+        }
+
         entry.resolve(requestedBy);
         deadLetterEntryRepository.save(entry);
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java
@@ -2,8 +2,10 @@ package com.marmitt.core.application.usecase.portfolio;
 
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
 import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
+import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,9 +19,12 @@ public class ManageDeadLetterUseCase implements ManageDeadLetterPort {
     private static final int MAX_LIMIT = 500;
 
     private final DeadLetterEntryRepositoryPort deadLetterEntryRepository;
+    private final DeadLetterReprocessingPort deadLetterReprocessingPort;
 
-    public ManageDeadLetterUseCase(DeadLetterEntryRepositoryPort deadLetterEntryRepository) {
+    public ManageDeadLetterUseCase(DeadLetterEntryRepositoryPort deadLetterEntryRepository,
+                                   DeadLetterReprocessingPort deadLetterReprocessingPort) {
         this.deadLetterEntryRepository = deadLetterEntryRepository;
+        this.deadLetterReprocessingPort = deadLetterReprocessingPort;
     }
 
     @Override
@@ -57,6 +62,41 @@ public class ManageDeadLetterUseCase implements ManageDeadLetterPort {
         return ResolveDeadLetterResponse.success(
                 DeadLetterEntryDto.fromDomain(entry),
                 "Dead letter entry resolved successfully"
+        );
+    }
+
+    @Override
+    public ReprocessDeadLetterResponse reprocess(UUID deadLetterId, String requestedBy, String resolutionNote) {
+        if (requestedBy == null || requestedBy.isBlank()) {
+            throw new IllegalArgumentException("requestedBy cannot be blank");
+        }
+
+        DeadLetterEntry entry = deadLetterEntryRepository.findById(deadLetterId).orElse(null);
+        if (entry == null) {
+            return ReprocessDeadLetterResponse.failure(deadLetterId, "Dead letter entry not found");
+        }
+
+        if (entry.isResolved()) {
+            return ReprocessDeadLetterResponse.failure(deadLetterId, "Dead letter entry is already resolved");
+        }
+
+        if (!deadLetterReprocessingPort.supports(entry)) {
+            return ReprocessDeadLetterResponse.failure(
+                    deadLetterId,
+                    "Dead letter entry cannot be reprocessed automatically"
+            );
+        }
+
+        deadLetterReprocessingPort.reprocess(entry);
+        entry.resolve(requestedBy);
+        deadLetterEntryRepository.save(entry);
+
+        log.info("deadLetter: reprocessed id={} portfolioId={} runnerId={} requestedBy={} note={}",
+                entry.getId(), entry.getPortfolioId(), entry.getRunnerId(), requestedBy, resolutionNote);
+
+        return ReprocessDeadLetterResponse.success(
+                DeadLetterEntryDto.fromDomain(entry),
+                "Dead letter entry reprocessed successfully"
         );
     }
 }

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/CapitalDeadLetterPayload.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/CapitalDeadLetterPayload.java
@@ -1,4 +1,4 @@
-package com.marmitt.application.spring.deadletter;
+package com.marmitt.core.dto.portfolio;
 
 import com.marmitt.core.enums.FeeType;
 import com.marmitt.core.enums.ReleaseReason;
@@ -6,7 +6,7 @@ import com.marmitt.core.enums.ReleaseReason;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-record CapitalDeadLetterPayload(
+public record CapitalDeadLetterPayload(
         String eventType,
         UUID runnerId,
         UUID transactionId,

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/DeadLetterReprocessingResult.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/DeadLetterReprocessingResult.java
@@ -1,0 +1,14 @@
+package com.marmitt.core.dto.portfolio;
+
+public record DeadLetterReprocessingResult(
+        boolean applied,
+        String message
+) {
+    public static DeadLetterReprocessingResult applied(String message) {
+        return new DeadLetterReprocessingResult(true, message);
+    }
+
+    public static DeadLetterReprocessingResult notApplied(String message) {
+        return new DeadLetterReprocessingResult(false, message);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/ReprocessDeadLetterRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/ReprocessDeadLetterRequest.java
@@ -1,0 +1,7 @@
+package com.marmitt.core.dto.portfolio;
+
+public record ReprocessDeadLetterRequest(
+        String requestedBy,
+        String resolutionNote
+) {
+}

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/ReprocessDeadLetterResponse.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/ReprocessDeadLetterResponse.java
@@ -1,0 +1,18 @@
+package com.marmitt.core.dto.portfolio;
+
+import java.util.UUID;
+
+public record ReprocessDeadLetterResponse(
+        UUID deadLetterId,
+        boolean reprocessed,
+        String message,
+        DeadLetterEntryDto entry
+) {
+    public static ReprocessDeadLetterResponse success(DeadLetterEntryDto entry, String message) {
+        return new ReprocessDeadLetterResponse(entry.id(), true, message, entry);
+    }
+
+    public static ReprocessDeadLetterResponse failure(UUID deadLetterId, String message) {
+        return new ReprocessDeadLetterResponse(deadLetterId, false, message, null);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/ManageDeadLetterPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/ManageDeadLetterPort.java
@@ -1,6 +1,7 @@
 package com.marmitt.core.ports.inbound.portfolio;
 
 import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
 
 import java.util.List;
@@ -11,4 +12,6 @@ public interface ManageDeadLetterPort {
     List<DeadLetterEntryDto> listUnresolved(UUID portfolioId, UUID runnerId, int limit);
 
     ResolveDeadLetterResponse resolve(UUID deadLetterId, String resolvedBy, String resolutionNote);
+
+    ReprocessDeadLetterResponse reprocess(UUID deadLetterId, String requestedBy, String resolutionNote);
 }

--- a/core/src/main/java/com/marmitt/core/ports/outbound/repository/DeadLetterReprocessingPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/repository/DeadLetterReprocessingPort.java
@@ -1,10 +1,11 @@
 package com.marmitt.core.ports.outbound.repository;
 
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.dto.portfolio.DeadLetterReprocessingResult;
 
 public interface DeadLetterReprocessingPort {
 
     boolean supports(DeadLetterEntry entry);
 
-    void reprocess(DeadLetterEntry entry);
+    DeadLetterReprocessingResult reprocess(DeadLetterEntry entry);
 }

--- a/core/src/main/java/com/marmitt/core/ports/outbound/repository/DeadLetterReprocessingPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/repository/DeadLetterReprocessingPort.java
@@ -1,0 +1,10 @@
+package com.marmitt.core.ports.outbound.repository;
+
+import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+
+public interface DeadLetterReprocessingPort {
+
+    boolean supports(DeadLetterEntry entry);
+
+    void reprocess(DeadLetterEntry entry);
+}

--- a/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
@@ -2,8 +2,10 @@ package com.marmitt.core.application.usecase.portfolio;
 
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
 import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
 import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -19,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,12 +30,13 @@ class ManageDeadLetterUseCaseTest {
     @Test
     void listUnresolvedShouldApplyDefaultLimitWhenRequestIsNonPositive() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         UUID portfolioId = UUID.randomUUID();
         UUID runnerId = UUID.randomUUID();
         DeadLetterEntry entry = newEntry(portfolioId, runnerId, "client-1");
         when(repository.findUnresolved(portfolioId, runnerId, 100)).thenReturn(List.of(entry));
 
-        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
         List<DeadLetterEntryDto> result = useCase.listUnresolved(portfolioId, runnerId, 0);
 
@@ -44,10 +48,11 @@ class ManageDeadLetterUseCaseTest {
     @Test
     void listUnresolvedShouldCapLimitAtMaximum() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         UUID portfolioId = UUID.randomUUID();
         when(repository.findUnresolved(portfolioId, null, 500)).thenReturn(List.of());
 
-        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
         useCase.listUnresolved(portfolioId, null, 999);
 
@@ -57,10 +62,11 @@ class ManageDeadLetterUseCaseTest {
     @Test
     void resolveShouldMarkEntryResolvedAndPersistIt() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         DeadLetterEntry entry = newEntry(UUID.randomUUID(), UUID.randomUUID(), "client-2");
         when(repository.findById(entry.getId())).thenReturn(Optional.of(entry));
 
-        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
         ResolveDeadLetterResponse response = useCase.resolve(entry.getId(), "operator@test", "manual review");
 
@@ -80,7 +86,8 @@ class ManageDeadLetterUseCaseTest {
     @Test
     void resolveShouldRejectBlankOperator() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
-        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
         IllegalArgumentException error = assertThrows(
                 IllegalArgumentException.class,
@@ -93,10 +100,11 @@ class ManageDeadLetterUseCaseTest {
     @Test
     void resolveShouldReturnFailureWhenEntryDoesNotExist() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         UUID deadLetterId = UUID.randomUUID();
         when(repository.findById(deadLetterId)).thenReturn(Optional.empty());
 
-        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
         ResolveDeadLetterResponse response = useCase.resolve(deadLetterId, "operator@test", "manual review");
 
@@ -108,17 +116,101 @@ class ManageDeadLetterUseCaseTest {
     @Test
     void resolveShouldReturnFailureWhenEntryIsAlreadyResolved() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         DeadLetterEntry entry = newEntry(UUID.randomUUID(), UUID.randomUUID(), "client-3");
         entry.resolve("operator@test");
         when(repository.findById(entry.getId())).thenReturn(Optional.of(entry));
 
-        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository);
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
         ResolveDeadLetterResponse response = useCase.resolve(entry.getId(), "another@test", "manual review");
 
         assertFalse(response.resolved());
         assertEquals("Dead letter entry is already resolved", response.message());
         assertNull(response.entry());
+    }
+
+    @Test
+    void reprocessShouldReapplySupportedEntryAndResolveIt() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
+        DeadLetterEntry entry = newRetryExhaustedEntry(UUID.randomUUID(), UUID.randomUUID(), "client-4");
+        when(repository.findById(entry.getId())).thenReturn(Optional.of(entry));
+        when(reprocessingPort.supports(entry)).thenReturn(true);
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
+
+        ReprocessDeadLetterResponse response = useCase.reprocess(entry.getId(), "operator@test", "retry capital flow");
+
+        assertTrue(response.reprocessed());
+        assertEquals("Dead letter entry reprocessed successfully", response.message());
+        assertEquals("operator@test", response.entry().resolvedBy());
+        verify(reprocessingPort).reprocess(entry);
+        verify(repository).save(entry);
+    }
+
+    @Test
+    void reprocessShouldReturnFailureWhenEntryDoesNotExist() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
+        UUID deadLetterId = UUID.randomUUID();
+        when(repository.findById(deadLetterId)).thenReturn(Optional.empty());
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
+
+        ReprocessDeadLetterResponse response = useCase.reprocess(deadLetterId, "operator@test", "retry capital flow");
+
+        assertFalse(response.reprocessed());
+        assertEquals("Dead letter entry not found", response.message());
+        assertNull(response.entry());
+    }
+
+    @Test
+    void reprocessShouldReturnFailureWhenEntryIsAlreadyResolved() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
+        DeadLetterEntry entry = newRetryExhaustedEntry(UUID.randomUUID(), UUID.randomUUID(), "client-5");
+        entry.resolve("operator@test");
+        when(repository.findById(entry.getId())).thenReturn(Optional.of(entry));
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
+
+        ReprocessDeadLetterResponse response = useCase.reprocess(entry.getId(), "operator@test", "retry capital flow");
+
+        assertFalse(response.reprocessed());
+        assertEquals("Dead letter entry is already resolved", response.message());
+        verify(reprocessingPort, never()).reprocess(entry);
+    }
+
+    @Test
+    void reprocessShouldReturnFailureWhenEntryIsNotSupported() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
+        DeadLetterEntry entry = newEntry(UUID.randomUUID(), UUID.randomUUID(), "client-6");
+        when(repository.findById(entry.getId())).thenReturn(Optional.of(entry));
+        when(reprocessingPort.supports(entry)).thenReturn(false);
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
+
+        ReprocessDeadLetterResponse response = useCase.reprocess(entry.getId(), "operator@test", "retry capital flow");
+
+        assertFalse(response.reprocessed());
+        assertEquals("Dead letter entry cannot be reprocessed automatically", response.message());
+        verify(reprocessingPort, never()).reprocess(entry);
+    }
+
+    @Test
+    void reprocessShouldRejectBlankRequester() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
+
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> useCase.reprocess(UUID.randomUUID(), " ", "retry capital flow")
+        );
+
+        assertEquals("requestedBy cannot be blank", error.getMessage());
     }
 
     private static DeadLetterEntry newEntry(UUID portfolioId, UUID runnerId, String clientOrderId) {
@@ -129,6 +221,17 @@ class ManageDeadLetterUseCaseTest {
                 "EX_" + clientOrderId,
                 "{\"source\":\"test\"}",
                 DlqReason.RECONCILIATION_CONFLICT
+        );
+    }
+
+    private static DeadLetterEntry newRetryExhaustedEntry(UUID portfolioId, UUID runnerId, String clientOrderId) {
+        return new DeadLetterEntry(
+                portfolioId,
+                runnerId,
+                clientOrderId,
+                "EX_" + clientOrderId,
+                "{\"eventType\":\"MARGIN_RELEASE\"}",
+                DlqReason.RETRY_EXHAUSTED
         );
     }
 }

--- a/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
@@ -2,6 +2,7 @@ package com.marmitt.core.application.usecase.portfolio;
 
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
 import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.DeadLetterReprocessingResult;
 import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
 import com.marmitt.core.enums.DlqReason;
@@ -137,6 +138,7 @@ class ManageDeadLetterUseCaseTest {
         DeadLetterEntry entry = newRetryExhaustedEntry(UUID.randomUUID(), UUID.randomUUID(), "client-4");
         when(repository.findById(entry.getId())).thenReturn(Optional.of(entry));
         when(reprocessingPort.supports(entry)).thenReturn(true);
+        when(reprocessingPort.reprocess(entry)).thenReturn(DeadLetterReprocessingResult.applied("Replay applied"));
 
         ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
@@ -197,6 +199,26 @@ class ManageDeadLetterUseCaseTest {
         assertFalse(response.reprocessed());
         assertEquals("Dead letter entry cannot be reprocessed automatically", response.message());
         verify(reprocessingPort, never()).reprocess(entry);
+    }
+
+    @Test
+    void reprocessShouldReturnFailureWhenReplayProducesNoStateChange() {
+        DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
+        DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
+        DeadLetterEntry entry = newRetryExhaustedEntry(UUID.randomUUID(), UUID.randomUUID(), "client-7");
+        when(repository.findById(entry.getId())).thenReturn(Optional.of(entry));
+        when(reprocessingPort.supports(entry)).thenReturn(true);
+        when(reprocessingPort.reprocess(entry)).thenReturn(
+                DeadLetterReprocessingResult.notApplied("Dead letter replay produced no state change and requires manual review")
+        );
+
+        ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
+
+        ReprocessDeadLetterResponse response = useCase.reprocess(entry.getId(), "operator@test", "retry capital flow");
+
+        assertFalse(response.reprocessed());
+        assertEquals("Dead letter replay produced no state change and requires manual review", response.message());
+        verify(repository, never()).save(entry);
     }
 
     @Test

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -125,6 +125,6 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Concluir o PR 2 da Fase 4 com DLQ operacional no boot (abertura e nao duplicacao).
-2. Avancar para resolucao/reprocessamento operacional da DLQ e continuidade da observabilidade de boot/recovery.
+1. Concluir o PR 4 da Fase 4 com reprocessamento seguro de DLQ para eventos de capital com retries esgotados.
+2. Avancar para os proximos blocos de resiliencia operacional e continuidade da observabilidade de boot/recovery.
 3. Atualizar este checklist a cada fase concluida do Testing Roadmap.

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -503,7 +503,9 @@ Fora de escopo da Fase 4:
 ### Fase 4 em progresso
 
 1. PR 1 (concluido): observabilidade do boot validada por teste cobrindo evento de fail-fast e metricas minimas por fase/resultado.
-2. PR 2 (atual): DLQ operacional no boot cobrindo abertura de entry e nao duplicacao da mesma identidade do problema.
+2. PR 2 (concluido): DLQ operacional no boot cobrindo abertura de entry e nao duplicacao da mesma identidade do problema.
+3. PR 3 (concluido): gestao manual da DLQ cobrindo listagem e resolucao via use case/controller.
+4. PR 4 (atual): reprocessamento seguro de DLQ para eventos de capital com retries esgotados.
 
 ## Backlog Pos-Testes
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/PortfolioConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/PortfolioConfig.java
@@ -1,5 +1,6 @@
 package com.marmitt.application.spring.config.core;
 
+import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import com.marmitt.core.application.usecase.portfolio.CreatePortfolioUseCase;
 import com.marmitt.core.application.usecase.portfolio.ManageDeadLetterUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
@@ -71,8 +72,9 @@ public class PortfolioConfig {
 
     @Bean
     public ManageDeadLetterPort manageDeadLetter(
-            DeadLetterEntryRepositoryPort deadLetterEntryRepository
+            DeadLetterEntryRepositoryPort deadLetterEntryRepository,
+            DeadLetterReprocessingPort deadLetterReprocessingPort
     ) {
-        return new ManageDeadLetterUseCase(deadLetterEntryRepository);
+        return new ManageDeadLetterUseCase(deadLetterEntryRepository, deadLetterReprocessingPort);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/PortfolioConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/PortfolioConfig.java
@@ -1,5 +1,6 @@
 package com.marmitt.application.spring.config.core;
 
+import com.marmitt.application.spring.service.TransactionalManageDeadLetterPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import com.marmitt.core.application.usecase.portfolio.CreatePortfolioUseCase;
 import com.marmitt.core.application.usecase.portfolio.ManageDeadLetterUseCase;
@@ -71,10 +72,17 @@ public class PortfolioConfig {
     }
 
     @Bean
-    public ManageDeadLetterPort manageDeadLetter(
+    public ManageDeadLetterUseCase manageDeadLetterUseCase(
             DeadLetterEntryRepositoryPort deadLetterEntryRepository,
             DeadLetterReprocessingPort deadLetterReprocessingPort
     ) {
         return new ManageDeadLetterUseCase(deadLetterEntryRepository, deadLetterReprocessingPort);
+    }
+
+    @Bean
+    public ManageDeadLetterPort manageDeadLetter(
+            ManageDeadLetterUseCase manageDeadLetterUseCase
+    ) {
+        return new TransactionalManageDeadLetterPort(manageDeadLetterUseCase);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/DeadLetterController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/DeadLetterController.java
@@ -1,6 +1,8 @@
 package com.marmitt.application.spring.controller;
 
 import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.ReprocessDeadLetterRequest;
+import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.ResolveDeadLetterRequest;
 import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
@@ -67,6 +69,36 @@ public class DeadLetterController {
             log.error("deadLetter: unexpected error resolving id={}", id, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(ResolveDeadLetterResponse.failure(id, "Internal server error: " + e.getMessage()));
+        }
+    }
+
+    @PostMapping("/{id}/reprocess")
+    public ResponseEntity<ReprocessDeadLetterResponse> reprocess(
+            @PathVariable UUID id,
+            @Valid @RequestBody ReprocessDeadLetterRequest request
+    ) {
+        try {
+            ReprocessDeadLetterResponse response = manageDeadLetter.reprocess(
+                    id,
+                    request.requestedBy(),
+                    request.resolutionNote()
+            );
+
+            if (response.reprocessed()) {
+                return ResponseEntity.ok(response);
+            }
+            if (response.message() != null && response.message().toLowerCase().contains("not found")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+            }
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("deadLetter: invalid reprocess request id={} reason={}", id, e.getMessage());
+            return ResponseEntity.badRequest()
+                    .body(ReprocessDeadLetterResponse.failure(id, "Invalid request: " + e.getMessage()));
+        } catch (Exception e) {
+            log.error("deadLetter: unexpected error reprocessing id={}", id, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ReprocessDeadLetterResponse.failure(id, "Internal server error: " + e.getMessage()));
         }
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterPayload.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterPayload.java
@@ -1,0 +1,29 @@
+package com.marmitt.application.spring.deadletter;
+
+import com.marmitt.core.enums.FeeType;
+import com.marmitt.core.enums.ReleaseReason;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+record CapitalDeadLetterPayload(
+        String eventType,
+        UUID runnerId,
+        UUID transactionId,
+        UUID matchId,
+        BigDecimal executedQuantity,
+        BigDecimal executedPrice,
+        BigDecimal feeAmount,
+        String feeAsset,
+        FeeType feeType,
+        BigDecimal feeConvertedAmount,
+        BigDecimal totalCost,
+        BigDecimal pnlRealized,
+        Boolean isFinal,
+        BigDecimal releaseAmount,
+        ReleaseReason reason,
+        BigDecimal executedAmount,
+        String failureType,
+        String failureMessage
+) {
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterPayloadCodec.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterPayloadCodec.java
@@ -7,6 +7,7 @@ import com.marmitt.core.dto.capital.ExecutionConfirmation;
 import com.marmitt.core.dto.capital.MarginRelease;
 import com.marmitt.core.dto.events.ExecutionConfirmedEvent;
 import com.marmitt.core.dto.events.MarginReleaseEvent;
+import com.marmitt.core.dto.portfolio.CapitalDeadLetterPayload;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterPayloadCodec.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterPayloadCodec.java
@@ -1,0 +1,133 @@
+package com.marmitt.application.spring.deadletter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.domain.shared.Fee;
+import com.marmitt.core.dto.capital.ExecutionConfirmation;
+import com.marmitt.core.dto.capital.MarginRelease;
+import com.marmitt.core.dto.events.ExecutionConfirmedEvent;
+import com.marmitt.core.dto.events.MarginReleaseEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CapitalDeadLetterPayloadCodec {
+
+    private static final String EXECUTION_CONFIRMED = "EXECUTION_CONFIRMED";
+    private static final String MARGIN_RELEASE = "MARGIN_RELEASE";
+
+    private final ObjectMapper objectMapper;
+
+    public CapitalDeadLetterPayloadCodec(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public String encodeExecutionConfirmed(ExecutionConfirmedEvent event, Exception failure) {
+        ExecutionConfirmation confirmation = event.confirmation();
+        return write(new CapitalDeadLetterPayload(
+                EXECUTION_CONFIRMED,
+                confirmation.runnerId(),
+                confirmation.transactionId(),
+                confirmation.matchId(),
+                confirmation.executedQuantity(),
+                confirmation.executedPrice(),
+                confirmation.fee().amount(),
+                confirmation.fee().asset(),
+                confirmation.fee().type(),
+                confirmation.fee().convertedAmount(),
+                confirmation.totalCost(),
+                confirmation.pnlRealized(),
+                confirmation.isFinal(),
+                null,
+                null,
+                null,
+                failure.getClass().getSimpleName(),
+                safeMessage(failure)
+        ));
+    }
+
+    public String encodeMarginRelease(MarginReleaseEvent event, Exception failure) {
+        MarginRelease release = event.release();
+        return write(new CapitalDeadLetterPayload(
+                MARGIN_RELEASE,
+                release.runnerId(),
+                release.transactionId(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                release.releaseAmount(),
+                release.reason(),
+                release.executedAmount(),
+                failure.getClass().getSimpleName(),
+                safeMessage(failure)
+        ));
+    }
+
+    public CapitalDeadLetterPayload decode(String rawPayload) {
+        try {
+            return objectMapper.readValue(rawPayload, CapitalDeadLetterPayload.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Invalid capital DLQ payload", e);
+        }
+    }
+
+    public boolean isExecutionConfirmed(CapitalDeadLetterPayload payload) {
+        return EXECUTION_CONFIRMED.equals(payload.eventType());
+    }
+
+    public boolean isMarginRelease(CapitalDeadLetterPayload payload) {
+        return MARGIN_RELEASE.equals(payload.eventType());
+    }
+
+    public ExecutionConfirmedEvent toExecutionConfirmedEvent(CapitalDeadLetterPayload payload) {
+        return new ExecutionConfirmedEvent(new ExecutionConfirmation(
+                payload.transactionId(),
+                payload.runnerId(),
+                payload.matchId(),
+                payload.executedQuantity(),
+                payload.executedPrice(),
+                toFee(payload),
+                payload.totalCost(),
+                payload.pnlRealized(),
+                Boolean.TRUE.equals(payload.isFinal())
+        ));
+    }
+
+    public MarginReleaseEvent toMarginReleaseEvent(CapitalDeadLetterPayload payload) {
+        return new MarginReleaseEvent(new MarginRelease(
+                payload.transactionId(),
+                payload.runnerId(),
+                payload.releaseAmount(),
+                payload.reason(),
+                payload.executedAmount()
+        ));
+    }
+
+    private Fee toFee(CapitalDeadLetterPayload payload) {
+        if (payload.feeAsset() == null || payload.feeType() == null) {
+            return Fee.zero("USDT");
+        }
+        if (payload.feeConvertedAmount() == null) {
+            return Fee.pendingConversion(payload.feeAmount(), payload.feeAsset(), payload.feeType());
+        }
+        return new Fee(payload.feeAmount(), payload.feeAsset(), payload.feeType(), payload.feeConvertedAmount());
+    }
+
+    private String write(CapitalDeadLetterPayload payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize capital DLQ payload", e);
+        }
+    }
+
+    private static String safeMessage(Throwable throwable) {
+        return throwable.getMessage() != null ? throwable.getMessage() : "<no-message>";
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapter.java
@@ -3,6 +3,7 @@ package com.marmitt.application.spring.deadletter;
 import com.marmitt.core.application.reaction.ExecutionConfirmedReaction;
 import com.marmitt.core.application.reaction.MarginReleasedReaction;
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.dto.portfolio.CapitalDeadLetterPayload;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import org.springframework.stereotype.Component;

--- a/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapter.java
@@ -3,9 +3,15 @@ package com.marmitt.application.spring.deadletter;
 import com.marmitt.core.application.reaction.ExecutionConfirmedReaction;
 import com.marmitt.core.application.reaction.MarginReleasedReaction;
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.domain.portfolio.GlobalBalance;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.dto.events.MarginReleaseEvent;
+import com.marmitt.core.dto.portfolio.DeadLetterReprocessingResult;
 import com.marmitt.core.dto.portfolio.CapitalDeadLetterPayload;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
+import com.marmitt.core.ports.outbound.repository.GlobalBalanceRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,13 +20,19 @@ public class CapitalDeadLetterReprocessingAdapter implements DeadLetterReprocess
     private final ExecutionConfirmedReaction executionConfirmedReaction;
     private final MarginReleasedReaction marginReleasedReaction;
     private final CapitalDeadLetterPayloadCodec payloadCodec;
+    private final StrategyRunnerRepositoryPort runnerRepository;
+    private final GlobalBalanceRepositoryPort globalBalanceRepository;
 
     public CapitalDeadLetterReprocessingAdapter(ExecutionConfirmedReaction executionConfirmedReaction,
                                                 MarginReleasedReaction marginReleasedReaction,
-                                                CapitalDeadLetterPayloadCodec payloadCodec) {
+                                                CapitalDeadLetterPayloadCodec payloadCodec,
+                                                StrategyRunnerRepositoryPort runnerRepository,
+                                                GlobalBalanceRepositoryPort globalBalanceRepository) {
         this.executionConfirmedReaction = executionConfirmedReaction;
         this.marginReleasedReaction = marginReleasedReaction;
         this.payloadCodec = payloadCodec;
+        this.runnerRepository = runnerRepository;
+        this.globalBalanceRepository = globalBalanceRepository;
     }
 
     @Override
@@ -31,23 +43,48 @@ public class CapitalDeadLetterReprocessingAdapter implements DeadLetterReprocess
 
         try {
             CapitalDeadLetterPayload payload = payloadCodec.decode(entry.getRawPayload());
-            return payloadCodec.isExecutionConfirmed(payload) || payloadCodec.isMarginRelease(payload);
-        } catch (IllegalArgumentException e) {
+            if (payloadCodec.isExecutionConfirmed(payload)) {
+                payloadCodec.toExecutionConfirmedEvent(payload);
+                return true;
+            }
+            if (payloadCodec.isMarginRelease(payload)) {
+                payloadCodec.toMarginReleaseEvent(payload);
+                return true;
+            }
+            return false;
+        } catch (RuntimeException e) {
             return false;
         }
     }
 
     @Override
-    public void reprocess(DeadLetterEntry entry) {
+    public DeadLetterReprocessingResult reprocess(DeadLetterEntry entry) {
         CapitalDeadLetterPayload payload = payloadCodec.decode(entry.getRawPayload());
         if (payloadCodec.isExecutionConfirmed(payload)) {
             executionConfirmedReaction.handle(payloadCodec.toExecutionConfirmedEvent(payload));
-            return;
+            return DeadLetterReprocessingResult.applied("Execution confirmed replay applied");
         }
         if (payloadCodec.isMarginRelease(payload)) {
-            marginReleasedReaction.handle(payloadCodec.toMarginReleaseEvent(payload));
-            return;
+            MarginReleaseEvent replay = payloadCodec.toMarginReleaseEvent(payload);
+            if (!canApplyMarginRelease(replay)) {
+                return DeadLetterReprocessingResult.notApplied(
+                        "Dead letter replay produced no state change and requires manual review"
+                );
+            }
+            marginReleasedReaction.handle(replay);
+            return DeadLetterReprocessingResult.applied("Margin release replay applied");
         }
         throw new IllegalArgumentException("Unsupported capital DLQ payload eventType=" + payload.eventType());
+    }
+
+    private boolean canApplyMarginRelease(MarginReleaseEvent event) {
+        StrategyRunner runner = runnerRepository.findById(event.release().runnerId())
+                .orElseThrow(() -> new IllegalStateException("Runner not found: " + event.release().runnerId()));
+
+        GlobalBalance balance = globalBalanceRepository.findByPortfolioId(runner.getPortfolioId())
+                .orElseThrow(() -> new IllegalStateException(
+                        "GlobalBalance not found for portfolio: " + runner.getPortfolioId()));
+
+        return balance.getReservedBalance().compareTo(event.release().releaseAmount()) >= 0;
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapter.java
@@ -1,0 +1,52 @@
+package com.marmitt.application.spring.deadletter;
+
+import com.marmitt.core.application.reaction.ExecutionConfirmedReaction;
+import com.marmitt.core.application.reaction.MarginReleasedReaction;
+import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CapitalDeadLetterReprocessingAdapter implements DeadLetterReprocessingPort {
+
+    private final ExecutionConfirmedReaction executionConfirmedReaction;
+    private final MarginReleasedReaction marginReleasedReaction;
+    private final CapitalDeadLetterPayloadCodec payloadCodec;
+
+    public CapitalDeadLetterReprocessingAdapter(ExecutionConfirmedReaction executionConfirmedReaction,
+                                                MarginReleasedReaction marginReleasedReaction,
+                                                CapitalDeadLetterPayloadCodec payloadCodec) {
+        this.executionConfirmedReaction = executionConfirmedReaction;
+        this.marginReleasedReaction = marginReleasedReaction;
+        this.payloadCodec = payloadCodec;
+    }
+
+    @Override
+    public boolean supports(DeadLetterEntry entry) {
+        if (entry.getReason() != DlqReason.RETRY_EXHAUSTED) {
+            return false;
+        }
+
+        try {
+            CapitalDeadLetterPayload payload = payloadCodec.decode(entry.getRawPayload());
+            return payloadCodec.isExecutionConfirmed(payload) || payloadCodec.isMarginRelease(payload);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void reprocess(DeadLetterEntry entry) {
+        CapitalDeadLetterPayload payload = payloadCodec.decode(entry.getRawPayload());
+        if (payloadCodec.isExecutionConfirmed(payload)) {
+            executionConfirmedReaction.handle(payloadCodec.toExecutionConfirmedEvent(payload));
+            return;
+        }
+        if (payloadCodec.isMarginRelease(payload)) {
+            marginReleasedReaction.handle(payloadCodec.toMarginReleaseEvent(payload));
+            return;
+        }
+        throw new IllegalArgumentException("Unsupported capital DLQ payload eventType=" + payload.eventType());
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/handler/CapitalEventListener.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/handler/CapitalEventListener.java
@@ -1,5 +1,6 @@
 package com.marmitt.application.spring.handler;
 
+import com.marmitt.application.spring.deadletter.CapitalDeadLetterPayloadCodec;
 import com.marmitt.core.application.reaction.ExecutionConfirmedReaction;
 import com.marmitt.core.application.reaction.MarginReleasedReaction;
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
@@ -38,17 +39,20 @@ public class CapitalEventListener {
     private final MarginReleasedReaction handleMarginRelease;
     private final StrategyRunnerRepositoryPort strategyRunnerRepository;
     private final DeadLetterEntryRepositoryPort deadLetterEntryRepository;
+    private final CapitalDeadLetterPayloadCodec payloadCodec;
 
     public CapitalEventListener(
             ExecutionConfirmedReaction handleExecutionConfirmed,
             MarginReleasedReaction handleMarginRelease,
             StrategyRunnerRepositoryPort strategyRunnerRepository,
-            DeadLetterEntryRepositoryPort deadLetterEntryRepository
+            DeadLetterEntryRepositoryPort deadLetterEntryRepository,
+            CapitalDeadLetterPayloadCodec payloadCodec
     ) {
         this.handleExecutionConfirmed = handleExecutionConfirmed;
         this.handleMarginRelease = handleMarginRelease;
         this.strategyRunnerRepository = strategyRunnerRepository;
         this.deadLetterEntryRepository = deadLetterEntryRepository;
+        this.payloadCodec = payloadCodec;
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -77,15 +81,7 @@ public class CapitalEventListener {
 
     @Recover
     public void recoverExecutionConfirmed(Exception ex, ExecutionConfirmedEvent event) {
-        String rawPayload = "event=EXECUTION_CONFIRMED"
-                + ", runnerId=" + event.confirmation().runnerId()
-                + ", transactionId=" + event.confirmation().transactionId()
-                + ", matchId=" + event.confirmation().matchId()
-                + ", totalCost=" + event.confirmation().totalCost()
-                + ", pnlRealized=" + event.confirmation().pnlRealized()
-                + ", isFinal=" + event.confirmation().isFinal()
-                + ", failure=" + ex.getClass().getSimpleName() + ":" + safeMessage(ex);
-
+        String rawPayload = payloadCodec.encodeExecutionConfirmed(event, ex);
         persistCapitalDlq("EXECUTION_CONFIRMED", event.confirmation().runnerId(), rawPayload, ex);
     }
 
@@ -115,13 +111,7 @@ public class CapitalEventListener {
 
     @Recover
     public void recoverMarginRelease(Exception ex, MarginReleaseEvent event) {
-        String rawPayload = "event=MARGIN_RELEASE"
-                + ", runnerId=" + event.release().runnerId()
-                + ", transactionId=" + event.release().transactionId()
-                + ", releaseAmount=" + event.release().releaseAmount()
-                + ", reason=" + event.release().reason()
-                + ", failure=" + ex.getClass().getSimpleName() + ":" + safeMessage(ex);
-
+        String rawPayload = payloadCodec.encodeMarginRelease(event, ex);
         persistCapitalDlq("MARGIN_RELEASE", event.release().runnerId(), rawPayload, ex);
     }
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/service/TransactionalManageDeadLetterPort.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/service/TransactionalManageDeadLetterPort.java
@@ -1,0 +1,38 @@
+package com.marmitt.application.spring.service;
+
+import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
+import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+public class TransactionalManageDeadLetterPort implements ManageDeadLetterPort {
+
+    private final ManageDeadLetterPort delegate;
+
+    public TransactionalManageDeadLetterPort(ManageDeadLetterPort delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DeadLetterEntryDto> listUnresolved(UUID portfolioId, UUID runnerId, int limit) {
+        return delegate.listUnresolved(portfolioId, runnerId, limit);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ResolveDeadLetterResponse resolve(UUID deadLetterId, String resolvedBy, String resolutionNote) {
+        return delegate.resolve(deadLetterId, resolvedBy, resolutionNote);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ReprocessDeadLetterResponse reprocess(UUID deadLetterId, String requestedBy, String resolutionNote) {
+        return delegate.reprocess(deadLetterId, requestedBy, resolutionNote);
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java
@@ -1,6 +1,7 @@
 package com.marmitt.application.spring.controller;
 
 import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
@@ -156,5 +157,89 @@ class DeadLetterControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.resolved").value(false))
                 .andExpect(jsonPath("$.message").value("Invalid request: resolvedBy cannot be blank"));
+    }
+
+    @Test
+    void reprocessShouldReturnOkWhenEntryIsReprocessed() throws Exception {
+        UUID deadLetterId = UUID.randomUUID();
+        UUID portfolioId = UUID.randomUUID();
+        UUID runnerId = UUID.randomUUID();
+        DeadLetterEntryDto entry = newEntry(deadLetterId, portfolioId, runnerId, true, "operator@test");
+        when(manageDeadLetter.reprocess(deadLetterId, "operator@test", "retry capital flow"))
+                .thenReturn(ReprocessDeadLetterResponse.success(entry, "Dead letter entry reprocessed successfully"));
+
+        mockMvc.perform(post("/api/dead-letters/{id}/reprocess", deadLetterId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "requestedBy": "operator@test",
+                                  "resolutionNote": "retry capital flow"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reprocessed").value(true))
+                .andExpect(jsonPath("$.deadLetterId").value(deadLetterId.toString()))
+                .andExpect(jsonPath("$.entry.resolvedBy").value("operator@test"));
+    }
+
+    @Test
+    void reprocessShouldReturnConflictWhenEntryCannotBeReprocessedAutomatically() throws Exception {
+        UUID deadLetterId = UUID.randomUUID();
+        when(manageDeadLetter.reprocess(deadLetterId, "operator@test", "retry capital flow"))
+                .thenReturn(ReprocessDeadLetterResponse.failure(
+                        deadLetterId,
+                        "Dead letter entry cannot be reprocessed automatically"
+                ));
+
+        mockMvc.perform(post("/api/dead-letters/{id}/reprocess", deadLetterId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "requestedBy": "operator@test",
+                                  "resolutionNote": "retry capital flow"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.reprocessed").value(false))
+                .andExpect(jsonPath("$.message").value("Dead letter entry cannot be reprocessed automatically"));
+    }
+
+    @Test
+    void reprocessShouldReturnBadRequestWhenUseCaseRejectsInput() throws Exception {
+        UUID deadLetterId = UUID.randomUUID();
+        when(manageDeadLetter.reprocess(deadLetterId, "", "retry capital flow"))
+                .thenThrow(new IllegalArgumentException("requestedBy cannot be blank"));
+
+        mockMvc.perform(post("/api/dead-letters/{id}/reprocess", deadLetterId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "requestedBy": "",
+                                  "resolutionNote": "retry capital flow"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.reprocessed").value(false))
+                .andExpect(jsonPath("$.message").value("Invalid request: requestedBy cannot be blank"));
+    }
+
+    private static DeadLetterEntryDto newEntry(UUID deadLetterId,
+                                               UUID portfolioId,
+                                               UUID runnerId,
+                                               boolean resolved,
+                                               String resolvedBy) {
+        return new DeadLetterEntryDto(
+                deadLetterId,
+                portfolioId,
+                runnerId,
+                "client-1",
+                "EX_1",
+                "{\"source\":\"test\"}",
+                DlqReason.RECONCILIATION_CONFLICT,
+                resolved,
+                resolvedBy,
+                resolved ? Instant.parse("2026-04-25T12:10:00Z") : null,
+                Instant.parse("2026-04-25T12:00:00Z")
+        );
     }
 }

--- a/spring-application/src/test/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapterTest.java
@@ -3,31 +3,46 @@ package com.marmitt.application.spring.deadletter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marmitt.core.application.reaction.ExecutionConfirmedReaction;
 import com.marmitt.core.application.reaction.MarginReleasedReaction;
+import com.marmitt.core.domain.portfolio.GlobalBalance;
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.shared.Fee;
 import com.marmitt.core.dto.capital.ExecutionConfirmation;
 import com.marmitt.core.dto.capital.MarginRelease;
+import com.marmitt.core.dto.portfolio.DeadLetterReprocessingResult;
+import com.marmitt.core.enums.AccountingPolicyType;
 import com.marmitt.core.dto.events.ExecutionConfirmedEvent;
 import com.marmitt.core.dto.events.MarginReleaseEvent;
 import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.enums.ExecutionPolicy;
 import com.marmitt.core.enums.ReleaseReason;
+import com.marmitt.core.enums.RunnerStatus;
+import com.marmitt.core.ports.outbound.repository.GlobalBalanceRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class CapitalDeadLetterReprocessingAdapterTest {
 
     private final ExecutionConfirmedReaction executionReaction = mock(ExecutionConfirmedReaction.class);
     private final MarginReleasedReaction marginReaction = mock(MarginReleasedReaction.class);
+    private final StrategyRunnerRepositoryPort runnerRepository = mock(StrategyRunnerRepositoryPort.class);
+    private final GlobalBalanceRepositoryPort globalBalanceRepository = mock(GlobalBalanceRepositoryPort.class);
     private final CapitalDeadLetterPayloadCodec codec = new CapitalDeadLetterPayloadCodec(new ObjectMapper());
 
     @Test
@@ -35,7 +50,9 @@ class CapitalDeadLetterReprocessingAdapterTest {
         CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
                 executionReaction,
                 marginReaction,
-                codec
+                codec,
+                runnerRepository,
+                globalBalanceRepository
         );
         DeadLetterEntry entry = new DeadLetterEntry(
                 UUID.randomUUID(),
@@ -54,7 +71,9 @@ class CapitalDeadLetterReprocessingAdapterTest {
         CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
                 executionReaction,
                 marginReaction,
-                codec
+                codec,
+                runnerRepository,
+                globalBalanceRepository
         );
         DeadLetterEntry entry = new DeadLetterEntry(
                 UUID.randomUUID(),
@@ -73,7 +92,9 @@ class CapitalDeadLetterReprocessingAdapterTest {
         CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
                 executionReaction,
                 marginReaction,
-                codec
+                codec,
+                runnerRepository,
+                globalBalanceRepository
         );
         ExecutionConfirmedEvent original = executionEvent();
         DeadLetterEntry entry = new DeadLetterEntry(
@@ -85,11 +106,12 @@ class CapitalDeadLetterReprocessingAdapterTest {
                 DlqReason.RETRY_EXHAUSTED
         );
 
-        adapter.reprocess(entry);
+        DeadLetterReprocessingResult result = adapter.reprocess(entry);
 
         ArgumentCaptor<ExecutionConfirmedEvent> captor = ArgumentCaptor.forClass(ExecutionConfirmedEvent.class);
         verify(executionReaction).handle(captor.capture());
         verifyNoInteractions(marginReaction);
+        assertTrue(result.applied());
         ExecutionConfirmedEvent replayed = captor.getValue();
         assertTrue(replayed.confirmation().transactionId().equals(original.confirmation().transactionId()));
         assertTrue(replayed.confirmation().matchId().equals(original.confirmation().matchId()));
@@ -101,9 +123,16 @@ class CapitalDeadLetterReprocessingAdapterTest {
         CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
                 executionReaction,
                 marginReaction,
-                codec
+                codec,
+                runnerRepository,
+                globalBalanceRepository
         );
         MarginReleaseEvent original = marginEvent();
+        UUID portfolioId = UUID.randomUUID();
+        when(runnerRepository.findById(original.release().runnerId()))
+                .thenReturn(Optional.of(activeRunner(portfolioId, original.release().runnerId())));
+        when(globalBalanceRepository.findByPortfolioId(portfolioId))
+                .thenReturn(Optional.of(balanceWithReserved(portfolioId, new BigDecimal("1000.00"))));
         DeadLetterEntry entry = new DeadLetterEntry(
                 UUID.randomUUID(),
                 UUID.randomUUID(),
@@ -113,15 +142,69 @@ class CapitalDeadLetterReprocessingAdapterTest {
                 DlqReason.RETRY_EXHAUSTED
         );
 
-        adapter.reprocess(entry);
+        DeadLetterReprocessingResult result = adapter.reprocess(entry);
 
         ArgumentCaptor<MarginReleaseEvent> captor = ArgumentCaptor.forClass(MarginReleaseEvent.class);
         verify(marginReaction).handle(captor.capture());
         verifyNoInteractions(executionReaction);
+        assertTrue(result.applied());
         MarginReleaseEvent replayed = captor.getValue();
         assertTrue(replayed.release().transactionId().equals(original.release().transactionId()));
         assertTrue(replayed.release().releaseAmount().compareTo(original.release().releaseAmount()) == 0);
         assertTrue(replayed.release().executedAmount().compareTo(original.release().executedAmount()) == 0);
+    }
+
+    @Test
+    void supportsShouldReturnFalseForMalformedRecognizedPayload() {
+        CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
+                executionReaction,
+                marginReaction,
+                codec,
+                runnerRepository,
+                globalBalanceRepository
+        );
+        DeadLetterEntry entry = new DeadLetterEntry(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                null,
+                "{\"eventType\":\"MARGIN_RELEASE\",\"runnerId\":null}",
+                DlqReason.RETRY_EXHAUSTED
+        );
+
+        assertFalse(adapter.supports(entry));
+    }
+
+    @Test
+    void reprocessShouldReturnNotAppliedWhenMarginReplayWouldBeSkipped() {
+        CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
+                executionReaction,
+                marginReaction,
+                codec,
+                runnerRepository,
+                globalBalanceRepository
+        );
+        MarginReleaseEvent original = marginEvent();
+        UUID portfolioId = UUID.randomUUID();
+        when(runnerRepository.findById(original.release().runnerId()))
+                .thenReturn(Optional.of(activeRunner(portfolioId, original.release().runnerId())));
+        when(globalBalanceRepository.findByPortfolioId(portfolioId))
+                .thenReturn(Optional.of(balanceWithReserved(portfolioId, new BigDecimal("10.00"))));
+        DeadLetterEntry entry = new DeadLetterEntry(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                null,
+                codec.encodeMarginRelease(original, new RuntimeException("temporary failure")),
+                DlqReason.RETRY_EXHAUSTED
+        );
+
+        DeadLetterReprocessingResult result = adapter.reprocess(entry);
+
+        assertFalse(result.applied());
+        assertEquals("Dead letter replay produced no state change and requires manual review", result.message());
+        verifyNoInteractions(marginReaction);
+        verifyNoInteractions(executionReaction);
     }
 
     private static ExecutionConfirmedEvent executionEvent() {
@@ -146,5 +229,45 @@ class CapitalDeadLetterReprocessingAdapterTest {
                 ReleaseReason.CANCELED,
                 new BigDecimal("120.00")
         ));
+    }
+
+    private static StrategyRunner activeRunner(UUID portfolioId, UUID runnerId) {
+        return new StrategyRunner(
+                runnerId,
+                portfolioId,
+                "x1",
+                UUID.randomUUID(),
+                "SimpleMovingAverage",
+                "BTCUSDT",
+                "MOCK",
+                Set.of("MOCK"),
+                RunnerStatus.ACTIVE,
+                ExecutionPolicy.SINGLE,
+                AccountingPolicyType.FIFO,
+                new BigDecimal("0.25"),
+                1,
+                1,
+                null,
+                false,
+                Instant.now(),
+                null,
+                null,
+                0L
+        );
+    }
+
+    private static GlobalBalance balanceWithReserved(UUID portfolioId, BigDecimal reserved) {
+        return new GlobalBalance(
+                portfolioId,
+                new BigDecimal("1000.00"),
+                reserved,
+                BigDecimal.ZERO,
+                new BigDecimal("1000.00"),
+                "USDT",
+                BigDecimal.ZERO,
+                null,
+                Instant.now(),
+                0L
+        );
     }
 }

--- a/spring-application/src/test/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapterTest.java
@@ -1,0 +1,150 @@
+package com.marmitt.application.spring.deadletter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.application.reaction.ExecutionConfirmedReaction;
+import com.marmitt.core.application.reaction.MarginReleasedReaction;
+import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.domain.shared.Fee;
+import com.marmitt.core.dto.capital.ExecutionConfirmation;
+import com.marmitt.core.dto.capital.MarginRelease;
+import com.marmitt.core.dto.events.ExecutionConfirmedEvent;
+import com.marmitt.core.dto.events.MarginReleaseEvent;
+import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.enums.ReleaseReason;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class CapitalDeadLetterReprocessingAdapterTest {
+
+    private final ExecutionConfirmedReaction executionReaction = mock(ExecutionConfirmedReaction.class);
+    private final MarginReleasedReaction marginReaction = mock(MarginReleasedReaction.class);
+    private final CapitalDeadLetterPayloadCodec codec = new CapitalDeadLetterPayloadCodec(new ObjectMapper());
+
+    @Test
+    void supportsShouldReturnTrueForRetryExhaustedExecutionPayload() {
+        CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
+                executionReaction,
+                marginReaction,
+                codec
+        );
+        DeadLetterEntry entry = new DeadLetterEntry(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                null,
+                codec.encodeExecutionConfirmed(executionEvent(), new RuntimeException("temporary failure")),
+                DlqReason.RETRY_EXHAUSTED
+        );
+
+        assertTrue(adapter.supports(entry));
+    }
+
+    @Test
+    void supportsShouldReturnFalseForUnsupportedReason() {
+        CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
+                executionReaction,
+                marginReaction,
+                codec
+        );
+        DeadLetterEntry entry = new DeadLetterEntry(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                null,
+                codec.encodeExecutionConfirmed(executionEvent(), new RuntimeException("temporary failure")),
+                DlqReason.RECONCILIATION_CONFLICT
+        );
+
+        assertFalse(adapter.supports(entry));
+    }
+
+    @Test
+    void reprocessShouldDispatchExecutionPayloadToExecutionReaction() {
+        CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
+                executionReaction,
+                marginReaction,
+                codec
+        );
+        ExecutionConfirmedEvent original = executionEvent();
+        DeadLetterEntry entry = new DeadLetterEntry(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                null,
+                codec.encodeExecutionConfirmed(original, new RuntimeException("temporary failure")),
+                DlqReason.RETRY_EXHAUSTED
+        );
+
+        adapter.reprocess(entry);
+
+        ArgumentCaptor<ExecutionConfirmedEvent> captor = ArgumentCaptor.forClass(ExecutionConfirmedEvent.class);
+        verify(executionReaction).handle(captor.capture());
+        verifyNoInteractions(marginReaction);
+        ExecutionConfirmedEvent replayed = captor.getValue();
+        assertTrue(replayed.confirmation().transactionId().equals(original.confirmation().transactionId()));
+        assertTrue(replayed.confirmation().matchId().equals(original.confirmation().matchId()));
+        assertTrue(replayed.confirmation().totalCost().compareTo(original.confirmation().totalCost()) == 0);
+    }
+
+    @Test
+    void reprocessShouldDispatchMarginPayloadToMarginReaction() {
+        CapitalDeadLetterReprocessingAdapter adapter = new CapitalDeadLetterReprocessingAdapter(
+                executionReaction,
+                marginReaction,
+                codec
+        );
+        MarginReleaseEvent original = marginEvent();
+        DeadLetterEntry entry = new DeadLetterEntry(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                null,
+                codec.encodeMarginRelease(original, new RuntimeException("temporary failure")),
+                DlqReason.RETRY_EXHAUSTED
+        );
+
+        adapter.reprocess(entry);
+
+        ArgumentCaptor<MarginReleaseEvent> captor = ArgumentCaptor.forClass(MarginReleaseEvent.class);
+        verify(marginReaction).handle(captor.capture());
+        verifyNoInteractions(executionReaction);
+        MarginReleaseEvent replayed = captor.getValue();
+        assertTrue(replayed.release().transactionId().equals(original.release().transactionId()));
+        assertTrue(replayed.release().releaseAmount().compareTo(original.release().releaseAmount()) == 0);
+        assertTrue(replayed.release().executedAmount().compareTo(original.release().executedAmount()) == 0);
+    }
+
+    private static ExecutionConfirmedEvent executionEvent() {
+        return new ExecutionConfirmedEvent(new ExecutionConfirmation(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                new BigDecimal("0.01000000"),
+                new BigDecimal("65000.00"),
+                Fee.zero("USDT"),
+                new BigDecimal("650.00"),
+                new BigDecimal("15.00"),
+                true
+        ));
+    }
+
+    private static MarginReleaseEvent marginEvent() {
+        return new MarginReleaseEvent(new MarginRelease(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                new BigDecimal("650.00"),
+                ReleaseReason.CANCELED,
+                new BigDecimal("120.00")
+        ));
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/handler/CapitalEventListenerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/handler/CapitalEventListenerTest.java
@@ -1,5 +1,7 @@
 package com.marmitt.application.spring.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.application.spring.deadletter.CapitalDeadLetterPayloadCodec;
 import com.marmitt.core.application.reaction.ExecutionConfirmedReaction;
 import com.marmitt.core.application.reaction.MarginReleasedReaction;
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
@@ -47,7 +49,8 @@ class CapitalEventListenerTest {
                 executionReaction,
                 marginReaction,
                 runnerRepository,
-                deadLetterRepository
+                deadLetterRepository,
+                payloadCodec()
         );
         ExecutionConfirmedEvent event = executionConfirmedEvent(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
 
@@ -67,7 +70,8 @@ class CapitalEventListenerTest {
                 executionReaction,
                 marginReaction,
                 runnerRepository,
-                deadLetterRepository
+                deadLetterRepository,
+                payloadCodec()
         );
         MarginReleaseEvent event = marginReleaseEvent(UUID.randomUUID(), UUID.randomUUID());
 
@@ -90,7 +94,8 @@ class CapitalEventListenerTest {
                 executionReaction,
                 marginReaction,
                 runnerRepository,
-                deadLetterRepository
+                deadLetterRepository,
+                payloadCodec()
         );
         ExecutionConfirmedEvent event = executionConfirmedEvent(UUID.randomUUID(), runnerId, UUID.randomUUID());
         RuntimeException failure = new RuntimeException("temporary failure");
@@ -103,10 +108,10 @@ class CapitalEventListenerTest {
         assertEquals(portfolioId, entry.getPortfolioId());
         assertEquals(runnerId, entry.getRunnerId());
         assertEquals(DlqReason.RETRY_EXHAUSTED, entry.getReason());
-        assertTrue(entry.getRawPayload().contains("event=EXECUTION_CONFIRMED"));
-        assertTrue(entry.getRawPayload().contains("transactionId=" + event.confirmation().transactionId()));
-        assertTrue(entry.getRawPayload().contains("matchId=" + event.confirmation().matchId()));
-        assertTrue(entry.getRawPayload().contains("failure=RuntimeException:temporary failure"));
+        assertTrue(entry.getRawPayload().contains("\"eventType\":\"EXECUTION_CONFIRMED\""));
+        assertTrue(entry.getRawPayload().contains("\"transactionId\":\"" + event.confirmation().transactionId() + "\""));
+        assertTrue(entry.getRawPayload().contains("\"matchId\":\"" + event.confirmation().matchId() + "\""));
+        assertTrue(entry.getRawPayload().contains("\"failureMessage\":\"temporary failure\""));
     }
 
     @Test
@@ -122,7 +127,8 @@ class CapitalEventListenerTest {
                 executionReaction,
                 marginReaction,
                 runnerRepository,
-                deadLetterRepository
+                deadLetterRepository,
+                payloadCodec()
         );
         MarginReleaseEvent event = marginReleaseEvent(UUID.randomUUID(), runnerId);
         RuntimeException failure = new RuntimeException("temporary failure");
@@ -135,10 +141,10 @@ class CapitalEventListenerTest {
         assertEquals(portfolioId, entry.getPortfolioId());
         assertEquals(runnerId, entry.getRunnerId());
         assertEquals(DlqReason.RETRY_EXHAUSTED, entry.getReason());
-        assertTrue(entry.getRawPayload().contains("event=MARGIN_RELEASE"));
-        assertTrue(entry.getRawPayload().contains("transactionId=" + event.release().transactionId()));
-        assertTrue(entry.getRawPayload().contains("reason=" + event.release().reason()));
-        assertTrue(entry.getRawPayload().contains("failure=RuntimeException:temporary failure"));
+        assertTrue(entry.getRawPayload().contains("\"eventType\":\"MARGIN_RELEASE\""));
+        assertTrue(entry.getRawPayload().contains("\"transactionId\":\"" + event.release().transactionId() + "\""));
+        assertTrue(entry.getRawPayload().contains("\"reason\":\"" + event.release().reason() + "\""));
+        assertTrue(entry.getRawPayload().contains("\"failureMessage\":\"temporary failure\""));
     }
 
     @Test
@@ -153,7 +159,8 @@ class CapitalEventListenerTest {
                 executionReaction,
                 marginReaction,
                 runnerRepository,
-                deadLetterRepository
+                deadLetterRepository,
+                payloadCodec()
         );
         ExecutionConfirmedEvent event = executionConfirmedEvent(UUID.randomUUID(), runnerId, UUID.randomUUID());
 
@@ -176,7 +183,8 @@ class CapitalEventListenerTest {
                 executionReaction,
                 marginReaction,
                 runnerRepository,
-                deadLetterRepository
+                deadLetterRepository,
+                payloadCodec()
         );
         MarginReleaseEvent event = marginReleaseEvent(UUID.randomUUID(), runnerId);
 
@@ -184,6 +192,10 @@ class CapitalEventListenerTest {
                 listener.recoverMarginRelease(new RuntimeException("temporary failure"), event));
 
         verify(deadLetterRepository).save(any(DeadLetterEntry.class));
+    }
+
+    private static CapitalDeadLetterPayloadCodec payloadCodec() {
+        return new CapitalDeadLetterPayloadCodec(new ObjectMapper());
     }
 
     private static ExecutionConfirmedEvent executionConfirmedEvent(UUID transactionId, UUID runnerId, UUID matchId) {


### PR DESCRIPTION
## Summary
- add explicit DLQ reprocessing to `ManageDeadLetterUseCase` and `DeadLetterController`
- introduce a Spring adapter that reprocesses retry-exhausted capital DLQ entries through the existing capital reactions
- enrich capital DLQ payloads so they carry enough data for safe replay
- update Phase 4 roadmap/go-live docs to reflect the current step

## Scope
- supported automatic reprocessing is intentionally limited to capital DLQ entries with `RETRY_EXHAUSTED`
- unsupported DLQ reasons remain manual-only and return a conflict response

## Validation
- `./gradlew -q :core:test --tests com.marmitt.core.application.usecase.portfolio.ManageDeadLetterUseCaseTest :spring-application:test --tests com.marmitt.application.spring.controller.DeadLetterControllerTest --tests com.marmitt.application.spring.deadletter.CapitalDeadLetterReprocessingAdapterTest`

## Notes
- replay safety is based on the existing idempotency of `ExecutionConfirmedReaction` (`matchId`) and `MarginReleasedReaction` (`transactionId`)
- this PR does not change boot DLQ semantics for non-capital anomalies