### PR TITLE
feat(core): add runtime transaction recovery use case

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
@@ -149,9 +149,31 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
                         "Exchange returned an order without status."
                 );
             }
+            String validationFailure = validateExchangeResponse(transaction, orderData);
+            if (validationFailure != null) {
+                return RecoverTransactionStatusResponse.failed(
+                        transaction.getId(),
+                        transaction.getRunnerId(),
+                        exchangeId,
+                        statusBefore,
+                        RecoverTransactionStatusResponse.FailureReason.INVALID_EXCHANGE_RESPONSE,
+                        validationFailure
+                );
+            }
 
             OrderDataDto normalized = normalizeQueriedOrder(transaction, orderData);
-            conciliationOrderUpdateExecutor.execute(normalized);
+            try {
+                conciliationOrderUpdateExecutor.execute(normalized);
+            } catch (IllegalArgumentException | IllegalStateException e) {
+                return RecoverTransactionStatusResponse.failed(
+                        transaction.getId(),
+                        transaction.getRunnerId(),
+                        exchangeId,
+                        statusBefore,
+                        RecoverTransactionStatusResponse.FailureReason.INVALID_EXCHANGE_RESPONSE,
+                        "Exchange response could not be reconciled: " + e.getMessage()
+                );
+            }
             return RecoverTransactionStatusResponse.recovered(
                     transaction.getId(),
                     transaction.getRunnerId(),
@@ -182,6 +204,44 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
                 action,
                 "Exchange did not find order; applied local " + fallbackStatus + " fallback."
         );
+    }
+
+    private String validateExchangeResponse(Transaction transaction, OrderDataDto orderData) {
+        if (orderData.clientOrderId() != null
+                && !orderData.clientOrderId().isBlank()
+                && !transaction.getClientOrderId().equals(orderData.clientOrderId())) {
+            return "Exchange returned a mismatched clientOrderId for the requested transaction.";
+        }
+
+        return switch (orderData.status()) {
+            case NEW -> {
+                String orderId = orderData.orderId() != null && !orderData.orderId().isBlank()
+                        ? orderData.orderId()
+                        : transaction.getExchangeOrderId();
+                if (orderId == null || orderId.isBlank()) {
+                    yield "Exchange returned NEW without orderId for reconciliation.";
+                }
+                yield null;
+            }
+            case FILLED, PARTIALLY_FILLED -> {
+                if (orderData.executedQuantity() == null
+                        || orderData.executedQuantity().compareTo(BigDecimal.ZERO) <= 0) {
+                    yield "Exchange returned fill status without a positive executedQuantity.";
+                }
+                if (orderData.executedPrice() == null
+                        || orderData.executedPrice().compareTo(BigDecimal.ZERO) <= 0) {
+                    yield "Exchange returned fill status without a positive executedPrice.";
+                }
+                yield null;
+            }
+            case REJECTED -> {
+                if (orderData.rejectReason() == null || orderData.rejectReason().isBlank()) {
+                    yield "Exchange returned REJECTED without rejectReason.";
+                }
+                yield null;
+            }
+            case CANCELED, EXPIRED -> null;
+        };
     }
 
     private RecoverTransactionStatusResponse failureFromQuery(Transaction transaction,
@@ -225,7 +285,7 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
 
         return new OrderDataDto(
                 queried.orderId() != null ? queried.orderId() : tx.getExchangeOrderId(),
-                queried.clientOrderId() != null ? queried.clientOrderId() : tx.getClientOrderId(),
+                tx.getClientOrderId(),
                 symbol,
                 side,
                 type,

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
@@ -1,0 +1,294 @@
+package com.marmitt.core.application.usecase.runner;
+
+import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdateExecutor;
+import com.marmitt.core.domain.Symbol;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.runner.request.RecoverTransactionStatusRequest;
+import com.marmitt.core.dto.runner.response.RecoverTransactionStatusResponse;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.exceptions.ExchangeQueryException;
+import com.marmitt.core.ports.inbound.runner.RecoverTransactionStatusPort;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+public class RecoverTransactionStatusUseCase implements RecoverTransactionStatusPort {
+
+    private static final List<TransactionStatus> ELIGIBLE_STATUSES = List.of(
+            TransactionStatus.PENDING,
+            TransactionStatus.SUBMITTED,
+            TransactionStatus.PARTIAL
+    );
+
+    private final StrategyRunnerRepositoryPort strategyRunnerRepository;
+    private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
+    private final ConciliationOrderUpdateExecutor conciliationOrderUpdateExecutor;
+
+    public RecoverTransactionStatusUseCase(StrategyRunnerRepositoryPort strategyRunnerRepository,
+                                           ExchangeAdapterRepositoryPort exchangeAdapterRepository,
+                                           ConciliationOrderUpdateExecutor conciliationOrderUpdateExecutor) {
+        this.strategyRunnerRepository = strategyRunnerRepository;
+        this.exchangeAdapterRepository = exchangeAdapterRepository;
+        this.conciliationOrderUpdateExecutor = conciliationOrderUpdateExecutor;
+    }
+
+    @Override
+    public RecoverTransactionStatusResponse execute(RecoverTransactionStatusRequest request) {
+        Transaction transaction = strategyRunnerRepository.findTransactionById(request.transactionId()).orElse(null);
+        if (transaction == null) {
+            return RecoverTransactionStatusResponse.failed(
+                    request.transactionId(),
+                    null,
+                    null,
+                    null,
+                    RecoverTransactionStatusResponse.FailureReason.TRANSACTION_NOT_FOUND,
+                    "Transaction not found."
+            );
+        }
+
+        TransactionStatus statusBefore = transaction.getStatus();
+        if (!ELIGIBLE_STATUSES.contains(statusBefore)) {
+            return RecoverTransactionStatusResponse.skipped(
+                    transaction.getId(),
+                    transaction.getRunnerId(),
+                    null,
+                    statusBefore,
+                    "Transaction status is not eligible for runtime recovery."
+            );
+        }
+
+        StrategyRunner runner = strategyRunnerRepository.findById(transaction.getRunnerId()).orElse(null);
+        if (runner == null) {
+            return RecoverTransactionStatusResponse.failed(
+                    transaction.getId(),
+                    transaction.getRunnerId(),
+                    null,
+                    statusBefore,
+                    RecoverTransactionStatusResponse.FailureReason.RUNNER_NOT_FOUND,
+                    "Runner not found for transaction."
+            );
+        }
+
+        String exchangeId = runner.getExchangeId();
+        Optional<ExchangeOrderQueryPort> orderQueryOptional =
+                exchangeAdapterRepository.findOrderQueryByName(exchangeId);
+        if (orderQueryOptional.isEmpty()) {
+            return RecoverTransactionStatusResponse.failed(
+                    transaction.getId(),
+                    transaction.getRunnerId(),
+                    exchangeId,
+                    statusBefore,
+                    RecoverTransactionStatusResponse.FailureReason.ORDER_QUERY_NOT_AVAILABLE,
+                    "Exchange order query capability is not available."
+            );
+        }
+
+        Optional<OrderDataDto> queried;
+        try {
+            queried = orderQueryOptional.get()
+                    .queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId());
+        } catch (UnsupportedOperationException e) {
+            return failureFromQuery(
+                    transaction,
+                    exchangeId,
+                    RecoverTransactionStatusResponse.FailureReason.ORDER_QUERY_UNSUPPORTED,
+                    "Exchange order query is unsupported.",
+                    e
+            );
+        } catch (ExchangeQueryException e) {
+            if (e.errorType() == ExchangeQueryException.ErrorType.NOT_SUPPORTED) {
+                return failureFromQuery(
+                        transaction,
+                        exchangeId,
+                        RecoverTransactionStatusResponse.FailureReason.ORDER_QUERY_UNSUPPORTED,
+                        "Exchange order query is unsupported.",
+                        e
+                );
+            }
+            return failureFromQuery(
+                    transaction,
+                    exchangeId,
+                    isRetryableQueryFailure(e)
+                            ? RecoverTransactionStatusResponse.FailureReason.EXCHANGE_QUERY_RETRYABLE_FAILURE
+                            : RecoverTransactionStatusResponse.FailureReason.EXCHANGE_QUERY_TERMINAL_FAILURE,
+                    e.getMessage(),
+                    e
+            );
+        } catch (RuntimeException e) {
+            return failureFromQuery(
+                    transaction,
+                    exchangeId,
+                    isRetryableQueryFailure(e)
+                            ? RecoverTransactionStatusResponse.FailureReason.EXCHANGE_QUERY_RETRYABLE_FAILURE
+                            : RecoverTransactionStatusResponse.FailureReason.EXCHANGE_QUERY_TERMINAL_FAILURE,
+                    e.getMessage(),
+                    e
+            );
+        }
+
+        if (queried.isPresent()) {
+            OrderDataDto orderData = queried.get();
+            if (orderData.status() == null) {
+                return RecoverTransactionStatusResponse.failed(
+                        transaction.getId(),
+                        transaction.getRunnerId(),
+                        exchangeId,
+                        statusBefore,
+                        RecoverTransactionStatusResponse.FailureReason.INVALID_EXCHANGE_RESPONSE,
+                        "Exchange returned an order without status."
+                );
+            }
+
+            OrderDataDto normalized = normalizeQueriedOrder(transaction, orderData);
+            conciliationOrderUpdateExecutor.execute(normalized);
+            return RecoverTransactionStatusResponse.recovered(
+                    transaction.getId(),
+                    transaction.getRunnerId(),
+                    exchangeId,
+                    statusBefore,
+                    transaction.getStatus(),
+                    RecoverTransactionStatusResponse.RecoveryAction.RECONCILED_FROM_EXCHANGE,
+                    "Transaction reconciled from exchange status " + normalized.status() + "."
+            );
+        }
+
+        OrderDataDto.OrderStatus fallbackStatus = transaction.getStatus() == TransactionStatus.PARTIAL
+                ? OrderDataDto.OrderStatus.CANCELED
+                : OrderDataDto.OrderStatus.EXPIRED;
+        OrderDataDto synthetic = buildSyntheticTerminalOrder(transaction, fallbackStatus, "RUNTIME_NOT_FOUND_ON_EXCHANGE");
+        conciliationOrderUpdateExecutor.execute(synthetic);
+
+        RecoverTransactionStatusResponse.RecoveryAction action = fallbackStatus == OrderDataDto.OrderStatus.CANCELED
+                ? RecoverTransactionStatusResponse.RecoveryAction.MARKED_CANCELED
+                : RecoverTransactionStatusResponse.RecoveryAction.MARKED_EXPIRED;
+
+        return RecoverTransactionStatusResponse.recovered(
+                transaction.getId(),
+                transaction.getRunnerId(),
+                exchangeId,
+                statusBefore,
+                transaction.getStatus(),
+                action,
+                "Exchange did not find order; applied local " + fallbackStatus + " fallback."
+        );
+    }
+
+    private RecoverTransactionStatusResponse failureFromQuery(Transaction transaction,
+                                                              String exchangeId,
+                                                              RecoverTransactionStatusResponse.FailureReason reason,
+                                                              String message,
+                                                              Exception e) {
+        log.warn("runtimeRecovery: failed transactionId={} runnerId={} exchange={} reason={} message={}",
+                transaction.getId(), transaction.getRunnerId(), exchangeId, reason, message);
+        log.debug("runtimeRecovery: query failure stack transactionId={}", transaction.getId(), e);
+        return RecoverTransactionStatusResponse.failed(
+                transaction.getId(),
+                transaction.getRunnerId(),
+                exchangeId,
+                transaction.getStatus(),
+                reason,
+                message != null && !message.isBlank()
+                        ? message
+                        : "Exchange query failed."
+        );
+    }
+
+    private OrderDataDto normalizeQueriedOrder(Transaction tx, OrderDataDto queried) {
+        Symbol symbol = queried.symbol() != null ? queried.symbol() : Symbol.of(tx.getSymbol());
+        OrderDataDto.OrderSide side = queried.side() != null
+                ? queried.side()
+                : (tx.isBuy() ? OrderDataDto.OrderSide.BUY : OrderDataDto.OrderSide.SELL);
+        OrderDataDto.OrderType type = queried.type() != null
+                ? queried.type()
+                : OrderDataDto.OrderType.LIMIT;
+
+        BigDecimal quantity = queried.quantity() != null ? queried.quantity() : tx.getQuantity();
+        BigDecimal executedQty = queried.executedQuantity() != null
+                ? queried.executedQuantity()
+                : tx.getEffectiveExecutedQuantity();
+        BigDecimal price = queried.price() != null ? queried.price() : tx.getPrice();
+        BigDecimal executedPrice = queried.executedPrice() != null
+                ? queried.executedPrice()
+                : tx.getEffectiveExecutedPrice();
+        BigDecimal fee = queried.fee() != null ? queried.fee() : BigDecimal.ZERO;
+
+        return new OrderDataDto(
+                queried.orderId() != null ? queried.orderId() : tx.getExchangeOrderId(),
+                queried.clientOrderId() != null ? queried.clientOrderId() : tx.getClientOrderId(),
+                symbol,
+                side,
+                type,
+                quantity,
+                executedQty,
+                price,
+                executedPrice,
+                fee,
+                queried.status(),
+                queried.rejectReason(),
+                queried.timestamp() != null ? queried.timestamp() : Instant.now()
+        );
+    }
+
+    private OrderDataDto buildSyntheticTerminalOrder(Transaction tx,
+                                                     OrderDataDto.OrderStatus status,
+                                                     String reason) {
+        return new OrderDataDto(
+                tx.getExchangeOrderId() != null ? tx.getExchangeOrderId() : "RUNTIME_" + tx.getId(),
+                tx.getClientOrderId(),
+                Symbol.of(tx.getSymbol()),
+                tx.isBuy() ? OrderDataDto.OrderSide.BUY : OrderDataDto.OrderSide.SELL,
+                OrderDataDto.OrderType.LIMIT,
+                tx.getQuantity(),
+                tx.getEffectiveExecutedQuantity(),
+                tx.getPrice(),
+                tx.getEffectiveExecutedPrice(),
+                BigDecimal.ZERO,
+                status,
+                reason,
+                Instant.now()
+        );
+    }
+
+    private boolean isRetryableQueryFailure(Throwable throwable) {
+        if (throwable instanceof UnsupportedOperationException) {
+            return false;
+        }
+        if (throwable instanceof IllegalArgumentException) {
+            return false;
+        }
+        if (throwable instanceof ExchangeQueryException exchangeQueryException) {
+            return exchangeQueryException.isRetryable();
+        }
+
+        String message = throwable.getMessage() != null
+                ? throwable.getMessage().toLowerCase(Locale.ROOT)
+                : "";
+
+        if (message.contains("timeout")
+                || message.contains("timed out")
+                || message.contains("connection reset")
+                || message.contains("temporarily")
+                || message.contains("rate limit")
+                || message.contains("429")
+                || message.contains("503")) {
+            return true;
+        }
+
+        Throwable cause = throwable.getCause();
+        if (cause == null || cause == throwable) {
+            return false;
+        }
+        return isRetryableQueryFailure(cause);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/runner/request/RecoverTransactionStatusRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/runner/request/RecoverTransactionStatusRequest.java
@@ -1,0 +1,11 @@
+package com.marmitt.core.dto.runner.request;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RecoverTransactionStatusRequest(UUID transactionId) {
+
+    public RecoverTransactionStatusRequest {
+        Objects.requireNonNull(transactionId, "transactionId cannot be null");
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/runner/response/RecoverTransactionStatusResponse.java
+++ b/core/src/main/java/com/marmitt/core/dto/runner/response/RecoverTransactionStatusResponse.java
@@ -1,0 +1,106 @@
+package com.marmitt.core.dto.runner.response;
+
+import com.marmitt.core.enums.TransactionStatus;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record RecoverTransactionStatusResponse(
+        UUID transactionId,
+        UUID runnerId,
+        String exchangeId,
+        TransactionStatus statusBefore,
+        TransactionStatus statusAfter,
+        RecoveryOutcome outcome,
+        RecoveryAction action,
+        FailureReason failureReason,
+        String message
+) {
+
+    public RecoverTransactionStatusResponse {
+        Objects.requireNonNull(transactionId, "transactionId cannot be null");
+        Objects.requireNonNull(outcome, "outcome cannot be null");
+        Objects.requireNonNull(action, "action cannot be null");
+    }
+
+    public static RecoverTransactionStatusResponse recovered(UUID transactionId,
+                                                             UUID runnerId,
+                                                             String exchangeId,
+                                                             TransactionStatus statusBefore,
+                                                             TransactionStatus statusAfter,
+                                                             RecoveryAction action,
+                                                             String message) {
+        return new RecoverTransactionStatusResponse(
+                transactionId,
+                runnerId,
+                exchangeId,
+                statusBefore,
+                statusAfter,
+                RecoveryOutcome.RECOVERED,
+                action,
+                null,
+                message
+        );
+    }
+
+    public static RecoverTransactionStatusResponse skipped(UUID transactionId,
+                                                           UUID runnerId,
+                                                           String exchangeId,
+                                                           TransactionStatus statusBefore,
+                                                           String message) {
+        return new RecoverTransactionStatusResponse(
+                transactionId,
+                runnerId,
+                exchangeId,
+                statusBefore,
+                statusBefore,
+                RecoveryOutcome.SKIPPED,
+                RecoveryAction.NONE,
+                FailureReason.TRANSACTION_NOT_ELIGIBLE,
+                message
+        );
+    }
+
+    public static RecoverTransactionStatusResponse failed(UUID transactionId,
+                                                          UUID runnerId,
+                                                          String exchangeId,
+                                                          TransactionStatus statusBefore,
+                                                          FailureReason failureReason,
+                                                          String message) {
+        return new RecoverTransactionStatusResponse(
+                transactionId,
+                runnerId,
+                exchangeId,
+                statusBefore,
+                statusBefore,
+                RecoveryOutcome.FAILED,
+                RecoveryAction.NONE,
+                Objects.requireNonNull(failureReason, "failureReason cannot be null"),
+                message
+        );
+    }
+
+    public enum RecoveryOutcome {
+        RECOVERED,
+        SKIPPED,
+        FAILED
+    }
+
+    public enum RecoveryAction {
+        NONE,
+        RECONCILED_FROM_EXCHANGE,
+        MARKED_EXPIRED,
+        MARKED_CANCELED
+    }
+
+    public enum FailureReason {
+        TRANSACTION_NOT_FOUND,
+        TRANSACTION_NOT_ELIGIBLE,
+        RUNNER_NOT_FOUND,
+        ORDER_QUERY_NOT_AVAILABLE,
+        ORDER_QUERY_UNSUPPORTED,
+        EXCHANGE_QUERY_RETRYABLE_FAILURE,
+        EXCHANGE_QUERY_TERMINAL_FAILURE,
+        INVALID_EXCHANGE_RESPONSE
+    }
+}

--- a/core/src/main/java/com/marmitt/core/ports/inbound/runner/RecoverTransactionStatusPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/runner/RecoverTransactionStatusPort.java
@@ -1,0 +1,9 @@
+package com.marmitt.core.ports.inbound.runner;
+
+import com.marmitt.core.dto.runner.request.RecoverTransactionStatusRequest;
+import com.marmitt.core.dto.runner.response.RecoverTransactionStatusResponse;
+
+public interface RecoverTransactionStatusPort {
+
+    RecoverTransactionStatusResponse execute(RecoverTransactionStatusRequest request);
+}

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
@@ -212,6 +212,84 @@ class RecoverTransactionStatusUseCaseTest {
     }
 
     @Test
+    void executeReturnsInvalidExchangeResponseWhenClientOrderIdDoesNotMatchRequestedTransaction() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+        ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        StrategyRunner runner = newRunner(transaction.getRunnerId(), "BINANCE");
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+        when(repository.findById(transaction.getRunnerId())).thenReturn(Optional.of(runner));
+        when(exchangeRepository.findOrderQueryByName("BINANCE")).thenReturn(Optional.of(orderQueryPort));
+        when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
+                .thenReturn(Optional.of(orderData(
+                        "another-client-order-id",
+                        transaction,
+                        OrderDataDto.OrderStatus.FILLED,
+                        new BigDecimal("2.50000000"),
+                        new BigDecimal("10.20000000"),
+                        "EX_ORDER_REMOTE",
+                        null
+                )));
+
+        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                newExecutor(repository)
+        );
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                new RecoverTransactionStatusRequest(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.FAILED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.FailureReason.INVALID_EXCHANGE_RESPONSE,
+                response.failureReason());
+        assertEquals(TransactionStatus.SUBMITTED, transaction.getStatus());
+    }
+
+    @Test
+    void executeReturnsInvalidExchangeResponseWhenFillPayloadIsIncomplete() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+        ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        StrategyRunner runner = newRunner(transaction.getRunnerId(), "BINANCE");
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+        when(repository.findById(transaction.getRunnerId())).thenReturn(Optional.of(runner));
+        when(exchangeRepository.findOrderQueryByName("BINANCE")).thenReturn(Optional.of(orderQueryPort));
+        when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
+                .thenReturn(Optional.of(orderData(
+                        transaction.getClientOrderId(),
+                        transaction,
+                        OrderDataDto.OrderStatus.FILLED,
+                        null,
+                        new BigDecimal("10.20000000"),
+                        "EX_ORDER_REMOTE",
+                        null
+                )));
+
+        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                newExecutor(repository)
+        );
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                new RecoverTransactionStatusRequest(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.FAILED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.FailureReason.INVALID_EXCHANGE_RESPONSE,
+                response.failureReason());
+        assertEquals(TransactionStatus.SUBMITTED, transaction.getStatus());
+    }
+
+    @Test
     void executeSkipsTerminalTransactions() {
         StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
         ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
@@ -310,9 +388,27 @@ class RecoverTransactionStatusUseCaseTest {
                                           BigDecimal executedQty,
                                           BigDecimal executedPrice,
                                           String exchangeOrderId) {
+        return orderData(
+                transaction.getClientOrderId(),
+                transaction,
+                status,
+                executedQty,
+                executedPrice,
+                exchangeOrderId,
+                null
+        );
+    }
+
+    private static OrderDataDto orderData(String clientOrderId,
+                                          Transaction transaction,
+                                          OrderDataDto.OrderStatus status,
+                                          BigDecimal executedQty,
+                                          BigDecimal executedPrice,
+                                          String exchangeOrderId,
+                                          String rejectReason) {
         return new OrderDataDto(
                 exchangeOrderId,
-                transaction.getClientOrderId(),
+                clientOrderId,
                 Symbol.of(transaction.getSymbol()),
                 OrderDataDto.OrderSide.BUY,
                 OrderDataDto.OrderType.LIMIT,
@@ -322,7 +418,7 @@ class RecoverTransactionStatusUseCaseTest {
                 executedPrice,
                 BigDecimal.ZERO,
                 status,
-                null,
+                rejectReason,
                 Instant.now()
         );
     }

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
@@ -1,0 +1,329 @@
+package com.marmitt.core.application.usecase.runner;
+
+import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdate;
+import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdateExecutor;
+import com.marmitt.core.domain.Symbol;
+import com.marmitt.core.domain.runner.ClientOrderId;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.runner.request.RecoverTransactionStatusRequest;
+import com.marmitt.core.dto.runner.response.RecoverTransactionStatusResponse;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.enums.AccountingPolicyType;
+import com.marmitt.core.enums.ExecutionPolicy;
+import com.marmitt.core.enums.RunnerStatus;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.exceptions.ExchangeQueryException;
+import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RecoverTransactionStatusUseCaseTest {
+
+    @Test
+    void executeRecoversSubmittedTransactionFromPositiveExchangeQuery() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+        ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        StrategyRunner runner = newRunner(transaction.getRunnerId(), "BINANCE");
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+        when(repository.findById(transaction.getRunnerId())).thenReturn(Optional.of(runner));
+        when(repository.findTransactionByClientOrderId(transaction.getClientOrderId())).thenReturn(Optional.of(transaction));
+        when(repository.findPositionByOpenedByTransactionIdForUpdate(transaction.getId())).thenReturn(Optional.empty());
+        when(repository.findOpenPositionByRunnerIdAndSymbolForUpdate(transaction.getRunnerId(), transaction.getSymbol()))
+                .thenReturn(Optional.empty());
+        when(repository.trySavePosition(any())).thenReturn(true);
+        when(exchangeRepository.findOrderQueryByName("BINANCE")).thenReturn(Optional.of(orderQueryPort));
+        when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
+                .thenReturn(Optional.of(orderData(
+                        transaction,
+                        OrderDataDto.OrderStatus.FILLED,
+                        new BigDecimal("2.50000000"),
+                        new BigDecimal("10.20000000"),
+                        "EX_ORDER_REMOTE"
+                )));
+
+        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                newExecutor(repository)
+        );
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                new RecoverTransactionStatusRequest(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.RECOVERED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.RecoveryAction.RECONCILED_FROM_EXCHANGE, response.action());
+        assertEquals(TransactionStatus.SUBMITTED, response.statusBefore());
+        assertEquals(TransactionStatus.FILLED, response.statusAfter());
+        assertEquals(TransactionStatus.FILLED, transaction.getStatus());
+        verify(orderQueryPort).queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId());
+    }
+
+    @Test
+    void executeMarksSubmittedTransactionExpiredWhenExchangeDoesNotFindOrder() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+        ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        StrategyRunner runner = newRunner(transaction.getRunnerId(), "BINANCE");
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+        when(repository.findById(transaction.getRunnerId())).thenReturn(Optional.of(runner));
+        when(repository.findTransactionByClientOrderId(transaction.getClientOrderId())).thenReturn(Optional.of(transaction));
+        when(exchangeRepository.findOrderQueryByName("BINANCE")).thenReturn(Optional.of(orderQueryPort));
+        when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
+                .thenReturn(Optional.empty());
+
+        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                newExecutor(repository)
+        );
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                new RecoverTransactionStatusRequest(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.RECOVERED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.RecoveryAction.MARKED_EXPIRED, response.action());
+        assertEquals(TransactionStatus.EXPIRED, response.statusAfter());
+        assertEquals(TransactionStatus.EXPIRED, transaction.getStatus());
+    }
+
+    @Test
+    void executeMarksPartialTransactionCanceledWhenExchangeDoesNotFindOrder() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+        ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        transaction.partialFill(new BigDecimal("1.00000000"), new BigDecimal("10.10000000"));
+        StrategyRunner runner = newRunner(transaction.getRunnerId(), "BINANCE");
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+        when(repository.findById(transaction.getRunnerId())).thenReturn(Optional.of(runner));
+        when(repository.findTransactionByClientOrderId(transaction.getClientOrderId())).thenReturn(Optional.of(transaction));
+        when(exchangeRepository.findOrderQueryByName("BINANCE")).thenReturn(Optional.of(orderQueryPort));
+        when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
+                .thenReturn(Optional.empty());
+
+        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                newExecutor(repository)
+        );
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                new RecoverTransactionStatusRequest(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.RECOVERED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.RecoveryAction.MARKED_CANCELED, response.action());
+        assertEquals(TransactionStatus.CANCELED, response.statusAfter());
+        assertEquals(TransactionStatus.CANCELED, transaction.getStatus());
+    }
+
+    @Test
+    void executeReturnsFailureWhenOrderQueryIsUnsupported() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+        ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        StrategyRunner runner = newRunner(transaction.getRunnerId(), "BINANCE");
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+        when(repository.findById(transaction.getRunnerId())).thenReturn(Optional.of(runner));
+        when(exchangeRepository.findOrderQueryByName("BINANCE")).thenReturn(Optional.of(orderQueryPort));
+        when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
+                .thenThrow(new UnsupportedOperationException("not supported"));
+
+        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                newExecutor(repository)
+        );
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                new RecoverTransactionStatusRequest(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.FAILED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.FailureReason.ORDER_QUERY_UNSUPPORTED, response.failureReason());
+        assertEquals(TransactionStatus.SUBMITTED, response.statusAfter());
+        assertEquals(TransactionStatus.SUBMITTED, transaction.getStatus());
+    }
+
+    @Test
+    void executeReturnsRetryableFailureWhenExchangeQueryFailsTemporarily() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+        ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        StrategyRunner runner = newRunner(transaction.getRunnerId(), "BINANCE");
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+        when(repository.findById(transaction.getRunnerId())).thenReturn(Optional.of(runner));
+        when(exchangeRepository.findOrderQueryByName("BINANCE")).thenReturn(Optional.of(orderQueryPort));
+        when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
+                .thenThrow(new ExchangeQueryException(
+                        "BINANCE",
+                        ExchangeQueryException.ErrorType.TEMPORARY,
+                        "Temporary upstream timeout"
+                ));
+
+        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                newExecutor(repository)
+        );
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                new RecoverTransactionStatusRequest(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.FAILED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.FailureReason.EXCHANGE_QUERY_RETRYABLE_FAILURE,
+                response.failureReason());
+        assertEquals(TransactionStatus.SUBMITTED, transaction.getStatus());
+    }
+
+    @Test
+    void executeSkipsTerminalTransactions() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        transaction.fill(new BigDecimal("2.50000000"), new BigDecimal("10.20000000"));
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+
+        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                newExecutor(repository)
+        );
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                new RecoverTransactionStatusRequest(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.SKIPPED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.FailureReason.TRANSACTION_NOT_ELIGIBLE, response.failureReason());
+        assertEquals(TransactionStatus.FILLED, response.statusBefore());
+        assertEquals(TransactionStatus.FILLED, response.statusAfter());
+        assertNull(response.exchangeId());
+    }
+
+    private static ConciliationOrderUpdateExecutor newExecutor(StrategyRunnerRepositoryPort repository) {
+        ConciliationOrderUpdate conciliation = new ConciliationOrderUpdate(repository, mock(EventPublisherPort.class));
+        return new ConciliationOrderUpdateExecutor() {
+            @Override
+            public void execute(OrderDataDto orderData) {
+                conciliation.execute(orderData, this::submitTransaction, this::processFill, this::releaseMargin);
+            }
+
+            @Override
+            public void submitTransaction(Transaction transaction) {
+                conciliation.submitTransaction(transaction);
+            }
+
+            @Override
+            public void processFill(Transaction transaction, OrderDataDto orderData, boolean isFinal) {
+                conciliation.processFill(transaction, orderData, isFinal);
+            }
+
+            @Override
+            public void releaseMargin(Transaction transaction) {
+                conciliation.releaseMargin(transaction);
+            }
+        };
+    }
+
+    private static Transaction newBuyTransaction() {
+        BigDecimal quantity = new BigDecimal("2.50000000");
+        BigDecimal price = new BigDecimal("10.00000000");
+        return new Transaction(
+                UUID.randomUUID(),
+                ClientOrderId.generate("x1", TransactionType.BUY),
+                TransactionType.BUY,
+                "BTCUSDT",
+                quantity,
+                price,
+                quantity.multiply(price),
+                new BigDecimal("0.8"),
+                "test",
+                null
+        );
+    }
+
+    private static StrategyRunner newRunner(UUID runnerId, String exchangeId) {
+        return new StrategyRunner(
+                runnerId,
+                UUID.randomUUID(),
+                "x1",
+                UUID.randomUUID(),
+                "strategy",
+                "BTCUSDT",
+                exchangeId,
+                Set.of("BINANCE"),
+                RunnerStatus.ACTIVE,
+                ExecutionPolicy.SINGLE,
+                AccountingPolicyType.FIFO,
+                new BigDecimal("0.2"),
+                1,
+                1,
+                null,
+                false,
+                Instant.now(),
+                null,
+                null,
+                0L
+        );
+    }
+
+    private static OrderDataDto orderData(Transaction transaction,
+                                          OrderDataDto.OrderStatus status,
+                                          BigDecimal executedQty,
+                                          BigDecimal executedPrice,
+                                          String exchangeOrderId) {
+        return new OrderDataDto(
+                exchangeOrderId,
+                transaction.getClientOrderId(),
+                Symbol.of(transaction.getSymbol()),
+                OrderDataDto.OrderSide.BUY,
+                OrderDataDto.OrderType.LIMIT,
+                transaction.getQuantity(),
+                executedQty,
+                transaction.getPrice(),
+                executedPrice,
+                BigDecimal.ZERO,
+                status,
+                null,
+                Instant.now()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `RecoverTransactionStatusPort` inbound contract in `core`
- implement `RecoverTransactionStatusUseCase` for runtime recovery of a single transaction by `transactionId`
- add request/response DTOs and unit coverage for positive query, fallback not-found, unsupported query, retryable failure, and terminal skip cases

## Scope
- this PR only introduces the core runtime recovery capability
- it does not refactor `RunnerBootRecoveryUseCase` yet
- it does not expose any Spring endpoint or watchdog flow yet

## Validation
- `./scripts/gradle-run.ps1 -q :core:test --tests com.marmitt.core.application.usecase.runner.RecoverTransactionStatusUseCaseTest`
- `./scripts/gradle-run.ps1 -q :core:compileJava :core:compileTestJava`