### PR TITLE
refactor(boot): extract boot sequence use case to core

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/boot/BootFailFastException.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/boot/BootFailFastException.java
@@ -1,0 +1,21 @@
+package com.marmitt.core.application.usecase.boot;
+
+public class BootFailFastException extends RuntimeException {
+
+    private final String phase;
+    private final String code;
+
+    public BootFailFastException(String phase, String code, String message) {
+        super(message + " code=" + code);
+        this.phase = phase;
+        this.code = code;
+    }
+
+    public String phase() {
+        return phase;
+    }
+
+    public String code() {
+        return code;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/boot/BootPhaseExecutionException.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/boot/BootPhaseExecutionException.java
@@ -1,0 +1,15 @@
+package com.marmitt.core.application.usecase.boot;
+
+public class BootPhaseExecutionException extends RuntimeException {
+
+    private final String phase;
+
+    public BootPhaseExecutionException(String phase, String message, Throwable cause) {
+        super(message, cause);
+        this.phase = phase;
+    }
+
+    public String phase() {
+        return phase;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java
@@ -1,0 +1,547 @@
+package com.marmitt.core.application.usecase.boot;
+
+import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
+import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
+import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
+import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
+import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.domain.portfolio.Portfolio;
+import com.marmitt.core.domain.runner.ClientOrderId;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.dto.boot.BootExecutionCommand;
+import com.marmitt.core.dto.boot.BootExecutionSummary;
+import com.marmitt.core.dto.exchange.boot.ExchangeBootReadiness;
+import com.marmitt.core.dto.portfolio.PortfolioBootSanityResult;
+import com.marmitt.core.dto.portfolio.PortfolioReservationTtlResult;
+import com.marmitt.core.dto.portfolio.PortfolioZombieCandidate;
+import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
+import com.marmitt.core.enums.BootAccountQueryPolicy;
+import com.marmitt.core.enums.BootFailureMode;
+import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.enums.PortfolioReservationTtlStatus;
+import com.marmitt.core.enums.PortfolioSanityStatus;
+import com.marmitt.core.enums.PortfolioZombieDetectionStatus;
+import com.marmitt.core.enums.RunnerStatus;
+import com.marmitt.core.ports.outbound.boot.BootExecutionObserverPort;
+import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@Slf4j
+@RequiredArgsConstructor
+public class RunBootSequenceUseCase {
+
+    private final PortfolioRepositoryPort portfolioRepository;
+    private final StrategyRunnerRepositoryPort strategyRunnerRepository;
+    private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
+    private final PortfolioBootSanityUseCase portfolioBootSanityUseCase;
+    private final PortfolioReservationTtlUseCase portfolioReservationTtlUseCase;
+    private final PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase;
+    private final DeadLetterEntryRepositoryPort deadLetterEntryRepository;
+    private final RunnerBootRecoveryUseCase runnerBootRecoveryUseCase;
+
+    public BootExecutionSummary execute(BootExecutionCommand command, BootExecutionObserverPort observer) {
+        List<Portfolio> portfolios = portfolioRepository.findAll();
+        List<StrategyRunner> eligibleRunners = portfolios.stream()
+                .flatMap(this::loadRunnersByPortfolio)
+                .filter(this::isEligibleForRecovery)
+                .toList();
+
+        executePhase("phase1.infrastructure", command.phase1Enabled(), observer,
+                () -> runPhase1InfrastructureReadiness(observer, eligibleRunners));
+
+        boolean phase2Enabled = command.phase2Enabled();
+        executePhase("phase2.sanity",
+                phase2Enabled && command.sanityEnabled(),
+                observer,
+                () -> runPhase2PortfolioSanity(command, observer, portfolios, eligibleRunners));
+        executePhase("phase2.zombie",
+                phase2Enabled && command.zombieDetectionEnabled(),
+                observer,
+                () -> runPhase2ZombieDetection(command, observer, portfolios, eligibleRunners));
+        executePhase("phase2.reservation_ttl",
+                phase2Enabled && command.reservationTtlEnabled(),
+                observer,
+                () -> runPhase2ReservationTtl(command, observer, portfolios, eligibleRunners));
+
+        List<RunnerBootRecoveryUseCase.RecoverySummary> summaries = new ArrayList<>();
+        executePhase("phase3.runner_recovery",
+                command.phase3Enabled(),
+                observer,
+                () -> summaries.addAll(eligibleRunners.stream().map(this::recoverRunner).toList()));
+
+        return new BootExecutionSummary(portfolios.size(), eligibleRunners.size(), List.copyOf(summaries));
+    }
+
+    private void runPhase1InfrastructureReadiness(BootExecutionObserverPort observer,
+                                                  List<StrategyRunner> runners) {
+        Set<String> exchanges = runners.stream()
+                .map(StrategyRunner::getExchangeId)
+                .filter(exchange -> exchange != null && !exchange.isBlank())
+                .map(String::toUpperCase)
+                .collect(java.util.stream.Collectors.toCollection(java.util.TreeSet::new));
+
+        if (exchanges.isEmpty()) {
+            log.info("bootOrchestrator.phase1: no exchange to validate");
+            return;
+        }
+
+        log.info("bootOrchestrator.phase1: start exchanges={}", exchanges.size());
+
+        for (String exchange : exchanges) {
+            ExchangeBootReadiness readiness = exchangeAdapterRepository.findBootReadinessByName(exchange)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Boot readiness capability is not registered for exchange=" + exchange))
+                    .checkBootReadiness();
+
+            if (!readiness.ready()) {
+                failFast(observer,
+                        "phase1.infrastructure",
+                        readiness.code(),
+                        "Phase1 readiness failed exchange=" + exchange + " message=" + readiness.message());
+            }
+
+            log.info("bootOrchestrator.phase1: exchange={} ready code={} message={}",
+                    exchange, readiness.code(), readiness.message());
+        }
+
+        log.info("bootOrchestrator.phase1: completed exchanges={}", exchanges.size());
+    }
+
+    private void runPhase2PortfolioSanity(BootExecutionCommand command,
+                                          BootExecutionObserverPort observer,
+                                          List<Portfolio> portfolios,
+                                          List<StrategyRunner> eligibleRunners) {
+        BootFailureMode mode = command.phase2Mode();
+        log.info("bootOrchestrator.phase2.sanity: start portfolios={} mode={} accountQueryPolicy={} threshold={}",
+                portfolios.size(), mode, command.accountQueryPolicy(), command.sanityThreshold());
+
+        for (Portfolio portfolio : portfolios) {
+            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
+
+            if (exchanges.isEmpty()) {
+                log.debug("bootOrchestrator.phase2.sanity: portfolio={} skipped - no eligible runner exchange",
+                        portfolio.getId());
+                continue;
+            }
+
+            for (String exchange : exchanges) {
+                long startedNs = System.nanoTime();
+                PortfolioBootSanityResult result = portfolioBootSanityUseCase.execute(
+                        portfolio.getId(),
+                        exchange,
+                        command.sanityThreshold()
+                );
+                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+                observer.onPortfolioPhaseEvaluated(
+                        "phase2.sanity",
+                        result.status().name(),
+                        exchange,
+                        mode.name(),
+                        durationMs
+                );
+
+                switch (result.status()) {
+                    case PASS, WARN_SURPLUS -> log.info(
+                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} localTotal={} exchangeTotal={} signedDelta={} deviation={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.code(),
+                            result.localTotal(),
+                            result.exchangeTotal(),
+                            result.signedDelta(),
+                            result.absoluteDeviation()
+                    );
+                    case SKIPPED -> log.warn(
+                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} message={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.code(),
+                            result.message()
+                    );
+                    case FAIL_DEFICIT -> log.error(
+                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} message={} localTotal={} exchangeTotal={} signedDelta={} deviation={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.code(),
+                            result.message(),
+                            result.localTotal(),
+                            result.exchangeTotal(),
+                            result.signedDelta(),
+                            result.absoluteDeviation()
+                    );
+                    case FAILED -> log.warn(
+                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} message={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.code(),
+                            result.message()
+                    );
+                }
+
+                boolean skippedWithFailPolicy = result.status() == PortfolioSanityStatus.SKIPPED
+                        && command.accountQueryPolicy() == BootAccountQueryPolicy.FAIL;
+                boolean criticalFailure = result.status() == PortfolioSanityStatus.FAIL_DEFICIT
+                        || result.status() == PortfolioSanityStatus.FAILED;
+                if ((skippedWithFailPolicy || criticalFailure) && mode == BootFailureMode.FAIL_FAST) {
+                    failFast(observer,
+                            "phase2.sanity",
+                            result.code(),
+                            "Phase2 sanity failed portfolio=" + result.portfolioId()
+                                    + " exchange=" + result.exchangeId()
+                                    + " message=" + result.message());
+                }
+            }
+        }
+
+        log.info("bootOrchestrator.phase2.sanity: completed");
+    }
+
+    private void runPhase2ZombieDetection(BootExecutionCommand command,
+                                          BootExecutionObserverPort observer,
+                                          List<Portfolio> portfolios,
+                                          List<StrategyRunner> eligibleRunners) {
+        BootFailureMode mode = command.phase2Mode();
+        log.info("bootOrchestrator.phase2.zombie: start portfolios={} mode={} cutoffEnabled={}",
+                portfolios.size(), mode, command.cutoffEnabled());
+
+        for (Portfolio portfolio : portfolios) {
+            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
+            if (exchanges.isEmpty()) {
+                continue;
+            }
+
+            for (String exchange : exchanges) {
+                long startedNs = System.nanoTime();
+                PortfolioZombieDetectionResult result =
+                        portfolioZombieDetectionUseCase.execute(
+                                portfolio.getId(),
+                                exchange,
+                                command.cutoffEnabled()
+                        );
+                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+                observer.onPortfolioPhaseEvaluated(
+                        "phase2.zombie",
+                        result.status().name(),
+                        exchange,
+                        mode.name(),
+                        durationMs
+                );
+
+                switch (result.status()) {
+                    case CLEAN -> log.info(
+                            "bootOrchestrator.phase2.zombie: portfolio={} exchange={} status={} openOrders={} zombies={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.openOrders(),
+                            result.zombieCount()
+                    );
+                    case DETECTED -> {
+                        boolean persistToDlq = mode == BootFailureMode.FAIL_FAST;
+                        int persistedSamples = persistToDlq ? persistZombieSamplesToDlq(result) : 0;
+                        log.warn(
+                                "bootOrchestrator.phase2.zombie: portfolio={} exchange={} mode={} status={} code={} openOrders={} zombies={} invalidFormat={} unknownRunner={} noLocalMatch={} beforeCutoff={} unknownSymbol={} persistedSamples={} dlqPersisted={}",
+                                result.portfolioId(),
+                                result.exchangeId(),
+                                mode,
+                                result.status(),
+                                result.code(),
+                                result.openOrders(),
+                                result.zombieCount(),
+                                result.invalidFormatCount(),
+                                result.unknownRunnerCount(),
+                                result.noLocalMatchCount(),
+                                result.beforeCutoffCount(),
+                                result.unknownSymbolCount(),
+                                persistedSamples,
+                                persistToDlq
+                        );
+                        result.samples().forEach(sample -> log.warn(
+                                "bootOrchestrator.phase2.zombie: sample portfolio={} exchange={} reason={} code={} clientOrderId={} exchangeOrderId={} symbol={}",
+                                result.portfolioId(),
+                                result.exchangeId(),
+                                sample.reason(),
+                                sample.code(),
+                                sample.clientOrderId(),
+                                sample.exchangeOrderId(),
+                                sample.symbol()
+                        ));
+                    }
+                    case SKIPPED -> log.warn(
+                            "bootOrchestrator.phase2.zombie: portfolio={} exchange={} status={} code={} message={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.code(),
+                            result.message()
+                    );
+                    case FAILED -> log.error(
+                            "bootOrchestrator.phase2.zombie: portfolio={} exchange={} status={} code={} message={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.code(),
+                            result.message()
+                    );
+                }
+
+                boolean criticalFailure = result.status() == PortfolioZombieDetectionStatus.FAILED
+                        || result.status() == PortfolioZombieDetectionStatus.DETECTED;
+                if (criticalFailure && mode == BootFailureMode.FAIL_FAST) {
+                    failFast(observer,
+                            "phase2.zombie",
+                            result.code(),
+                            "Phase2 zombie detection failed portfolio=" + result.portfolioId()
+                                    + " exchange=" + result.exchangeId()
+                                    + " message=" + result.message());
+                }
+            }
+        }
+
+        log.info("bootOrchestrator.phase2.zombie: completed");
+    }
+
+    private void runPhase2ReservationTtl(BootExecutionCommand command,
+                                         BootExecutionObserverPort observer,
+                                         List<Portfolio> portfolios,
+                                         List<StrategyRunner> eligibleRunners) {
+        long ttlMs = command.reservationTtlMs();
+        BootFailureMode mode = command.phase2Mode();
+        log.info("bootOrchestrator.phase2.ttl: start portfolios={} mode={} ttlMs={}",
+                portfolios.size(), mode, ttlMs);
+
+        for (Portfolio portfolio : portfolios) {
+            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
+            if (exchanges.isEmpty()) {
+                continue;
+            }
+
+            for (String exchange : exchanges) {
+                List<StrategyRunner> scopedRunners = eligibleRunners.stream()
+                        .filter(runner -> runner.getPortfolioId().equals(portfolio.getId()))
+                        .filter(runner -> exchange.equalsIgnoreCase(runner.getExchangeId()))
+                        .toList();
+
+                long startedNs = System.nanoTime();
+                PortfolioReservationTtlResult result = portfolioReservationTtlUseCase.execute(
+                        portfolio.getId(),
+                        exchange,
+                        ttlMs,
+                        scopedRunners
+                );
+                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+                observer.onPortfolioPhaseEvaluated(
+                        "phase2.reservation_ttl",
+                        result.status().name(),
+                        exchange,
+                        mode.name(),
+                        durationMs
+                );
+
+                switch (result.status()) {
+                    case CLEAN -> log.info(
+                            "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.ttlMs(),
+                            result.scannedPendingCount(),
+                            result.eligibleNoExchangeOrderIdCount(),
+                            result.expiredCount(),
+                            result.freshCount(),
+                            result.errorCount()
+                    );
+                    case EXPIRED -> {
+                        log.warn(
+                                "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} code={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
+                                result.portfolioId(),
+                                result.exchangeId(),
+                                result.status(),
+                                result.code(),
+                                result.ttlMs(),
+                                result.scannedPendingCount(),
+                                result.eligibleNoExchangeOrderIdCount(),
+                                result.expiredCount(),
+                                result.freshCount(),
+                                result.errorCount()
+                        );
+                        result.samples().forEach(transactionId -> log.warn(
+                                "bootOrchestrator.phase2.ttl: expiredSample portfolio={} exchange={} transactionId={}",
+                                result.portfolioId(),
+                                result.exchangeId(),
+                                transactionId
+                        ));
+                    }
+                    case SKIPPED -> log.warn(
+                            "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} code={} message={} ttlMs={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.code(),
+                            result.message(),
+                            result.ttlMs()
+                    );
+                    case FAILED -> log.error(
+                            "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} code={} message={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
+                            result.portfolioId(),
+                            result.exchangeId(),
+                            result.status(),
+                            result.code(),
+                            result.message(),
+                            result.ttlMs(),
+                            result.scannedPendingCount(),
+                            result.eligibleNoExchangeOrderIdCount(),
+                            result.expiredCount(),
+                            result.freshCount(),
+                            result.errorCount()
+                    );
+                }
+
+                boolean criticalFailure = result.status() == PortfolioReservationTtlStatus.FAILED;
+                if (criticalFailure && mode == BootFailureMode.FAIL_FAST) {
+                    failFast(observer,
+                            "phase2.reservation_ttl",
+                            result.code(),
+                            "Phase2 reservation TTL failed portfolio=" + result.portfolioId()
+                                    + " exchange=" + result.exchangeId()
+                                    + " message=" + result.message());
+                }
+            }
+        }
+
+        log.info("bootOrchestrator.phase2.ttl: completed");
+    }
+
+    private Set<String> resolvePortfolioExchanges(Portfolio portfolio, List<StrategyRunner> eligibleRunners) {
+        return eligibleRunners.stream()
+                .filter(runner -> runner.getPortfolioId().equals(portfolio.getId()))
+                .map(StrategyRunner::getExchangeId)
+                .filter(exchange -> exchange != null && !exchange.isBlank())
+                .map(String::toUpperCase)
+                .collect(java.util.stream.Collectors.toCollection(java.util.TreeSet::new));
+    }
+
+    private Stream<StrategyRunner> loadRunnersByPortfolio(Portfolio portfolio) {
+        return strategyRunnerRepository.findByPortfolioId(portfolio.getId()).stream();
+    }
+
+    private boolean isEligibleForRecovery(StrategyRunner runner) {
+        return runner.getStatus() != RunnerStatus.ARCHIVED
+                && runner.getStatus() != RunnerStatus.TERMINATING;
+    }
+
+    private RunnerBootRecoveryUseCase.RecoverySummary recoverRunner(StrategyRunner runner) {
+        RunnerBootRecoveryUseCase.RecoverySummary summary = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        log.info("bootOrchestrator: runner={} inFlight={} zombies={} limbo={}",
+                summary.runnerId(), summary.inFlightCount(), summary.zombiesCount(), summary.limboCount());
+
+        if (log.isDebugEnabled()) {
+            summary.notes().forEach(note ->
+                    log.debug("bootOrchestrator: runner={} plan={}", summary.runnerId(), note));
+        }
+
+        return summary;
+    }
+
+    private void executePhase(String phase, boolean enabled, BootExecutionObserverPort observer, Runnable action) {
+        if (!enabled) {
+            observer.onPhaseSkipped(phase, "disabled_by_configuration");
+            log.info("bootOrchestrator: phase={} status=SKIPPED reason=disabled_by_configuration", phase);
+            return;
+        }
+
+        long startedNs = System.nanoTime();
+        observer.onPhaseStarted(phase);
+        try {
+            action.run();
+            long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+            observer.onPhaseCompleted(phase, true, durationMs, "ok");
+            log.info("bootOrchestrator: phase={} status=SUCCESS durationMs={}", phase, durationMs);
+        } catch (RuntimeException e) {
+            long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+            observer.onPhaseCompleted(phase, false, durationMs, e.getMessage());
+            throw e;
+        }
+    }
+
+    private void failFast(BootExecutionObserverPort observer, String phase, String code, String message) {
+        observer.onFailFastRequested(phase, code, message);
+        throw new BootFailFastException(phase, code, message);
+    }
+
+    private int persistZombieSamplesToDlq(PortfolioZombieDetectionResult result) {
+        int persisted = 0;
+        for (PortfolioZombieCandidate sample : result.samples()) {
+            UUID runnerId = resolveRunnerIdForZombieSample(result.portfolioId(), sample);
+
+            boolean alreadyOpen = deadLetterEntryRepository.existsUnresolvedByIdentity(
+                    result.portfolioId(),
+                    runnerId,
+                    sample.clientOrderId(),
+                    sample.exchangeOrderId(),
+                    sample.reason()
+            );
+
+            if (alreadyOpen) {
+                continue;
+            }
+
+            DeadLetterEntry entry = new DeadLetterEntry(
+                    result.portfolioId(),
+                    runnerId,
+                    sample.clientOrderId(),
+                    sample.exchangeOrderId(),
+                    "source=boot.phase2.zombie"
+                            + ", exchange=" + result.exchangeId()
+                            + ", runnerId=" + runnerId
+                            + ", code=" + sample.code()
+                            + ", symbol=" + sample.symbol()
+                            + ", reason=" + sample.reason(),
+                    sample.reason()
+            );
+            deadLetterEntryRepository.save(entry);
+            persisted++;
+        }
+        return persisted;
+    }
+
+    private UUID resolveRunnerIdForZombieSample(UUID portfolioId, PortfolioZombieCandidate sample) {
+        String clientOrderId = sample.clientOrderId();
+        if (clientOrderId == null || clientOrderId.isBlank()) {
+            return null;
+        }
+
+        var byTransaction = strategyRunnerRepository.findTransactionByClientOrderId(clientOrderId)
+                .flatMap(tx -> strategyRunnerRepository.findById(tx.getRunnerId())
+                        .filter(runner -> portfolioId.equals(runner.getPortfolioId()))
+                        .map(StrategyRunner::getId));
+        if (byTransaction.isPresent()) {
+            return byTransaction.get();
+        }
+
+        String shortCode = ClientOrderId.getRunnerShortCode(clientOrderId);
+        if (shortCode == null || shortCode.isBlank()) {
+            return null;
+        }
+
+        return strategyRunnerRepository.findByShortCodeAndPortfolioId(shortCode.toLowerCase(Locale.ROOT), portfolioId)
+                .map(StrategyRunner::getId)
+                .orElse(null);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java
@@ -476,7 +476,10 @@ public class RunBootSequenceUseCase {
         } catch (RuntimeException e) {
             long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
             observer.onPhaseCompleted(phase, false, durationMs, e.getMessage());
-            throw e;
+            if (e instanceof BootFailFastException) {
+                throw e;
+            }
+            throw new BootPhaseExecutionException(phase, e.getMessage(), e);
         }
     }
 

--- a/core/src/main/java/com/marmitt/core/dto/boot/BootExecutionCommand.java
+++ b/core/src/main/java/com/marmitt/core/dto/boot/BootExecutionCommand.java
@@ -1,0 +1,21 @@
+package com.marmitt.core.dto.boot;
+
+import com.marmitt.core.enums.BootAccountQueryPolicy;
+import com.marmitt.core.enums.BootFailureMode;
+
+import java.math.BigDecimal;
+
+public record BootExecutionCommand(
+        boolean phase1Enabled,
+        boolean phase2Enabled,
+        boolean phase3Enabled,
+        BootFailureMode phase2Mode,
+        BootAccountQueryPolicy accountQueryPolicy,
+        boolean sanityEnabled,
+        BigDecimal sanityThreshold,
+        boolean zombieDetectionEnabled,
+        boolean reservationTtlEnabled,
+        long reservationTtlMs,
+        boolean cutoffEnabled
+) {
+}

--- a/core/src/main/java/com/marmitt/core/dto/boot/BootExecutionSummary.java
+++ b/core/src/main/java/com/marmitt/core/dto/boot/BootExecutionSummary.java
@@ -1,0 +1,12 @@
+package com.marmitt.core.dto.boot;
+
+import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
+
+import java.util.List;
+
+public record BootExecutionSummary(
+        int portfoliosCount,
+        int eligibleRunnersCount,
+        List<RunnerBootRecoveryUseCase.RecoverySummary> runnerSummaries
+) {
+}

--- a/core/src/main/java/com/marmitt/core/enums/BootAccountQueryPolicy.java
+++ b/core/src/main/java/com/marmitt/core/enums/BootAccountQueryPolicy.java
@@ -1,0 +1,6 @@
+package com.marmitt.core.enums;
+
+public enum BootAccountQueryPolicy {
+    SKIP,
+    FAIL
+}

--- a/core/src/main/java/com/marmitt/core/enums/BootFailureMode.java
+++ b/core/src/main/java/com/marmitt/core/enums/BootFailureMode.java
@@ -1,0 +1,6 @@
+package com.marmitt.core.enums;
+
+public enum BootFailureMode {
+    WARN_ONLY,
+    FAIL_FAST
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/boot/BootExecutionObserverPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/boot/BootExecutionObserverPort.java
@@ -1,0 +1,14 @@
+package com.marmitt.core.ports.outbound.boot;
+
+public interface BootExecutionObserverPort {
+
+    void onPhaseStarted(String phase);
+
+    void onPhaseCompleted(String phase, boolean success, long durationMs, String message);
+
+    void onPhaseSkipped(String phase, String reason);
+
+    void onPortfolioPhaseEvaluated(String phase, String status, String exchange, String mode, long durationMs);
+
+    void onFailFastRequested(String phase, String code, String message);
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
@@ -1,26 +1,12 @@
 package com.marmitt.application.spring.bootstrap;
 
-import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
-import com.marmitt.core.domain.portfolio.DeadLetterEntry;
-import com.marmitt.core.domain.portfolio.Portfolio;
-import com.marmitt.core.domain.runner.ClientOrderId;
-import com.marmitt.core.domain.runner.StrategyRunner;
-import com.marmitt.core.dto.portfolio.PortfolioBootSanityResult;
-import com.marmitt.core.dto.portfolio.PortfolioZombieCandidate;
-import com.marmitt.core.dto.portfolio.PortfolioReservationTtlResult;
-import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
-import com.marmitt.core.dto.exchange.boot.ExchangeBootReadiness;
-import com.marmitt.core.enums.PortfolioReservationTtlStatus;
-import com.marmitt.core.enums.RunnerStatus;
-import com.marmitt.core.enums.PortfolioSanityStatus;
-import com.marmitt.core.enums.PortfolioZombieDetectionStatus;
-import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
-import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
-import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
-import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import com.marmitt.core.application.usecase.boot.BootFailFastException;
+import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
+import com.marmitt.core.dto.boot.BootExecutionCommand;
+import com.marmitt.core.dto.boot.BootExecutionSummary;
+import com.marmitt.core.enums.BootAccountQueryPolicy;
+import com.marmitt.core.enums.BootFailureMode;
+import com.marmitt.core.ports.outbound.boot.BootExecutionObserverPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -30,28 +16,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Stream;
 
-/**
- * Orquestrador de boot em nivel de aplicacao.
- *
- * <p>Responsabilidade nesta fase:
- * <ul>
- *   <li>Demonstrar a ordem de fases do boot recovery.</li>
- *   <li>Disparar o RunnerBootRecoveryUseCase para cada runner elegivel.</li>
- *   <li>Executar saneamento/reconciliacao por runner e registrar resumo em log.</li>
- * </ul>
- *
- * <p>Ativacao:
- * <ul>
- *   <li>{@code runner.boot.orchestrator-enabled=true}</li>
- * </ul>
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -62,13 +27,6 @@ import java.util.stream.Stream;
 )
 public class BootOrchestrator {
 
-    private final PortfolioRepositoryPort portfolioRepository;
-    private final StrategyRunnerRepositoryPort strategyRunnerRepository;
-    private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
-    private final PortfolioBootSanityUseCase portfolioBootSanityUseCase;
-    private final PortfolioReservationTtlUseCase portfolioReservationTtlUseCase;
-    private final PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase;
-    private final DeadLetterEntryRepositoryPort deadLetterEntryRepository;
     private final RunnerBootPhase1Properties phase1Properties;
     private final RunnerBootPhase2Properties phase2Properties;
     private final RunnerBootPhase3Properties phase3Properties;
@@ -76,7 +34,7 @@ public class BootOrchestrator {
     private final PortfolioReservationTtlProperties portfolioReservationTtlProperties;
     private final PortfolioZombieDetectionProperties portfolioZombieDetectionProperties;
     private final PortfolioCutoffProperties portfolioCutoffProperties;
-    private final RunnerBootRecoveryUseCase runnerBootRecoveryUseCase;
+    private final RunBootSequenceUseCase runBootSequenceUseCase;
     private final BootStatusTracker bootStatusTracker;
     private final BootMetricsRecorder bootMetricsRecorder;
     private final ApplicationEventPublisher applicationEventPublisher;
@@ -92,39 +50,22 @@ public class BootOrchestrator {
                 phase3Properties.isEnabled());
 
         try {
-            List<Portfolio> portfolios = portfolioRepository.findAll();
-            List<StrategyRunner> eligibleRunners = portfolios.stream()
-                    .flatMap(this::loadRunnersByPortfolio)
-                    .filter(this::isEligibleForRecovery)
-                    .toList();
-
-            executePhase("phase1.infrastructure", phase1Properties.isEnabled(),
-                    () -> runPhase1InfrastructureReadiness(eligibleRunners));
-
-            boolean phase2Enabled = phase2Properties.isEnabled();
-            executePhase("phase2.sanity",
-                    phase2Enabled && portfolioSanityCheckProperties.isEnabled(),
-                    () -> runPhase2PortfolioSanity(portfolios, eligibleRunners));
-            executePhase("phase2.zombie",
-                    phase2Enabled && portfolioZombieDetectionProperties.isEnabled(),
-                    () -> runPhase2ZombieDetection(portfolios, eligibleRunners));
-            executePhase("phase2.reservation_ttl",
-                    phase2Enabled && portfolioReservationTtlProperties.isEnabled(),
-                    () -> runPhase2ReservationTtl(portfolios, eligibleRunners));
-
-            List<RunnerBootRecoveryUseCase.RecoverySummary> summaries = new ArrayList<>();
-            executePhase("phase3.runner_recovery", phase3Properties.isEnabled(),
-                    () -> summaries.addAll(eligibleRunners.stream().map(this::recoverRunner).toList()));
+            BootExecutionSummary summary = runBootSequenceUseCase.execute(buildCommand(), new SpringBootExecutionObserver());
 
             bootStatusTracker.completeRun();
             bootMetricsRecorder.recordRun(BootRunStatus.SUCCESS);
             log.info("bootOrchestrator: completed runId={} portfolios={} runners={}",
-                    bootStatusTracker.currentRunId(), portfolios.size(), summaries.size());
+                    bootStatusTracker.currentRunId(),
+                    summary.portfoliosCount(),
+                    summary.runnerSummaries().size());
+        } catch (BootFailFastException e) {
+            failRunIfStillRunning(e.phase(), e.getMessage());
+            bootMetricsRecorder.recordRun(BootRunStatus.FAILED);
+            log.error("bootOrchestrator: failed runId={} phase={} code={} reason={}",
+                    bootStatusTracker.currentRunId(), e.phase(), e.code(), e.getMessage(), e);
+            throw new IllegalStateException(e.getMessage(), e);
         } catch (RuntimeException e) {
-            BootRunSnapshot snapshot = bootStatusTracker.snapshot();
-            if (snapshot.status() == BootRunStatus.RUNNING) {
-                bootStatusTracker.failRun("boot", e.getMessage());
-            }
+            failRunIfStillRunning("boot", e.getMessage());
             bootMetricsRecorder.recordRun(BootRunStatus.FAILED);
             log.error("bootOrchestrator: failed runId={} reason={}",
                     bootStatusTracker.currentRunId(), e.getMessage(), e);
@@ -132,474 +73,82 @@ public class BootOrchestrator {
         }
     }
 
-    private void runPhase1InfrastructureReadiness(List<StrategyRunner> runners) {
-        Set<String> exchanges = runners.stream()
-                .map(StrategyRunner::getExchangeId)
-                .filter(exchange -> exchange != null && !exchange.isBlank())
-                .map(String::toUpperCase)
-                .collect(java.util.stream.Collectors.toCollection(java.util.TreeSet::new));
+    private BootExecutionCommand buildCommand() {
+        return new BootExecutionCommand(
+                phase1Properties.isEnabled(),
+                phase2Properties.isEnabled(),
+                phase3Properties.isEnabled(),
+                toFailureMode(phase2Properties.getMode()),
+                toAccountQueryPolicy(phase2Properties.getAccountQueryPolicy()),
+                portfolioSanityCheckProperties.isEnabled(),
+                portfolioSanityCheckProperties.getThreshold(),
+                portfolioZombieDetectionProperties.isEnabled(),
+                portfolioReservationTtlProperties.isEnabled(),
+                portfolioReservationTtlProperties.getTtlMs(),
+                portfolioCutoffProperties.isEnabled()
+        );
+    }
 
-        if (exchanges.isEmpty()) {
-            log.info("bootOrchestrator.phase1: no exchange to validate");
-            return;
+    private void failRunIfStillRunning(String phase, String message) {
+        BootRunSnapshot snapshot = bootStatusTracker.snapshot();
+        if (snapshot.status() == BootRunStatus.RUNNING) {
+            bootStatusTracker.failRun(phase, message);
+        }
+    }
+
+    private static BootFailureMode toFailureMode(Phase2Mode mode) {
+        return switch (mode) {
+            case WARN_ONLY -> BootFailureMode.WARN_ONLY;
+            case FAIL_FAST -> BootFailureMode.FAIL_FAST;
+        };
+    }
+
+    private static BootAccountQueryPolicy toAccountQueryPolicy(Phase2AccountQueryPolicy policy) {
+        return switch (policy) {
+            case SKIP -> BootAccountQueryPolicy.SKIP;
+            case FAIL -> BootAccountQueryPolicy.FAIL;
+        };
+    }
+
+    private final class SpringBootExecutionObserver implements BootExecutionObserverPort {
+
+        @Override
+        public void onPhaseStarted(String phase) {
+            bootStatusTracker.startPhase(phase);
         }
 
-        log.info("bootOrchestrator.phase1: start exchanges={}", exchanges.size());
-
-        for (String exchange : exchanges) {
-            ExchangeBootReadiness readiness = exchangeAdapterRepository.findBootReadinessByName(exchange)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Boot readiness capability is not registered for exchange=" + exchange))
-                    .checkBootReadiness();
-
-            if (!readiness.ready()) {
-                throw failFast(
-                        "phase1.infrastructure",
-                        readiness.code(),
-                        "Phase1 readiness failed exchange=" + exchange + " message=" + readiness.message()
-                );
-            }
-
-            log.info("bootOrchestrator.phase1: exchange={} ready code={} message={}",
-                    exchange, readiness.code(), readiness.message());
+        @Override
+        public void onPhaseCompleted(String phase, boolean success, long durationMs, String message) {
+            BootPhaseStatus status = success ? BootPhaseStatus.SUCCESS : BootPhaseStatus.FAILED;
+            bootStatusTracker.completePhase(phase, status, message);
+            bootMetricsRecorder.recordPhase(phase, status, durationMs);
+            log.info("bootOrchestrator: phase={} status={} durationMs={} runId={}",
+                    phase, status, durationMs, bootStatusTracker.currentRunId());
         }
 
-        log.info("bootOrchestrator.phase1: completed exchanges={}", exchanges.size());
-    }
-
-    private void runPhase2PortfolioSanity(List<Portfolio> portfolios, List<StrategyRunner> eligibleRunners) {
-        Phase2Mode mode = phase2Properties.getMode();
-        log.info("bootOrchestrator.phase2.sanity: start portfolios={} mode={} accountQueryPolicy={} threshold={}",
-                portfolios.size(), mode, phase2Properties.getAccountQueryPolicy(), portfolioSanityCheckProperties.getThreshold());
-
-        for (Portfolio portfolio : portfolios) {
-            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
-
-            if (exchanges.isEmpty()) {
-                log.debug("bootOrchestrator.phase2.sanity: portfolio={} skipped - no eligible runner exchange",
-                        portfolio.getId());
-                continue;
-            }
-
-            for (String exchange : exchanges) {
-                long startedNs = System.nanoTime();
-                PortfolioBootSanityResult result =
-                        portfolioBootSanityUseCase.execute(
-                                portfolio.getId(),
-                                exchange,
-                                portfolioSanityCheckProperties.getThreshold()
-                        );
-                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-                bootMetricsRecorder.recordPortfolioPhaseEvaluation(
-                        "phase2.sanity",
-                        result.status().name(),
-                        exchange,
-                        mode.name(),
-                        durationMs
-                );
-
-                switch (result.status()) {
-                    case PASS, WARN_SURPLUS -> log.info(
-                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} localTotal={} exchangeTotal={} signedDelta={} deviation={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.localTotal(),
-                            result.exchangeTotal(),
-                            result.signedDelta(),
-                            result.absoluteDeviation()
-                    );
-                    case SKIPPED -> log.warn(
-                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} message={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message()
-                    );
-                    case FAIL_DEFICIT -> log.error(
-                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} message={} localTotal={} exchangeTotal={} signedDelta={} deviation={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message(),
-                            result.localTotal(),
-                            result.exchangeTotal(),
-                            result.signedDelta(),
-                            result.absoluteDeviation()
-                    );
-                    case FAILED -> log.warn(
-                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} message={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message()
-                    );
-                }
-
-                boolean skippedWithFailPolicy = result.status() == PortfolioSanityStatus.SKIPPED
-                        && phase2Properties.getAccountQueryPolicy() == Phase2AccountQueryPolicy.FAIL;
-                boolean criticalFailure = result.status() == PortfolioSanityStatus.FAIL_DEFICIT
-                        || result.status() == PortfolioSanityStatus.FAILED;
-                if ((skippedWithFailPolicy || criticalFailure) && mode == Phase2Mode.FAIL_FAST) {
-                    throw failFast(
-                            "phase2.sanity",
-                            result.code(),
-                            "Phase2 sanity failed portfolio=" + result.portfolioId()
-                                    + " exchange=" + result.exchangeId()
-                                    + " message=" + result.message()
-                    );
-                }
-            }
-        }
-
-        log.info("bootOrchestrator.phase2.sanity: completed");
-    }
-
-    private void runPhase2ZombieDetection(List<Portfolio> portfolios, List<StrategyRunner> eligibleRunners) {
-        Phase2Mode mode = phase2Properties.getMode();
-        log.info("bootOrchestrator.phase2.zombie: start portfolios={} mode={} cutoffEnabled={}",
-                portfolios.size(), mode, portfolioCutoffProperties.isEnabled());
-
-        for (Portfolio portfolio : portfolios) {
-            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
-            if (exchanges.isEmpty()) {
-                continue;
-            }
-
-            for (String exchange : exchanges) {
-                long startedNs = System.nanoTime();
-                PortfolioZombieDetectionResult result =
-                        portfolioZombieDetectionUseCase.execute(
-                                portfolio.getId(),
-                                exchange,
-                                portfolioCutoffProperties.isEnabled()
-                        );
-                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-                bootMetricsRecorder.recordPortfolioPhaseEvaluation(
-                        "phase2.zombie",
-                        result.status().name(),
-                        exchange,
-                        mode.name(),
-                        durationMs
-                );
-
-                switch (result.status()) {
-                    case CLEAN -> log.info(
-                            "bootOrchestrator.phase2.zombie: portfolio={} exchange={} status={} openOrders={} zombies={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.openOrders(),
-                            result.zombieCount()
-                    );
-                    case DETECTED -> {
-                        boolean persistToDlq = mode == Phase2Mode.FAIL_FAST;
-                        int persistedSamples = persistToDlq ? persistZombieSamplesToDlq(result) : 0;
-                        log.warn(
-                                "bootOrchestrator.phase2.zombie: portfolio={} exchange={} mode={} status={} code={} openOrders={} zombies={} invalidFormat={} unknownRunner={} noLocalMatch={} beforeCutoff={} unknownSymbol={} persistedSamples={} dlqPersisted={}",
-                                result.portfolioId(),
-                                result.exchangeId(),
-                                mode,
-                                result.status(),
-                                result.code(),
-                                result.openOrders(),
-                                result.zombieCount(),
-                                result.invalidFormatCount(),
-                                result.unknownRunnerCount(),
-                                result.noLocalMatchCount(),
-                                result.beforeCutoffCount(),
-                                result.unknownSymbolCount(),
-                                persistedSamples,
-                                persistToDlq
-                        );
-                        result.samples().forEach(sample -> log.warn(
-                                "bootOrchestrator.phase2.zombie: sample portfolio={} exchange={} reason={} code={} clientOrderId={} exchangeOrderId={} symbol={}",
-                                result.portfolioId(),
-                                result.exchangeId(),
-                                sample.reason(),
-                                sample.code(),
-                                sample.clientOrderId(),
-                                sample.exchangeOrderId(),
-                                sample.symbol()
-                        ));
-                    }
-                    case SKIPPED -> log.warn(
-                            "bootOrchestrator.phase2.zombie: portfolio={} exchange={} status={} code={} message={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message()
-                    );
-                    case FAILED -> log.error(
-                            "bootOrchestrator.phase2.zombie: portfolio={} exchange={} status={} code={} message={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message()
-                    );
-                }
-
-                boolean criticalFailure = result.status() == PortfolioZombieDetectionStatus.FAILED
-                        || result.status() == PortfolioZombieDetectionStatus.DETECTED;
-                if (criticalFailure && mode == Phase2Mode.FAIL_FAST) {
-                    throw failFast(
-                            "phase2.zombie",
-                            result.code(),
-                            "Phase2 zombie detection failed portfolio=" + result.portfolioId()
-                                    + " exchange=" + result.exchangeId()
-                                    + " message=" + result.message()
-                    );
-                }
-            }
-        }
-
-        log.info("bootOrchestrator.phase2.zombie: completed");
-    }
-
-    private void runPhase2ReservationTtl(List<Portfolio> portfolios, List<StrategyRunner> eligibleRunners) {
-        long ttlMs = portfolioReservationTtlProperties.getTtlMs();
-        Phase2Mode mode = phase2Properties.getMode();
-        log.info("bootOrchestrator.phase2.ttl: start portfolios={} mode={} ttlMs={}",
-                portfolios.size(), mode, ttlMs);
-
-        for (Portfolio portfolio : portfolios) {
-            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
-            if (exchanges.isEmpty()) {
-                continue;
-            }
-
-            for (String exchange : exchanges) {
-                List<StrategyRunner> scopedRunners = eligibleRunners.stream()
-                        .filter(runner -> runner.getPortfolioId().equals(portfolio.getId()))
-                        .filter(runner -> exchange.equalsIgnoreCase(runner.getExchangeId()))
-                        .toList();
-
-                long startedNs = System.nanoTime();
-                PortfolioReservationTtlResult result = portfolioReservationTtlUseCase.execute(
-                        portfolio.getId(),
-                        exchange,
-                        ttlMs,
-                        scopedRunners
-                );
-                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-                bootMetricsRecorder.recordPortfolioPhaseEvaluation(
-                        "phase2.reservation_ttl",
-                        result.status().name(),
-                        exchange,
-                        mode.name(),
-                        durationMs
-                );
-
-                switch (result.status()) {
-                    case CLEAN -> log.info(
-                            "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.ttlMs(),
-                            result.scannedPendingCount(),
-                            result.eligibleNoExchangeOrderIdCount(),
-                            result.expiredCount(),
-                            result.freshCount(),
-                            result.errorCount()
-                    );
-                    case EXPIRED -> {
-                        log.warn(
-                                "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} code={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
-                                result.portfolioId(),
-                                result.exchangeId(),
-                                result.status(),
-                                result.code(),
-                                result.ttlMs(),
-                                result.scannedPendingCount(),
-                                result.eligibleNoExchangeOrderIdCount(),
-                                result.expiredCount(),
-                                result.freshCount(),
-                                result.errorCount()
-                        );
-                        result.samples().forEach(transactionId -> log.warn(
-                                "bootOrchestrator.phase2.ttl: expiredSample portfolio={} exchange={} transactionId={}",
-                                result.portfolioId(),
-                                result.exchangeId(),
-                                transactionId
-                        ));
-                    }
-                    case SKIPPED -> log.warn(
-                            "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} code={} message={} ttlMs={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message(),
-                            result.ttlMs()
-                    );
-                    case FAILED -> log.error(
-                            "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} code={} message={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message(),
-                            result.ttlMs(),
-                            result.scannedPendingCount(),
-                            result.eligibleNoExchangeOrderIdCount(),
-                            result.expiredCount(),
-                            result.freshCount(),
-                            result.errorCount()
-                    );
-                }
-
-                boolean criticalFailure = result.status() == PortfolioReservationTtlStatus.FAILED;
-                if (criticalFailure && mode == Phase2Mode.FAIL_FAST) {
-                    throw failFast(
-                            "phase2.reservation_ttl",
-                            result.code(),
-                            "Phase2 reservation TTL failed portfolio=" + result.portfolioId()
-                                    + " exchange=" + result.exchangeId()
-                                    + " message=" + result.message()
-                    );
-                }
-            }
-        }
-
-        log.info("bootOrchestrator.phase2.ttl: completed");
-    }
-
-    private Set<String> resolvePortfolioExchanges(Portfolio portfolio, List<StrategyRunner> eligibleRunners) {
-        return eligibleRunners.stream()
-                .filter(runner -> runner.getPortfolioId().equals(portfolio.getId()))
-                .map(StrategyRunner::getExchangeId)
-                .filter(exchange -> exchange != null && !exchange.isBlank())
-                .map(String::toUpperCase)
-                .collect(java.util.stream.Collectors.toCollection(java.util.TreeSet::new));
-    }
-
-    private Stream<StrategyRunner> loadRunnersByPortfolio(Portfolio portfolio) {
-        return strategyRunnerRepository.findByPortfolioId(portfolio.getId()).stream();
-    }
-
-    private boolean isEligibleForRecovery(StrategyRunner runner) {
-        return runner.getStatus() != RunnerStatus.ARCHIVED
-                && runner.getStatus() != RunnerStatus.TERMINATING;
-    }
-
-    private RunnerBootRecoveryUseCase.RecoverySummary recoverRunner(StrategyRunner runner) {
-        RunnerBootRecoveryUseCase.RecoverySummary summary = runnerBootRecoveryUseCase.recoverRunner(runner);
-
-        log.info("bootOrchestrator: runner={} inFlight={} zombies={} limbo={}",
-                summary.runnerId(), summary.inFlightCount(), summary.zombiesCount(), summary.limboCount());
-
-        // Verbose somente em debug para nao poluir log de producao.
-        if (log.isDebugEnabled()) {
-            summary.notes().forEach(note ->
-                    log.debug("bootOrchestrator: runner={} plan={}", summary.runnerId(), note));
-        }
-
-        return summary;
-    }
-
-    private void executePhase(String phase, boolean enabled, Runnable action) {
-        if (!enabled) {
-            bootStatusTracker.completePhase(phase, BootPhaseStatus.SKIPPED, "disabled_by_configuration");
+        @Override
+        public void onPhaseSkipped(String phase, String reason) {
+            bootStatusTracker.completePhase(phase, BootPhaseStatus.SKIPPED, reason);
             bootMetricsRecorder.recordPhase(phase, BootPhaseStatus.SKIPPED, 0L);
-            log.info("bootOrchestrator: phase={} status=SKIPPED reason=disabled_by_configuration runId={}",
-                    phase, bootStatusTracker.currentRunId());
-            return;
+            log.info("bootOrchestrator: phase={} status=SKIPPED reason={} runId={}",
+                    phase, reason, bootStatusTracker.currentRunId());
         }
 
-        long startedNs = System.nanoTime();
-        bootStatusTracker.startPhase(phase);
-        try {
-            action.run();
-            long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-            bootStatusTracker.completePhase(phase, BootPhaseStatus.SUCCESS, "ok");
-            bootMetricsRecorder.recordPhase(phase, BootPhaseStatus.SUCCESS, durationMs);
-            log.info("bootOrchestrator: phase={} status=SUCCESS durationMs={} runId={}",
-                    phase, durationMs, bootStatusTracker.currentRunId());
-        } catch (RuntimeException e) {
-            long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-            bootStatusTracker.completePhase(phase, BootPhaseStatus.FAILED, e.getMessage());
-            bootMetricsRecorder.recordPhase(phase, BootPhaseStatus.FAILED, durationMs);
-            bootStatusTracker.failRun(phase, e.getMessage());
-            throw e;
-        }
-    }
-
-    private IllegalStateException failFast(String phase, String code, String message) {
-        bootMetricsRecorder.recordFailFast(phase, code);
-        applicationEventPublisher.publishEvent(new BootFailFastEvent(
-                bootStatusTracker.currentRunId(),
-                phase,
-                code,
-                message,
-                Instant.now()
-        ));
-        return new IllegalStateException(message + " code=" + code);
-    }
-
-    private int persistZombieSamplesToDlq(PortfolioZombieDetectionResult result) {
-        int persisted = 0;
-        for (PortfolioZombieCandidate sample : result.samples()) {
-            UUID runnerId = resolveRunnerIdForZombieSample(result.portfolioId(), sample);
-
-            boolean alreadyOpen = deadLetterEntryRepository.existsUnresolvedByIdentity(
-                    result.portfolioId(),
-                    runnerId,
-                    sample.clientOrderId(),
-                    sample.exchangeOrderId(),
-                    sample.reason()
-            );
-
-            if (alreadyOpen) {
-                continue;
-            }
-
-            DeadLetterEntry entry = new DeadLetterEntry(
-                    result.portfolioId(),
-                    runnerId,
-                    sample.clientOrderId(),
-                    sample.exchangeOrderId(),
-                    "source=boot.phase2.zombie"
-                            + ", exchange=" + result.exchangeId()
-                            + ", runnerId=" + runnerId
-                            + ", code=" + sample.code()
-                            + ", symbol=" + sample.symbol()
-                            + ", reason=" + sample.reason(),
-                    sample.reason()
-            );
-            deadLetterEntryRepository.save(entry);
-            persisted++;
-        }
-        return persisted;
-    }
-
-    private UUID resolveRunnerIdForZombieSample(UUID portfolioId, PortfolioZombieCandidate sample) {
-        String clientOrderId = sample.clientOrderId();
-        if (clientOrderId == null || clientOrderId.isBlank()) {
-            return null;
+        @Override
+        public void onPortfolioPhaseEvaluated(String phase, String status, String exchange, String mode, long durationMs) {
+            bootMetricsRecorder.recordPortfolioPhaseEvaluation(phase, status, exchange, mode, durationMs);
         }
 
-        var byTransaction = strategyRunnerRepository.findTransactionByClientOrderId(clientOrderId)
-                .flatMap(tx -> strategyRunnerRepository.findById(tx.getRunnerId())
-                        .filter(runner -> portfolioId.equals(runner.getPortfolioId()))
-                        .map(StrategyRunner::getId));
-        if (byTransaction.isPresent()) {
-            return byTransaction.get();
+        @Override
+        public void onFailFastRequested(String phase, String code, String message) {
+            bootMetricsRecorder.recordFailFast(phase, code);
+            applicationEventPublisher.publishEvent(new BootFailFastEvent(
+                    bootStatusTracker.currentRunId(),
+                    phase,
+                    code,
+                    message,
+                    Instant.now()
+            ));
         }
-
-        String shortCode = ClientOrderId.getRunnerShortCode(clientOrderId);
-        if (shortCode == null || shortCode.isBlank()) {
-            return null;
-        }
-
-        return strategyRunnerRepository.findByShortCodeAndPortfolioId(shortCode.toLowerCase(Locale.ROOT), portfolioId)
-                .map(StrategyRunner::getId)
-                .orElse(null);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
@@ -1,6 +1,7 @@
 package com.marmitt.application.spring.bootstrap;
 
 import com.marmitt.core.application.usecase.boot.BootFailFastException;
+import com.marmitt.core.application.usecase.boot.BootPhaseExecutionException;
 import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
 import com.marmitt.core.dto.boot.BootExecutionCommand;
 import com.marmitt.core.dto.boot.BootExecutionSummary;
@@ -63,6 +64,12 @@ public class BootOrchestrator {
             bootMetricsRecorder.recordRun(BootRunStatus.FAILED);
             log.error("bootOrchestrator: failed runId={} phase={} code={} reason={}",
                     bootStatusTracker.currentRunId(), e.phase(), e.code(), e.getMessage(), e);
+            throw new IllegalStateException(e.getMessage(), e);
+        } catch (BootPhaseExecutionException e) {
+            failRunIfStillRunning(e.phase(), e.getMessage());
+            bootMetricsRecorder.recordRun(BootRunStatus.FAILED);
+            log.error("bootOrchestrator: failed runId={} phase={} reason={}",
+                    bootStatusTracker.currentRunId(), e.phase(), e.getMessage(), e);
             throw new IllegalStateException(e.getMessage(), e);
         } catch (RuntimeException e) {
             failRunIfStillRunning("boot", e.getMessage());

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/BootConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/BootConfig.java
@@ -1,0 +1,40 @@
+package com.marmitt.application.spring.config.core;
+
+import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
+import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
+import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
+import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
+import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
+import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BootConfig {
+
+    @Bean
+    public RunBootSequenceUseCase runBootSequenceUseCase(
+            PortfolioRepositoryPort portfolioRepository,
+            StrategyRunnerRepositoryPort strategyRunnerRepository,
+            ExchangeAdapterRepositoryPort exchangeAdapterRepository,
+            PortfolioBootSanityUseCase portfolioBootSanityUseCase,
+            PortfolioReservationTtlUseCase portfolioReservationTtlUseCase,
+            PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase,
+            DeadLetterEntryRepositoryPort deadLetterEntryRepository,
+            RunnerBootRecoveryUseCase runnerBootRecoveryUseCase
+    ) {
+        return new RunBootSequenceUseCase(
+                portfolioRepository,
+                strategyRunnerRepository,
+                exchangeAdapterRepository,
+                portfolioBootSanityUseCase,
+                portfolioReservationTtlUseCase,
+                portfolioZombieDetectionUseCase,
+                deadLetterEntryRepository,
+                runnerBootRecoveryUseCase
+        );
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
@@ -1,5 +1,6 @@
 package com.marmitt.application.spring.bootstrap;
 
+import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
@@ -181,7 +182,7 @@ class BootOrchestratorBootMinimumTest {
         PortfolioCutoffProperties cutoffProperties = new PortfolioCutoffProperties();
         cutoffProperties.setEnabled(true);
 
-        return new BootOrchestrator(
+        RunBootSequenceUseCase runBootSequenceUseCase = new RunBootSequenceUseCase(
                 portfolioRepository,
                 strategyRunnerRepository,
                 exchangeAdapterRepository,
@@ -189,6 +190,10 @@ class BootOrchestratorBootMinimumTest {
                 portfolioReservationTtlUseCase,
                 portfolioZombieDetectionUseCase,
                 deadLetterRepository,
+                runnerBootRecoveryUseCase
+        );
+
+        return new BootOrchestrator(
                 phase1Properties,
                 phase2Properties,
                 phase3Properties,
@@ -196,7 +201,7 @@ class BootOrchestratorBootMinimumTest {
                 ttlProperties,
                 zombieProperties,
                 cutoffProperties,
-                runnerBootRecoveryUseCase,
+                runBootSequenceUseCase,
                 tracker,
                 bootMetricsRecorder,
                 eventPublisher

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
@@ -140,6 +140,31 @@ class BootOrchestratorBootMinimumTest {
         verify(eventPublisher).publishEvent(any(BootFailFastEvent.class));
     }
 
+    @Test
+    void unexpectedPhaseRuntimePreservesSpecificFailurePhase() {
+        Portfolio portfolio = new Portfolio(UUID.randomUUID(), "p1");
+        StrategyRunner runner = activeRunner(portfolio.getId(), "MOCK");
+
+        BootStatusTracker tracker = new BootStatusTracker();
+        DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        BootOrchestrator orchestrator = newOrchestratorWithZombieFailure(
+                portfolio,
+                runner,
+                tracker,
+                deadLetterRepository,
+                eventPublisher
+        );
+
+        assertThrows(IllegalStateException.class, orchestrator::onApplicationReady);
+
+        BootRunSnapshot snapshot = tracker.snapshot();
+        assertEquals(BootRunStatus.FAILED, snapshot.status());
+        assertEquals("phase2.zombie", snapshot.failurePhase());
+        verifyNoInteractions(deadLetterRepository);
+        verifyNoInteractions(eventPublisher);
+    }
+
     private static BootOrchestrator newOrchestrator(Phase2Mode mode,
                                                     Portfolio portfolio,
                                                     StrategyRunner runner,
@@ -166,6 +191,73 @@ class BootOrchestratorBootMinimumTest {
         RunnerBootPhase2Properties phase2Properties = new RunnerBootPhase2Properties();
         phase2Properties.setEnabled(true);
         phase2Properties.setMode(mode);
+
+        RunnerBootPhase3Properties phase3Properties = new RunnerBootPhase3Properties();
+        phase3Properties.setEnabled(false);
+
+        PortfolioSanityCheckProperties sanityProperties = new PortfolioSanityCheckProperties();
+        sanityProperties.setEnabled(false);
+
+        PortfolioReservationTtlProperties ttlProperties = new PortfolioReservationTtlProperties();
+        ttlProperties.setEnabled(false);
+
+        PortfolioZombieDetectionProperties zombieProperties = new PortfolioZombieDetectionProperties();
+        zombieProperties.setEnabled(true);
+
+        PortfolioCutoffProperties cutoffProperties = new PortfolioCutoffProperties();
+        cutoffProperties.setEnabled(true);
+
+        RunBootSequenceUseCase runBootSequenceUseCase = new RunBootSequenceUseCase(
+                portfolioRepository,
+                strategyRunnerRepository,
+                exchangeAdapterRepository,
+                portfolioBootSanityUseCase,
+                portfolioReservationTtlUseCase,
+                portfolioZombieDetectionUseCase,
+                deadLetterRepository,
+                runnerBootRecoveryUseCase
+        );
+
+        return new BootOrchestrator(
+                phase1Properties,
+                phase2Properties,
+                phase3Properties,
+                sanityProperties,
+                ttlProperties,
+                zombieProperties,
+                cutoffProperties,
+                runBootSequenceUseCase,
+                tracker,
+                bootMetricsRecorder,
+                eventPublisher
+        );
+    }
+
+    private static BootOrchestrator newOrchestratorWithZombieFailure(Portfolio portfolio,
+                                                                     StrategyRunner runner,
+                                                                     BootStatusTracker tracker,
+                                                                     DeadLetterEntryRepositoryPort deadLetterRepository,
+                                                                     ApplicationEventPublisher eventPublisher) {
+        PortfolioRepositoryPort portfolioRepository = mock(PortfolioRepositoryPort.class);
+        StrategyRunnerRepositoryPort strategyRunnerRepository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeAdapterRepository = mock(ExchangeAdapterRepositoryPort.class);
+        PortfolioBootSanityUseCase portfolioBootSanityUseCase = mock(PortfolioBootSanityUseCase.class);
+        PortfolioReservationTtlUseCase portfolioReservationTtlUseCase = mock(PortfolioReservationTtlUseCase.class);
+        PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase = mock(PortfolioZombieDetectionUseCase.class);
+        RunnerBootRecoveryUseCase runnerBootRecoveryUseCase = mock(RunnerBootRecoveryUseCase.class);
+        BootMetricsRecorder bootMetricsRecorder = mock(BootMetricsRecorder.class);
+
+        when(portfolioRepository.findAll()).thenReturn(List.of(portfolio));
+        when(strategyRunnerRepository.findByPortfolioId(portfolio.getId())).thenReturn(List.of(runner));
+        when(portfolioZombieDetectionUseCase.execute(portfolio.getId(), "MOCK", true))
+                .thenThrow(new IllegalStateException("Simulated unexpected zombie failure"));
+
+        RunnerBootPhase1Properties phase1Properties = new RunnerBootPhase1Properties();
+        phase1Properties.setEnabled(false);
+
+        RunnerBootPhase2Properties phase2Properties = new RunnerBootPhase2Properties();
+        phase2Properties.setEnabled(true);
+        phase2Properties.setMode(Phase2Mode.WARN_ONLY);
 
         RunnerBootPhase3Properties phase3Properties = new RunnerBootPhase3Properties();
         phase3Properties.setEnabled(false);

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
@@ -1,5 +1,6 @@
 package com.marmitt.application.spring.bootstrap;
 
+import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
@@ -189,7 +190,7 @@ class BootOrchestratorDlqOperationalTest {
         PortfolioCutoffProperties cutoffProperties = new PortfolioCutoffProperties();
         cutoffProperties.setEnabled(true);
 
-        return new BootOrchestrator(
+        RunBootSequenceUseCase runBootSequenceUseCase = new RunBootSequenceUseCase(
                 portfolioRepository,
                 strategyRunnerRepository,
                 exchangeAdapterRepository,
@@ -197,6 +198,10 @@ class BootOrchestratorDlqOperationalTest {
                 portfolioReservationTtlUseCase,
                 portfolioZombieDetectionUseCase,
                 deadLetterRepository,
+                runnerBootRecoveryUseCase
+        );
+
+        return new BootOrchestrator(
                 phase1Properties,
                 phase2Properties,
                 phase3Properties,
@@ -204,7 +209,7 @@ class BootOrchestratorDlqOperationalTest {
                 ttlProperties,
                 zombieProperties,
                 cutoffProperties,
-                runnerBootRecoveryUseCase,
+                runBootSequenceUseCase,
                 tracker,
                 bootMetricsRecorder,
                 eventPublisher

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
@@ -1,5 +1,6 @@
 package com.marmitt.application.spring.bootstrap;
 
+import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
@@ -196,7 +197,7 @@ class BootOrchestratorObservabilityTest {
         PortfolioCutoffProperties cutoffProperties = new PortfolioCutoffProperties();
         cutoffProperties.setEnabled(true);
 
-        return new BootOrchestrator(
+        RunBootSequenceUseCase runBootSequenceUseCase = new RunBootSequenceUseCase(
                 portfolioRepository,
                 strategyRunnerRepository,
                 exchangeAdapterRepository,
@@ -204,6 +205,10 @@ class BootOrchestratorObservabilityTest {
                 portfolioReservationTtlUseCase,
                 portfolioZombieDetectionUseCase,
                 deadLetterRepository,
+                runnerBootRecoveryUseCase
+        );
+
+        return new BootOrchestrator(
                 phase1Properties,
                 phase2Properties,
                 phase3Properties,
@@ -211,7 +216,7 @@ class BootOrchestratorObservabilityTest {
                 ttlProperties,
                 zombieProperties,
                 cutoffProperties,
-                runnerBootRecoveryUseCase,
+                runBootSequenceUseCase,
                 tracker,
                 bootMetricsRecorder,
                 eventPublisher


### PR DESCRIPTION
## Summary
- extract the boot phase sequencing and fail-fast decisions into a core `RunBootSequenceUseCase`
- keep `BootOrchestrator` as the Spring adapter for `ApplicationReadyEvent`, metrics, status tracking and fail-fast event publication
- introduce a core observer port so boot observability stays at the edge while the orchestration flow moves inward

## Validation
- `powershell -ExecutionPolicy Bypass -File .\scripts\gradle-run.ps1 --no-daemon -q :core:compileJava :spring-application:compileJava`
- `powershell -ExecutionPolicy Bypass -File .\scripts\gradle-run.ps1 --no-daemon -q :spring-application:test --tests com.marmitt.application.spring.bootstrap.BootOrchestratorBootMinimumTest --tests com.marmitt.application.spring.bootstrap.BootOrchestratorObservabilityTest --tests com.marmitt.application.spring.bootstrap.BootOrchestratorDlqOperationalTest`