### PR TITLE
refactor(boot): move semantic status types to core

### DIFF
--- a/core/src/main/java/com/marmitt/core/dto/boot/BootPhaseSnapshot.java
+++ b/core/src/main/java/com/marmitt/core/dto/boot/BootPhaseSnapshot.java
@@ -1,4 +1,6 @@
-package com.marmitt.application.spring.bootstrap;
+package com.marmitt.core.dto.boot;
+
+import com.marmitt.core.enums.BootPhaseStatus;
 
 import java.time.Instant;
 

--- a/core/src/main/java/com/marmitt/core/dto/boot/BootRunSnapshot.java
+++ b/core/src/main/java/com/marmitt/core/dto/boot/BootRunSnapshot.java
@@ -1,4 +1,6 @@
-package com.marmitt.application.spring.bootstrap;
+package com.marmitt.core.dto.boot;
+
+import com.marmitt.core.enums.BootRunStatus;
 
 import java.time.Instant;
 import java.util.List;

--- a/core/src/main/java/com/marmitt/core/enums/BootAccountQueryPolicy.java
+++ b/core/src/main/java/com/marmitt/core/enums/BootAccountQueryPolicy.java
@@ -1,0 +1,6 @@
+package com.marmitt.core.enums;
+
+public enum BootAccountQueryPolicy {
+    SKIP,
+    FAIL
+}

--- a/core/src/main/java/com/marmitt/core/enums/BootFailureMode.java
+++ b/core/src/main/java/com/marmitt/core/enums/BootFailureMode.java
@@ -1,0 +1,6 @@
+package com.marmitt.core.enums;
+
+public enum BootFailureMode {
+    WARN_ONLY,
+    FAIL_FAST
+}

--- a/core/src/main/java/com/marmitt/core/enums/BootPhaseStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/BootPhaseStatus.java
@@ -1,4 +1,4 @@
-package com.marmitt.application.spring.bootstrap;
+package com.marmitt.core.enums;
 
 public enum BootPhaseStatus {
     RUNNING,

--- a/core/src/main/java/com/marmitt/core/enums/BootRunStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/BootRunStatus.java
@@ -1,4 +1,4 @@
-package com.marmitt.application.spring.bootstrap;
+package com.marmitt.core.enums;
 
 public enum BootRunStatus {
     NOT_STARTED,

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootMetricsRecorder.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootMetricsRecorder.java
@@ -1,5 +1,7 @@
 package com.marmitt.application.spring.bootstrap;
 
+import com.marmitt.core.enums.BootPhaseStatus;
+import com.marmitt.core.enums.BootRunStatus;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.springframework.stereotype.Component;

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
@@ -5,6 +5,11 @@ import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase
 import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
 import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.dto.boot.BootRunSnapshot;
+import com.marmitt.core.enums.BootAccountQueryPolicy;
+import com.marmitt.core.enums.BootFailureMode;
+import com.marmitt.core.enums.BootPhaseStatus;
+import com.marmitt.core.enums.BootRunStatus;
 import com.marmitt.core.domain.portfolio.Portfolio;
 import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.domain.runner.StrategyRunner;
@@ -168,7 +173,7 @@ public class BootOrchestrator {
     }
 
     private void runPhase2PortfolioSanity(List<Portfolio> portfolios, List<StrategyRunner> eligibleRunners) {
-        Phase2Mode mode = phase2Properties.getMode();
+        BootFailureMode mode = phase2Properties.getMode();
         log.info("bootOrchestrator.phase2.sanity: start portfolios={} mode={} accountQueryPolicy={} threshold={}",
                 portfolios.size(), mode, phase2Properties.getAccountQueryPolicy(), portfolioSanityCheckProperties.getThreshold());
 
@@ -241,10 +246,10 @@ public class BootOrchestrator {
                 }
 
                 boolean skippedWithFailPolicy = result.status() == PortfolioSanityStatus.SKIPPED
-                        && phase2Properties.getAccountQueryPolicy() == Phase2AccountQueryPolicy.FAIL;
+                        && phase2Properties.getAccountQueryPolicy() == BootAccountQueryPolicy.FAIL;
                 boolean criticalFailure = result.status() == PortfolioSanityStatus.FAIL_DEFICIT
                         || result.status() == PortfolioSanityStatus.FAILED;
-                if ((skippedWithFailPolicy || criticalFailure) && mode == Phase2Mode.FAIL_FAST) {
+                if ((skippedWithFailPolicy || criticalFailure) && mode == BootFailureMode.FAIL_FAST) {
                     throw failFast(
                             "phase2.sanity",
                             result.code(),
@@ -260,7 +265,7 @@ public class BootOrchestrator {
     }
 
     private void runPhase2ZombieDetection(List<Portfolio> portfolios, List<StrategyRunner> eligibleRunners) {
-        Phase2Mode mode = phase2Properties.getMode();
+        BootFailureMode mode = phase2Properties.getMode();
         log.info("bootOrchestrator.phase2.zombie: start portfolios={} mode={} cutoffEnabled={}",
                 portfolios.size(), mode, portfolioCutoffProperties.isEnabled());
 
@@ -297,7 +302,7 @@ public class BootOrchestrator {
                             result.zombieCount()
                     );
                     case DETECTED -> {
-                        boolean persistToDlq = mode == Phase2Mode.FAIL_FAST;
+                        boolean persistToDlq = mode == BootFailureMode.FAIL_FAST;
                         int persistedSamples = persistToDlq ? persistZombieSamplesToDlq(result) : 0;
                         log.warn(
                                 "bootOrchestrator.phase2.zombie: portfolio={} exchange={} mode={} status={} code={} openOrders={} zombies={} invalidFormat={} unknownRunner={} noLocalMatch={} beforeCutoff={} unknownSymbol={} persistedSamples={} dlqPersisted={}",
@@ -347,7 +352,7 @@ public class BootOrchestrator {
 
                 boolean criticalFailure = result.status() == PortfolioZombieDetectionStatus.FAILED
                         || result.status() == PortfolioZombieDetectionStatus.DETECTED;
-                if (criticalFailure && mode == Phase2Mode.FAIL_FAST) {
+                if (criticalFailure && mode == BootFailureMode.FAIL_FAST) {
                     throw failFast(
                             "phase2.zombie",
                             result.code(),
@@ -364,7 +369,7 @@ public class BootOrchestrator {
 
     private void runPhase2ReservationTtl(List<Portfolio> portfolios, List<StrategyRunner> eligibleRunners) {
         long ttlMs = portfolioReservationTtlProperties.getTtlMs();
-        Phase2Mode mode = phase2Properties.getMode();
+        BootFailureMode mode = phase2Properties.getMode();
         log.info("bootOrchestrator.phase2.ttl: start portfolios={} mode={} ttlMs={}",
                 portfolios.size(), mode, ttlMs);
 
@@ -456,7 +461,7 @@ public class BootOrchestrator {
                 }
 
                 boolean criticalFailure = result.status() == PortfolioReservationTtlStatus.FAILED;
-                if (criticalFailure && mode == Phase2Mode.FAIL_FAST) {
+                if (criticalFailure && mode == BootFailureMode.FAIL_FAST) {
                     throw failFast(
                             "phase2.reservation_ttl",
                             result.code(),

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootStatusTracker.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootStatusTracker.java
@@ -1,5 +1,9 @@
 package com.marmitt.application.spring.bootstrap;
 
+import com.marmitt.core.dto.boot.BootPhaseSnapshot;
+import com.marmitt.core.dto.boot.BootRunSnapshot;
+import com.marmitt.core.enums.BootPhaseStatus;
+import com.marmitt.core.enums.BootRunStatus;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/Phase2AccountQueryPolicy.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/Phase2AccountQueryPolicy.java
@@ -1,6 +1,0 @@
-package com.marmitt.application.spring.bootstrap;
-
-public enum Phase2AccountQueryPolicy {
-    SKIP,
-    FAIL
-}

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/Phase2Mode.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/Phase2Mode.java
@@ -1,6 +1,0 @@
-package com.marmitt.application.spring.bootstrap;
-
-public enum Phase2Mode {
-    WARN_ONLY,
-    FAIL_FAST
-}

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/RunnerBootPhase2Properties.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/RunnerBootPhase2Properties.java
@@ -1,5 +1,7 @@
 package com.marmitt.application.spring.bootstrap;
 
+import com.marmitt.core.enums.BootAccountQueryPolicy;
+import com.marmitt.core.enums.BootFailureMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -8,8 +10,8 @@ import org.springframework.stereotype.Component;
 public class RunnerBootPhase2Properties {
 
     private boolean enabled = true;
-    private Phase2Mode mode = Phase2Mode.WARN_ONLY;
-    private Phase2AccountQueryPolicy accountQueryPolicy = Phase2AccountQueryPolicy.SKIP;
+    private BootFailureMode mode = BootFailureMode.WARN_ONLY;
+    private BootAccountQueryPolicy accountQueryPolicy = BootAccountQueryPolicy.SKIP;
 
     public boolean isEnabled() {
         return enabled;
@@ -19,19 +21,19 @@ public class RunnerBootPhase2Properties {
         this.enabled = enabled;
     }
 
-    public Phase2Mode getMode() {
+    public BootFailureMode getMode() {
         return mode;
     }
 
-    public void setMode(Phase2Mode mode) {
+    public void setMode(BootFailureMode mode) {
         this.mode = mode;
     }
 
-    public Phase2AccountQueryPolicy getAccountQueryPolicy() {
+    public BootAccountQueryPolicy getAccountQueryPolicy() {
         return accountQueryPolicy;
     }
 
-    public void setAccountQueryPolicy(Phase2AccountQueryPolicy accountQueryPolicy) {
+    public void setAccountQueryPolicy(BootAccountQueryPolicy accountQueryPolicy) {
         this.accountQueryPolicy = accountQueryPolicy;
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/BootController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/BootController.java
@@ -1,6 +1,6 @@
 package com.marmitt.application.spring.controller;
 
-import com.marmitt.application.spring.bootstrap.BootRunSnapshot;
+import com.marmitt.core.dto.boot.BootRunSnapshot;
 import com.marmitt.application.spring.bootstrap.BootStatusTracker;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
@@ -11,6 +11,9 @@ import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
 import com.marmitt.core.enums.AccountingPolicyType;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.enums.ExecutionPolicy;
+import com.marmitt.core.dto.boot.BootRunSnapshot;
+import com.marmitt.core.enums.BootFailureMode;
+import com.marmitt.core.enums.BootRunStatus;
 import com.marmitt.core.enums.RunnerStatus;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
@@ -50,7 +53,7 @@ class BootOrchestratorBootMinimumTest {
         DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.WARN_ONLY,
+                BootFailureMode.WARN_ONLY,
                 portfolio,
                 runner,
                 detected,
@@ -88,7 +91,7 @@ class BootOrchestratorBootMinimumTest {
         DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.FAIL_FAST,
+                BootFailureMode.FAIL_FAST,
                 portfolio,
                 runner,
                 detected,
@@ -121,7 +124,7 @@ class BootOrchestratorBootMinimumTest {
         DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.FAIL_FAST,
+                BootFailureMode.FAIL_FAST,
                 portfolio,
                 runner,
                 failed,
@@ -139,7 +142,7 @@ class BootOrchestratorBootMinimumTest {
         verify(eventPublisher).publishEvent(any(BootFailFastEvent.class));
     }
 
-    private static BootOrchestrator newOrchestrator(Phase2Mode mode,
+    private static BootOrchestrator newOrchestrator(BootFailureMode mode,
                                                     Portfolio portfolio,
                                                     StrategyRunner runner,
                                                     PortfolioZombieDetectionResult zombieResult,

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
@@ -12,6 +12,7 @@ import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
 import com.marmitt.core.enums.AccountingPolicyType;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.enums.ExecutionPolicy;
+import com.marmitt.core.enums.BootFailureMode;
 import com.marmitt.core.enums.RunnerStatus;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
@@ -172,7 +173,7 @@ class BootOrchestratorDlqOperationalTest {
 
         RunnerBootPhase2Properties phase2Properties = new RunnerBootPhase2Properties();
         phase2Properties.setEnabled(true);
-        phase2Properties.setMode(Phase2Mode.FAIL_FAST);
+        phase2Properties.setMode(BootFailureMode.FAIL_FAST);
 
         RunnerBootPhase3Properties phase3Properties = new RunnerBootPhase3Properties();
         phase3Properties.setEnabled(false);

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
@@ -11,6 +11,9 @@ import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
 import com.marmitt.core.enums.AccountingPolicyType;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.enums.ExecutionPolicy;
+import com.marmitt.core.enums.BootFailureMode;
+import com.marmitt.core.enums.BootPhaseStatus;
+import com.marmitt.core.enums.BootRunStatus;
 import com.marmitt.core.enums.RunnerStatus;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
@@ -48,7 +51,7 @@ class BootOrchestratorObservabilityTest {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         CapturingEventPublisher eventPublisher = new CapturingEventPublisher();
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.WARN_ONLY,
+                BootFailureMode.WARN_ONLY,
                 portfolio,
                 runner,
                 detected,
@@ -76,14 +79,14 @@ class BootOrchestratorObservabilityTest {
                 .tag("phase", "phase2.zombie")
                 .tag("status", "DETECTED")
                 .tag("exchange", "MOCK")
-                .tag("mode", Phase2Mode.WARN_ONLY.name())
+                .tag("mode", BootFailureMode.WARN_ONLY.name())
                 .counter()
                 .count());
         assertEquals(1L, meterRegistry.get("boot.phase.portfolio.duration")
                 .tag("phase", "phase2.zombie")
                 .tag("status", "DETECTED")
                 .tag("exchange", "MOCK")
-                .tag("mode", Phase2Mode.WARN_ONLY.name())
+                .tag("mode", BootFailureMode.WARN_ONLY.name())
                 .timer()
                 .count());
         assertEquals(0, eventPublisher.events().size());
@@ -108,7 +111,7 @@ class BootOrchestratorObservabilityTest {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         CapturingEventPublisher eventPublisher = new CapturingEventPublisher();
         BootOrchestrator orchestrator = newOrchestrator(
-                Phase2Mode.FAIL_FAST,
+                BootFailureMode.FAIL_FAST,
                 portfolio,
                 runner,
                 detected,
@@ -136,7 +139,7 @@ class BootOrchestratorObservabilityTest {
                 .tag("phase", "phase2.zombie")
                 .tag("status", "DETECTED")
                 .tag("exchange", "MOCK")
-                .tag("mode", Phase2Mode.FAIL_FAST.name())
+                .tag("mode", BootFailureMode.FAIL_FAST.name())
                 .counter()
                 .count());
         assertEquals(1.0d, meterRegistry.get("boot.failfast.total")
@@ -154,7 +157,7 @@ class BootOrchestratorObservabilityTest {
         assertNotNull(event.timestamp());
     }
 
-    private static BootOrchestrator newOrchestrator(Phase2Mode mode,
+    private static BootOrchestrator newOrchestrator(BootFailureMode mode,
                                                     Portfolio portfolio,
                                                     StrategyRunner runner,
                                                     PortfolioZombieDetectionResult zombieResult,


### PR DESCRIPTION
## Summary

- Move `BootPhaseStatus`, `BootRunStatus` from `spring-application.bootstrap` → `core.enums`
- Move `BootPhaseSnapshot`, `BootRunSnapshot` from `spring-application.bootstrap` → `core.dto.boot`
- Rename `Phase2Mode` → `BootFailureMode` (core.enums) — reflete intenção boot-scoped, não posição de fase
- Rename `Phase2AccountQueryPolicy` → `BootAccountQueryPolicy` (core.enums) — mesma motivação

Sem mudança de comportamento. Os consumidores Spring (`BootStatusTracker`, `BootMetricsRecorder`, `BootOrchestrator`, `RunnerBootPhase2Properties`, `BootController`) e os 3 testes `BootOrchestrator*` recebem apenas imports atualizados.

## Contexto

PR 1 de 2 para mover a lógica de orquestração de boot para o core. Este PR estabelece o vocabulário semântico compartilhado. O PR 2 criará `RunBootSequenceUseCase` e esvaziará o `BootOrchestrator` para adaptador fino.

## Test plan

- [x] `./gradlew :core:compileJava :spring-application:compileJava :spring-application:compileTestJava` — sem erros
- [x] `BootOrchestratorBootMinimumTest` — 4 testes passando
- [x] `BootOrchestratorDlqOperationalTest` — 2 testes passando
- [x] `BootOrchestratorObservabilityTest` — 2 testes passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)