### PR TITLE
refactor(dto): split portfolio contracts into request and response

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/portfolio/CreatePortfolioUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/portfolio/CreatePortfolioUseCase.java
@@ -2,8 +2,8 @@ package com.marmitt.core.application.usecase.portfolio;
 
 import com.marmitt.core.domain.portfolio.GlobalBalance;
 import com.marmitt.core.domain.portfolio.Portfolio;
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
 import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
 import com.marmitt.core.ports.outbound.repository.GlobalBalanceRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
@@ -70,3 +70,4 @@ public class CreatePortfolioUseCase implements CreatePortfolioPort {
         }
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java
@@ -1,10 +1,10 @@
 package com.marmitt.core.application.usecase.portfolio;
 
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
-import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.response.DeadLetterEntryDto;
 import com.marmitt.core.dto.portfolio.DeadLetterReprocessingResult;
-import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
-import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.ReprocessDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
@@ -105,3 +105,4 @@ public class ManageDeadLetterUseCase implements ManageDeadLetterPort {
         );
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/application/usecase/portfolio/QueryPortfolioUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/portfolio/QueryPortfolioUseCase.java
@@ -1,9 +1,9 @@
 package com.marmitt.core.application.usecase.portfolio;
 
-import com.marmitt.core.dto.portfolio.PortfolioDto;
-import com.marmitt.core.dto.portfolio.GlobalBalanceDto;
-import com.marmitt.core.dto.portfolio.PortfolioPnlDto;
-import com.marmitt.core.dto.portfolio.TransactionDto;
+import com.marmitt.core.dto.portfolio.response.PortfolioDto;
+import com.marmitt.core.dto.portfolio.response.GlobalBalanceDto;
+import com.marmitt.core.dto.portfolio.response.PortfolioPnlDto;
+import com.marmitt.core.dto.portfolio.response.TransactionDto;
 import com.marmitt.core.domain.portfolio.GlobalBalance;
 import com.marmitt.core.domain.runner.Position;
 import com.marmitt.core.enums.TransactionStatus;
@@ -126,3 +126,4 @@ public class QueryPortfolioUseCase implements QueryPortfolioPort {
                 .build());
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/QueryRunnerUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/QueryRunnerUseCase.java
@@ -1,6 +1,6 @@
 package com.marmitt.core.application.usecase.runner;
 
-import com.marmitt.core.dto.portfolio.TransactionDto;
+import com.marmitt.core.dto.portfolio.response.TransactionDto;
 import com.marmitt.core.dto.runner.RunnerDto;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.ports.inbound.runner.QueryRunnerPort;
@@ -50,3 +50,4 @@ public class QueryRunnerUseCase implements QueryRunnerPort {
                 .toList();
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/request/CreatePortfolioRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/request/CreatePortfolioRequest.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.request;
 
 import lombok.Builder;
 
@@ -29,3 +29,4 @@ public record CreatePortfolioRequest(
         }
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/request/ReprocessDeadLetterRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/request/ReprocessDeadLetterRequest.java
@@ -1,7 +1,8 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.request;
 
 public record ReprocessDeadLetterRequest(
         String requestedBy,
         String resolutionNote
 ) {
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/request/ResolveDeadLetterRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/request/ResolveDeadLetterRequest.java
@@ -1,7 +1,8 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.request;
 
 public record ResolveDeadLetterRequest(
         String resolvedBy,
         String resolutionNote
 ) {
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/response/AggregatedTransactionsResponse.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/response/AggregatedTransactionsResponse.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.response;
 
 import java.util.List;
 import java.util.UUID;
@@ -10,3 +10,4 @@ public record AggregatedTransactionsResponse(
         int totalCount
 ) {
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/response/CreatePortfolioResponse.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/response/CreatePortfolioResponse.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.response;
 
 import lombok.Builder;
 
@@ -40,3 +40,4 @@ public record CreatePortfolioResponse(
                 .build();
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/response/DeadLetterEntryDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/response/DeadLetterEntryDto.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.response;
 
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
 import com.marmitt.core.enums.DlqReason;
@@ -35,3 +35,4 @@ public record DeadLetterEntryDto(
         );
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/response/GlobalBalanceDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/response/GlobalBalanceDto.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.response;
 
 import com.marmitt.core.domain.portfolio.GlobalBalance;
 import lombok.Builder;
@@ -34,3 +34,4 @@ public record GlobalBalanceDto(
                 .build();
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/response/PortfolioDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/response/PortfolioDto.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.response;
 
 import com.marmitt.core.domain.portfolio.Portfolio;
 import com.marmitt.core.enums.CapitalPoolingMode;
@@ -29,3 +29,4 @@ public record PortfolioDto(
                 .build();
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/response/PortfolioPnlDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/response/PortfolioPnlDto.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.response;
 
 import lombok.Builder;
 
@@ -13,3 +13,4 @@ public record PortfolioPnlDto(
         BigDecimal totalPnL
 ) {
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/response/ReprocessDeadLetterResponse.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/response/ReprocessDeadLetterResponse.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.response;
 
 import java.util.UUID;
 
@@ -16,3 +16,4 @@ public record ReprocessDeadLetterResponse(
         return new ReprocessDeadLetterResponse(deadLetterId, false, message, null);
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/response/ResolveDeadLetterResponse.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/response/ResolveDeadLetterResponse.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.response;
 
 import java.util.UUID;
 
@@ -16,3 +16,4 @@ public record ResolveDeadLetterResponse(
         return new ResolveDeadLetterResponse(deadLetterId, false, message, null);
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/dto/portfolio/response/TransactionDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/portfolio/response/TransactionDto.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.response;
 
 import com.marmitt.core.domain.runner.Transaction;
 import com.marmitt.core.enums.TransactionStatus;
@@ -55,3 +55,4 @@ public record TransactionDto(
                 .build();
     }
 }
+

--- a/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/CreatePortfolioPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/CreatePortfolioPort.java
@@ -1,7 +1,7 @@
 package com.marmitt.core.ports.inbound.portfolio;
 
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
 
 public interface CreatePortfolioPort {
 
@@ -13,3 +13,4 @@ public interface CreatePortfolioPort {
      */
     CreatePortfolioResponse execute(CreatePortfolioRequest request);
 }
+

--- a/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/ManageDeadLetterPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/ManageDeadLetterPort.java
@@ -1,8 +1,8 @@
 package com.marmitt.core.ports.inbound.portfolio;
 
-import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
-import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
-import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.response.ReprocessDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
 
 import java.util.List;
 import java.util.UUID;
@@ -15,3 +15,4 @@ public interface ManageDeadLetterPort {
 
     ReprocessDeadLetterResponse reprocess(UUID deadLetterId, String requestedBy, String resolutionNote);
 }
+

--- a/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/QueryPortfolioPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/portfolio/QueryPortfolioPort.java
@@ -1,9 +1,9 @@
 package com.marmitt.core.ports.inbound.portfolio;
 
-import com.marmitt.core.dto.portfolio.PortfolioDto;
-import com.marmitt.core.dto.portfolio.GlobalBalanceDto;
-import com.marmitt.core.dto.portfolio.PortfolioPnlDto;
-import com.marmitt.core.dto.portfolio.TransactionDto;
+import com.marmitt.core.dto.portfolio.response.PortfolioDto;
+import com.marmitt.core.dto.portfolio.response.GlobalBalanceDto;
+import com.marmitt.core.dto.portfolio.response.PortfolioPnlDto;
+import com.marmitt.core.dto.portfolio.response.TransactionDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,3 +23,4 @@ public interface QueryPortfolioPort {
 
     Optional<PortfolioPnlDto> findPnlByPortfolioId(UUID portfolioId);
 }
+

--- a/core/src/main/java/com/marmitt/core/ports/inbound/runner/QueryRunnerPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/runner/QueryRunnerPort.java
@@ -1,6 +1,6 @@
 package com.marmitt.core.ports.inbound.runner;
 
-import com.marmitt.core.dto.portfolio.TransactionDto;
+import com.marmitt.core.dto.portfolio.response.TransactionDto;
 import com.marmitt.core.dto.runner.RunnerDto;
 
 import java.util.List;
@@ -12,3 +12,4 @@ public interface QueryRunnerPort {
 
     List<TransactionDto> findTransactionsByRunnerId(UUID runnerId);
 }
+

--- a/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
@@ -1,10 +1,10 @@
 package com.marmitt.core.application.usecase.portfolio;
 
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
-import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.response.DeadLetterEntryDto;
 import com.marmitt.core.dto.portfolio.DeadLetterReprocessingResult;
-import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
-import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.ReprocessDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
@@ -257,3 +257,4 @@ class ManageDeadLetterUseCaseTest {
         );
     }
 }
+

--- a/core/src/test/java/com/marmitt/core/dto/portfolio/CreatePortfolioRequestTest.java
+++ b/core/src/test/java/com/marmitt/core/dto/portfolio/CreatePortfolioRequestTest.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.dto.portfolio;
+package com.marmitt.core.dto.portfolio.request;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,3 +27,4 @@ class CreatePortfolioRequestTest {
         ));
     }
 }
+

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/DeadLetterController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/DeadLetterController.java
@@ -1,10 +1,10 @@
 package com.marmitt.application.spring.controller;
 
-import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
-import com.marmitt.core.dto.portfolio.ReprocessDeadLetterRequest;
-import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
-import com.marmitt.core.dto.portfolio.ResolveDeadLetterRequest;
-import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.request.ReprocessDeadLetterRequest;
+import com.marmitt.core.dto.portfolio.response.ReprocessDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.request.ResolveDeadLetterRequest;
+import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -102,3 +102,4 @@ public class DeadLetterController {
         }
     }
 }
+

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/PortfolioController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/PortfolioController.java
@@ -1,12 +1,12 @@
 package com.marmitt.application.spring.controller;
 
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
-import com.marmitt.core.dto.portfolio.AggregatedTransactionsResponse;
-import com.marmitt.core.dto.portfolio.GlobalBalanceDto;
-import com.marmitt.core.dto.portfolio.PortfolioDto;
-import com.marmitt.core.dto.portfolio.PortfolioPnlDto;
-import com.marmitt.core.dto.portfolio.TransactionDto;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.response.AggregatedTransactionsResponse;
+import com.marmitt.core.dto.portfolio.response.GlobalBalanceDto;
+import com.marmitt.core.dto.portfolio.response.PortfolioDto;
+import com.marmitt.core.dto.portfolio.response.PortfolioPnlDto;
+import com.marmitt.core.dto.portfolio.response.TransactionDto;
 import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
 import com.marmitt.core.ports.inbound.portfolio.QueryPortfolioPort;
 import lombok.extern.slf4j.Slf4j;
@@ -155,3 +155,4 @@ public class PortfolioController {
     }
 
 }
+

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/PortfolioRunnerController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/PortfolioRunnerController.java
@@ -1,6 +1,6 @@
 package com.marmitt.application.spring.controller;
 
-import com.marmitt.core.dto.portfolio.PortfolioDto;
+import com.marmitt.core.dto.portfolio.response.PortfolioDto;
 import com.marmitt.core.dto.runner.CreateRunnerDto;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
@@ -105,3 +105,4 @@ public class PortfolioRunnerController {
         return ResponseEntity.ok(runners);
     }
 }
+

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/RunnerController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/RunnerController.java
@@ -1,6 +1,6 @@
 package com.marmitt.application.spring.controller;
 
-import com.marmitt.core.dto.portfolio.TransactionDto;
+import com.marmitt.core.dto.portfolio.response.TransactionDto;
 import com.marmitt.core.ports.inbound.runner.QueryRunnerPort;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -36,3 +36,4 @@ public class RunnerController {
         return ResponseEntity.ok(transactions);
     }
 }
+

--- a/spring-application/src/main/java/com/marmitt/application/spring/service/TransactionalManageDeadLetterPort.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/service/TransactionalManageDeadLetterPort.java
@@ -1,8 +1,8 @@
 package com.marmitt.application.spring.service;
 
-import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
-import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
-import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.response.ReprocessDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,3 +36,4 @@ public class TransactionalManageDeadLetterPort implements ManageDeadLetterPort {
         return delegate.reprocess(deadLetterId, requestedBy, resolutionNote);
     }
 }
+

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/CapitalDeadLetterReplayIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/CapitalDeadLetterReplayIntegrationTest.java
@@ -11,8 +11,8 @@ import com.marmitt.core.dto.capital.ExecutionConfirmation;
 import com.marmitt.core.dto.capital.MarginRelease;
 import com.marmitt.core.dto.events.ExecutionConfirmedEvent;
 import com.marmitt.core.dto.events.MarginReleaseEvent;
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
 import com.marmitt.core.enums.ReleaseReason;
@@ -385,3 +385,4 @@ class CapitalDeadLetterReplayIntegrationTest {
         }
     }
 }
+

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ConcurrentSellLockIntegrationTest.java
@@ -5,8 +5,8 @@ import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.domain.runner.Position;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
 import com.marmitt.core.enums.PositionStatus;
@@ -331,3 +331,4 @@ class ConcurrentSellLockIntegrationTest {
     private record LockResult(UUID transactionId, boolean locked) {
     }
 }
+

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockOrderOverrideIntegrationTestSupport.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockOrderOverrideIntegrationTestSupport.java
@@ -5,8 +5,8 @@ import com.marmitt.application.spring.config.exchange.MockExchangeAdapter;
 import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
@@ -601,3 +601,4 @@ abstract class MockOrderOverrideIntegrationTestSupport {
     protected record BalanceRow(BigDecimal available, BigDecimal reserved, BigDecimal realized) {
     }
 }
+

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderLifecycleMockIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderLifecycleMockIntegrationTest.java
@@ -3,8 +3,8 @@ package com.marmitt.application.spring.bootstrap;
 import com.marmitt.application.spring.CTradeApplication;
 import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.domain.runner.StrategyRunner;
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
 import com.marmitt.core.dto.websocket.data.MarketDataDto;
@@ -413,3 +413,4 @@ class OrderLifecycleMockIntegrationTest {
                                          BigDecimal realizedBalance) {
     }
 }
+

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderTerminationConciliationIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderTerminationConciliationIntegrationTest.java
@@ -6,8 +6,8 @@ import com.marmitt.core.domain.portfolio.GlobalBalance;
 import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.domain.runner.Position;
 import com.marmitt.core.domain.runner.Transaction;
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
@@ -392,3 +392,4 @@ class OrderTerminationConciliationIntegrationTest {
         }
     }
 }
+

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ProcessTradeSignalMockIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ProcessTradeSignalMockIntegrationTest.java
@@ -3,8 +3,8 @@ package com.marmitt.application.spring.bootstrap;
 import com.marmitt.application.spring.CTradeApplication;
 import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.domain.runner.StrategyRunner;
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
 import com.marmitt.core.dto.websocket.data.MarketDataDto;
@@ -292,3 +292,4 @@ class ProcessTradeSignalMockIntegrationTest {
                                         Set<String> seenStatuses) {
     }
 }
+

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java
@@ -9,8 +9,8 @@ import com.marmitt.core.domain.runner.Position;
 import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
-import com.marmitt.core.dto.portfolio.CreatePortfolioRequest;
-import com.marmitt.core.dto.portfolio.CreatePortfolioResponse;
+import com.marmitt.core.dto.portfolio.request.CreatePortfolioRequest;
+import com.marmitt.core.dto.portfolio.response.CreatePortfolioResponse;
 import com.marmitt.core.dto.runner.CreateRunnerRequest;
 import com.marmitt.core.dto.runner.CreateRunnerResponse;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
@@ -838,3 +838,4 @@ class RunnerBootRecoveryIntegrationTest {
         }
     }
 }
+

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java
@@ -1,8 +1,8 @@
 package com.marmitt.application.spring.controller;
 
-import com.marmitt.core.dto.portfolio.DeadLetterEntryDto;
-import com.marmitt.core.dto.portfolio.ReprocessDeadLetterResponse;
-import com.marmitt.core.dto.portfolio.ResolveDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.DeadLetterEntryDto;
+import com.marmitt.core.dto.portfolio.response.ReprocessDeadLetterResponse;
+import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
 import org.junit.jupiter.api.BeforeEach;
@@ -243,3 +243,4 @@ class DeadLetterControllerTest {
         );
     }
 }
+


### PR DESCRIPTION
## Summary
- split `core.dto.portfolio` transport-facing contracts into `request` and `response` packages
- keep boot/DLQ internal result/context DTOs in the root `portfolio` package for now
- update use cases, ports, controllers and tests to the new package layout without changing behavior

## Validation
- `powershell -ExecutionPolicy Bypass -File .\scripts\gradle-run.ps1 -q :core:compileJava :core:compileTestJava :spring-application:compileJava :spring-application:compileTestJava`