### PR TITLE
refactor(boot): move semantic status types to core

### DIFF
--- a/core/src/main/java/com/marmitt/core/dto/boot/BootPhaseSnapshot.java
+++ b/core/src/main/java/com/marmitt/core/dto/boot/BootPhaseSnapshot.java
@@ -1,4 +1,6 @@
-package com.marmitt.application.spring.bootstrap;
+package com.marmitt.core.dto.boot;
+
+import com.marmitt.core.enums.BootPhaseStatus;
 
 import java.time.Instant;
 

--- a/core/src/main/java/com/marmitt/core/dto/boot/BootRunSnapshot.java
+++ b/core/src/main/java/com/marmitt/core/dto/boot/BootRunSnapshot.java
@@ -1,4 +1,6 @@
-package com.marmitt.application.spring.bootstrap;
+package com.marmitt.core.dto.boot;
+
+import com.marmitt.core.enums.BootRunStatus;
 
 import java.time.Instant;
 import java.util.List;

--- a/core/src/main/java/com/marmitt/core/enums/BootPhaseStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/BootPhaseStatus.java
@@ -1,4 +1,4 @@
-package com.marmitt.application.spring.bootstrap;
+package com.marmitt.core.enums;
 
 public enum BootPhaseStatus {
     RUNNING,

--- a/core/src/main/java/com/marmitt/core/enums/BootRunStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/BootRunStatus.java
@@ -1,4 +1,4 @@
-package com.marmitt.application.spring.bootstrap;
+package com.marmitt.core.enums;
 
 public enum BootRunStatus {
     NOT_STARTED,

--- a/docs/QUESTOES_SEM_CLASSIFICACAO.md
+++ b/docs/QUESTOES_SEM_CLASSIFICACAO.md
@@ -1,1 +1,19 @@
-# Questões Sem Classificação
+# Questoes Sem Classificacao
+
+## Boot Orchestrator - semantica ainda presa no Spring
+
+Proximo PR da trilha do boot:
+
+- mover para o `core` os enums e snapshots que ainda representam semantica de boot:
+  - `BootRunStatus`
+  - `BootPhaseStatus`
+  - `BootRunSnapshot`
+  - `BootPhaseSnapshot`
+  - `Phase2Mode`
+  - `Phase2AccountQueryPolicy`
+- manter no `spring-application` apenas o que for detalhe de framework/adaptacao:
+  - `@ConfigurationProperties`
+  - `ApplicationReadyEvent`
+  - metricas
+  - `BootFailFastEvent`
+- objetivo: consolidar no `core` o estado e a politica do boot, deixando no `spring` apenas lifecycle, wiring e observabilidade tecnica

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootMetricsRecorder.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootMetricsRecorder.java
@@ -1,5 +1,7 @@
 package com.marmitt.application.spring.bootstrap;
 
+import com.marmitt.core.enums.BootPhaseStatus;
+import com.marmitt.core.enums.BootRunStatus;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.springframework.stereotype.Component;

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
@@ -4,7 +4,10 @@ import com.marmitt.core.application.usecase.boot.BootFailFastException;
 import com.marmitt.core.application.usecase.boot.BootPhaseExecutionException;
 import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
 import com.marmitt.core.dto.boot.BootExecutionCommand;
+import com.marmitt.core.dto.boot.BootRunSnapshot;
 import com.marmitt.core.dto.boot.BootExecutionSummary;
+import com.marmitt.core.enums.BootPhaseStatus;
+import com.marmitt.core.enums.BootRunStatus;
 import com.marmitt.core.enums.BootAccountQueryPolicy;
 import com.marmitt.core.enums.BootFailureMode;
 import com.marmitt.core.ports.outbound.boot.BootExecutionObserverPort;
@@ -85,8 +88,8 @@ public class BootOrchestrator {
                 phase1Properties.isEnabled(),
                 phase2Properties.isEnabled(),
                 phase3Properties.isEnabled(),
-                toFailureMode(phase2Properties.getMode()),
-                toAccountQueryPolicy(phase2Properties.getAccountQueryPolicy()),
+                phase2Properties.getMode(),
+                phase2Properties.getAccountQueryPolicy(),
                 portfolioSanityCheckProperties.isEnabled(),
                 portfolioSanityCheckProperties.getThreshold(),
                 portfolioZombieDetectionProperties.isEnabled(),
@@ -101,20 +104,6 @@ public class BootOrchestrator {
         if (snapshot.status() == BootRunStatus.RUNNING) {
             bootStatusTracker.failRun(phase, message);
         }
-    }
-
-    private static BootFailureMode toFailureMode(Phase2Mode mode) {
-        return switch (mode) {
-            case WARN_ONLY -> BootFailureMode.WARN_ONLY;
-            case FAIL_FAST -> BootFailureMode.FAIL_FAST;
-        };
-    }
-
-    private static BootAccountQueryPolicy toAccountQueryPolicy(Phase2AccountQueryPolicy policy) {
-        return switch (policy) {
-            case SKIP -> BootAccountQueryPolicy.SKIP;
-            case FAIL -> BootAccountQueryPolicy.FAIL;
-        };
     }
 
     private final class SpringBootExecutionObserver implements BootExecutionObserverPort {

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootStatusTracker.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootStatusTracker.java
@@ -1,5 +1,9 @@
 package com.marmitt.application.spring.bootstrap;
 
+import com.marmitt.core.dto.boot.BootPhaseSnapshot;
+import com.marmitt.core.dto.boot.BootRunSnapshot;
+import com.marmitt.core.enums.BootPhaseStatus;
+import com.marmitt.core.enums.BootRunStatus;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/Phase2AccountQueryPolicy.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/Phase2AccountQueryPolicy.java
@@ -1,6 +1,0 @@
-package com.marmitt.application.spring.bootstrap;
-
-public enum Phase2AccountQueryPolicy {
-    SKIP,
-    FAIL
-}

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/Phase2Mode.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/Phase2Mode.java
@@ -1,6 +1,0 @@
-package com.marmitt.application.spring.bootstrap;
-
-public enum Phase2Mode {
-    WARN_ONLY,
-    FAIL_FAST
-}

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/RunnerBootPhase2Properties.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/RunnerBootPhase2Properties.java
@@ -1,5 +1,7 @@
 package com.marmitt.application.spring.bootstrap;
 
+import com.marmitt.core.enums.BootAccountQueryPolicy;
+import com.marmitt.core.enums.BootFailureMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -8,8 +10,8 @@ import org.springframework.stereotype.Component;
 public class RunnerBootPhase2Properties {
 
     private boolean enabled = true;
-    private Phase2Mode mode = Phase2Mode.WARN_ONLY;
-    private Phase2AccountQueryPolicy accountQueryPolicy = Phase2AccountQueryPolicy.SKIP;
+    private BootFailureMode mode = BootFailureMode.WARN_ONLY;
+    private BootAccountQueryPolicy accountQueryPolicy = BootAccountQueryPolicy.SKIP;
 
     public boolean isEnabled() {
         return enabled;
@@ -19,19 +21,19 @@ public class RunnerBootPhase2Properties {
         this.enabled = enabled;
     }
 
-    public Phase2Mode getMode() {
+    public BootFailureMode getMode() {
         return mode;
     }
 
-    public void setMode(Phase2Mode mode) {
+    public void setMode(BootFailureMode mode) {
         this.mode = mode;
     }
 
-    public Phase2AccountQueryPolicy getAccountQueryPolicy() {
+    public BootAccountQueryPolicy getAccountQueryPolicy() {
         return accountQueryPolicy;
     }
 
-    public void setAccountQueryPolicy(Phase2AccountQueryPolicy accountQueryPolicy) {
+    public void setAccountQueryPolicy(BootAccountQueryPolicy accountQueryPolicy) {
         this.accountQueryPolicy = accountQueryPolicy;
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/BootController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/BootController.java
@@ -1,7 +1,7 @@
 package com.marmitt.application.spring.controller;
 
-import com.marmitt.application.spring.bootstrap.BootRunSnapshot;
 import com.marmitt.application.spring.bootstrap.BootStatusTracker;
+import com.marmitt.core.dto.boot.BootRunSnapshot;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
@@ -5,11 +5,14 @@ import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase
 import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
 import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
+import com.marmitt.core.dto.boot.BootRunSnapshot;
 import com.marmitt.core.domain.portfolio.Portfolio;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.dto.portfolio.PortfolioZombieCandidate;
 import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
 import com.marmitt.core.enums.AccountingPolicyType;
+import com.marmitt.core.enums.BootFailureMode;
+import com.marmitt.core.enums.BootRunStatus;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.enums.ExecutionPolicy;
 import com.marmitt.core.enums.RunnerStatus;
@@ -51,7 +54,7 @@ class BootOrchestratorBootMinimumTest {
         DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.WARN_ONLY,
+                BootFailureMode.WARN_ONLY,
                 portfolio,
                 runner,
                 detected,
@@ -89,7 +92,7 @@ class BootOrchestratorBootMinimumTest {
         DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.FAIL_FAST,
+                BootFailureMode.FAIL_FAST,
                 portfolio,
                 runner,
                 detected,
@@ -122,7 +125,7 @@ class BootOrchestratorBootMinimumTest {
         DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.FAIL_FAST,
+                BootFailureMode.FAIL_FAST,
                 portfolio,
                 runner,
                 failed,
@@ -165,7 +168,7 @@ class BootOrchestratorBootMinimumTest {
         verifyNoInteractions(eventPublisher);
     }
 
-    private static BootOrchestrator newOrchestrator(Phase2Mode mode,
+    private static BootOrchestrator newOrchestrator(BootFailureMode mode,
                                                     Portfolio portfolio,
                                                     StrategyRunner runner,
                                                     PortfolioZombieDetectionResult zombieResult,
@@ -257,7 +260,7 @@ class BootOrchestratorBootMinimumTest {
 
         RunnerBootPhase2Properties phase2Properties = new RunnerBootPhase2Properties();
         phase2Properties.setEnabled(true);
-        phase2Properties.setMode(Phase2Mode.WARN_ONLY);
+        phase2Properties.setMode(BootFailureMode.WARN_ONLY);
 
         RunnerBootPhase3Properties phase3Properties = new RunnerBootPhase3Properties();
         phase3Properties.setEnabled(false);

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
@@ -11,6 +11,7 @@ import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.dto.portfolio.PortfolioZombieCandidate;
 import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
 import com.marmitt.core.enums.AccountingPolicyType;
+import com.marmitt.core.enums.BootFailureMode;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.enums.ExecutionPolicy;
 import com.marmitt.core.enums.RunnerStatus;
@@ -173,7 +174,7 @@ class BootOrchestratorDlqOperationalTest {
 
         RunnerBootPhase2Properties phase2Properties = new RunnerBootPhase2Properties();
         phase2Properties.setEnabled(true);
-        phase2Properties.setMode(Phase2Mode.FAIL_FAST);
+        phase2Properties.setMode(BootFailureMode.FAIL_FAST);
 
         RunnerBootPhase3Properties phase3Properties = new RunnerBootPhase3Properties();
         phase3Properties.setEnabled(false);

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
@@ -5,6 +5,9 @@ import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase
 import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
 import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
+import com.marmitt.core.enums.BootFailureMode;
+import com.marmitt.core.enums.BootPhaseStatus;
+import com.marmitt.core.enums.BootRunStatus;
 import com.marmitt.core.domain.portfolio.Portfolio;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.dto.portfolio.PortfolioZombieCandidate;
@@ -49,7 +52,7 @@ class BootOrchestratorObservabilityTest {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         CapturingEventPublisher eventPublisher = new CapturingEventPublisher();
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.WARN_ONLY,
+                BootFailureMode.WARN_ONLY,
                 portfolio,
                 runner,
                 detected,
@@ -77,14 +80,14 @@ class BootOrchestratorObservabilityTest {
                 .tag("phase", "phase2.zombie")
                 .tag("status", "DETECTED")
                 .tag("exchange", "MOCK")
-                .tag("mode", Phase2Mode.WARN_ONLY.name())
+                .tag("mode", BootFailureMode.WARN_ONLY.name())
                 .counter()
                 .count());
         assertEquals(1L, meterRegistry.get("boot.phase.portfolio.duration")
                 .tag("phase", "phase2.zombie")
                 .tag("status", "DETECTED")
                 .tag("exchange", "MOCK")
-                .tag("mode", Phase2Mode.WARN_ONLY.name())
+                .tag("mode", BootFailureMode.WARN_ONLY.name())
                 .timer()
                 .count());
         assertEquals(0, eventPublisher.events().size());
@@ -109,7 +112,7 @@ class BootOrchestratorObservabilityTest {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         CapturingEventPublisher eventPublisher = new CapturingEventPublisher();
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.FAIL_FAST,
+                BootFailureMode.FAIL_FAST,
                 portfolio,
                 runner,
                 detected,
@@ -137,7 +140,7 @@ class BootOrchestratorObservabilityTest {
                 .tag("phase", "phase2.zombie")
                 .tag("status", "DETECTED")
                 .tag("exchange", "MOCK")
-                .tag("mode", Phase2Mode.FAIL_FAST.name())
+                .tag("mode", BootFailureMode.FAIL_FAST.name())
                 .counter()
                 .count());
         assertEquals(1.0d, meterRegistry.get("boot.failfast.total")
@@ -155,7 +158,7 @@ class BootOrchestratorObservabilityTest {
         assertNotNull(event.timestamp());
     }
 
-    private static BootOrchestrator newOrchestrator(Phase2Mode mode,
+    private static BootOrchestrator newOrchestrator(BootFailureMode mode,
                                                     Portfolio portfolio,
                                                     StrategyRunner runner,
                                                     PortfolioZombieDetectionResult zombieResult,


### PR DESCRIPTION
## Resumo
- move os snapshots e status de boot do `spring-application` para o `core`
- elimina as enums duplicadas `Phase2Mode` e `Phase2AccountQueryPolicy` do Spring
- faz `RunnerBootPhase2Properties` usar diretamente `BootFailureMode` e `BootAccountQueryPolicy`
- atualiza `BootStatusTracker`, `BootController`, `BootMetricsRecorder` e os testes de boot para consumir os tipos do `core`
- registra a trilha residual de limpeza do boot em `docs/QUESTOES_SEM_CLASSIFICACAO.md`

## Validacao
- `powershell -ExecutionPolicy Bypass -File .\\scripts\\gradle-run.ps1 --no-daemon -q :spring-application:compileJava :core:compileJava`
- `powershell -ExecutionPolicy Bypass -File .\\scripts\\gradle-run.ps1 --no-daemon -q :spring-application:test --tests com.marmitt.application.spring.bootstrap.BootOrchestratorBootMinimumTest --tests com.marmitt.application.spring.bootstrap.BootOrchestratorObservabilityTest --tests com.marmitt.application.spring.bootstrap.BootOrchestratorDlqOperationalTest`