### PR TITLE
docs(phase4): close testing roadmap phase 4

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -86,7 +86,7 @@ Consolidar os principais critérios para sair do ambiente de simulação (MOCK) 
 - Testing Roadmap Fase 1B: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 2: CONCLUIDA no branch `develop`.
 - Testing Roadmap Fase 3: CONCLUIDA no branch `develop`.
-- Testing Roadmap Fase 4: EM ANDAMENTO.
+- Testing Roadmap Fase 4: CONCLUIDA no branch `develop`.
 
 Evidencias de Fase 0 em testes automatizados:
 - `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
@@ -109,8 +109,8 @@ Evidencias de Fase 1B em testes automatizados:
 ### Impacto no Go-Live
 
 - Item 1 (Testes automatizados minimos): PARCIAL (AVANCADO).
-- Baseline de invariantes, integracao core com MOCK, controles deterministicos do MOCK, robustez contra duplicidade/concorrencia e boot recovery completo cobertos (Fases 0, 1A, 1B, 2 e 3).
-- Ainda faltam observabilidade operacional, DLQ operacional e integracao real com exchange (Fase 4 + integracoes reais).
+- Baseline de invariantes, integracao core com MOCK, controles deterministicos do MOCK, robustez contra duplicidade/concorrencia, boot recovery completo, observabilidade operacional e ciclo de DLQ operacional cobertos (Fases 0, 1A, 1B, 2, 3 e 4).
+- Ainda faltam staging/soak test, carga controlada, guardrails finais de producao e integracao real com exchange.
 
 ### Evidencias adicionais de Fase 3
 
@@ -125,6 +125,15 @@ Evidencias de Fase 1B em testes automatizados:
 
 ### Proximo passo recomendado
 
-1. Concluir o PR 5 da Fase 4 com replay ponta a ponta de DLQ de capital, cobrindo persistencia, reprocessamento e ausencia de drift economico.
-2. Avancar para os proximos blocos de resiliencia operacional e continuidade da observabilidade de boot/recovery.
-3. Atualizar este checklist a cada fase concluida do Testing Roadmap.
+1. Iniciar a trilha de go-live fora do escopo atual com `MOCK`: staging, soak test e carga controlada.
+2. Priorizar integracao real de exchange com os mesmos invariantes ja protegidos pela suite atual.
+3. Atualizar este checklist conforme avancarem guardrails de producao, segredos, observabilidade e operacao real.
+
+### Backlog de Go-Live Apos a Fase 4
+
+- staging com comportamento proximo ao real
+- soak test por janela prolongada
+- carga controlada e medicionamento de latencia/convergencia
+- integracao real com exchange
+- kill switch global e circuit breaker por exchange
+- governanca de segredos e endurecimento operacional final

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -426,7 +426,7 @@ Fora de escopo da Fase 4:
 - Fase 1B: CONCLUIDA.
 - Fase 2: CONCLUIDA.
 - Fase 3: CONCLUIDA.
-- Fase 4: EM ANDAMENTO.
+- Fase 4: CONCLUIDA.
 
 ### Evidencias de conclusao da Fase 1B
 
@@ -500,13 +500,28 @@ Fora de escopo da Fase 4:
   - `query retry exhausted`
   - reexecucao idempotente do recovery nos cenarios relevantes
 
-### Fase 4 em progresso
+### Fase 4 concluida
 
 1. PR 1 (concluido): observabilidade do boot validada por teste cobrindo evento de fail-fast e metricas minimas por fase/resultado.
 2. PR 2 (concluido): DLQ operacional no boot cobrindo abertura de entry e nao duplicacao da mesma identidade do problema.
 3. PR 3 (concluido): gestao manual da DLQ cobrindo listagem e resolucao via use case/controller.
 4. PR 4 (concluido): reprocessamento seguro de DLQ para eventos de capital com retries esgotados.
-5. PR 5 (atual): replay ponta a ponta de DLQ de capital, do recover ate o reprocessamento via controller, com validacao de efeito economico e idempotencia.
+5. PR 5 (concluido): replay ponta a ponta de DLQ de capital, do recover ate o reprocessamento via controller, com validacao de efeito economico e idempotencia.
+
+### Evidencias de conclusao da Fase 4
+
+- Observabilidade de boot consolidada em:
+  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java`
+- DLQ operacional de boot consolidada em:
+  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java`
+- Gestao manual de DLQ consolidada em:
+  - `core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java`
+  - `spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java`
+- Resiliencia do listener de capital consolidada em:
+  - `spring-application/src/test/java/com/marmitt/application/spring/handler/CapitalEventListenerTest.java`
+- Reprocessamento seguro e replay ponta a ponta de DLQ de capital consolidados em:
+  - `spring-application/src/test/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapterTest.java`
+  - `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/CapitalDeadLetterReplayIntegrationTest.java`
 
 ## Backlog Pos-Testes
 
@@ -516,3 +531,6 @@ Fora de escopo da Fase 4:
   - extrair a orquestracao do boot para um use case do `core`;
   - reduzir o acoplamento atual entre framework e sequenciamento das fases de boot.
 - Prioridade: somente depois de concluir a trilha atual de testes e endurecimento operacional.
+- Executar soak tests de maior duracao para monitorar acumulacao de pendencias e degradacao progressiva.
+- Executar testes de carga controlada para medir latencia de conciliacao e convergencia sob pressao.
+- Avancar para staging e integracao real de exchange como proxima trilha fora do escopo atual com `MOCK`.


### PR DESCRIPTION
## Summary
- mark Phase 4 as concluded for the current MOCK-based testing scope
- consolidate the evidence that closes the operational hardening phase
- move soak, controlled load and real-exchange work into explicit post-phase backlog

## Scope
- documentation only

## Notes
- this PR does not change production code
- it formalizes the current boundary between completed MOCK validation and remaining go-live work