### PR TITLE
refactor(boot): extract RunBootSequenceUseCase from BootOrchestrator

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java
@@ -1,0 +1,457 @@
+package com.marmitt.core.application.usecase.boot;
+
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioBootSanityUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioReservationTtlUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioZombieDetectionUseCase;
+import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
+import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.domain.portfolio.Portfolio;
+import com.marmitt.core.domain.runner.ClientOrderId;
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.dto.boot.BootExecutionCommand;
+import com.marmitt.core.dto.exchange.boot.ExchangeBootReadiness;
+import com.marmitt.core.dto.portfolio.PortfolioBootSanityResult;
+import com.marmitt.core.dto.portfolio.PortfolioReservationTtlResult;
+import com.marmitt.core.dto.portfolio.PortfolioZombieCandidate;
+import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
+import com.marmitt.core.enums.BootAccountQueryPolicy;
+import com.marmitt.core.enums.BootFailureMode;
+import com.marmitt.core.enums.PortfolioReservationTtlStatus;
+import com.marmitt.core.enums.PortfolioSanityStatus;
+import com.marmitt.core.enums.PortfolioZombieDetectionStatus;
+import com.marmitt.core.enums.RunnerStatus;
+import com.marmitt.core.ports.inbound.boot.RunBootSequencePort;
+import com.marmitt.core.ports.outbound.boot.BootExecutionObserverPort;
+import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+public class RunBootSequenceUseCase implements RunBootSequencePort {
+
+    private final PortfolioRepositoryPort portfolioRepository;
+    private final StrategyRunnerRepositoryPort strategyRunnerRepository;
+    private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
+    private final PortfolioBootSanityUseCase portfolioBootSanityUseCase;
+    private final PortfolioReservationTtlUseCase portfolioReservationTtlUseCase;
+    private final PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase;
+    private final DeadLetterEntryRepositoryPort deadLetterEntryRepository;
+    private final RunnerBootRecoveryUseCase runnerBootRecoveryUseCase;
+
+    public RunBootSequenceUseCase(PortfolioRepositoryPort portfolioRepository,
+                                  StrategyRunnerRepositoryPort strategyRunnerRepository,
+                                  ExchangeAdapterRepositoryPort exchangeAdapterRepository,
+                                  PortfolioBootSanityUseCase portfolioBootSanityUseCase,
+                                  PortfolioReservationTtlUseCase portfolioReservationTtlUseCase,
+                                  PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase,
+                                  DeadLetterEntryRepositoryPort deadLetterEntryRepository,
+                                  RunnerBootRecoveryUseCase runnerBootRecoveryUseCase) {
+        this.portfolioRepository = portfolioRepository;
+        this.strategyRunnerRepository = strategyRunnerRepository;
+        this.exchangeAdapterRepository = exchangeAdapterRepository;
+        this.portfolioBootSanityUseCase = portfolioBootSanityUseCase;
+        this.portfolioReservationTtlUseCase = portfolioReservationTtlUseCase;
+        this.portfolioZombieDetectionUseCase = portfolioZombieDetectionUseCase;
+        this.deadLetterEntryRepository = deadLetterEntryRepository;
+        this.runnerBootRecoveryUseCase = runnerBootRecoveryUseCase;
+    }
+
+    @Override
+    public void execute(BootExecutionCommand command, BootExecutionObserverPort observer) {
+        String runId = UUID.randomUUID().toString();
+        observer.onRunStarted(runId, command.failureMode().name());
+        log.info("bootSequence: start runId={} mode={} phase1Enabled={} phase2Enabled={} phase3Enabled={}",
+                runId, command.failureMode(), command.phase1Enabled(), command.phase2Enabled(), command.phase3Enabled());
+
+        try {
+            List<Portfolio> portfolios = portfolioRepository.findAll();
+            List<StrategyRunner> eligibleRunners = portfolios.stream()
+                    .flatMap(this::loadRunnersByPortfolio)
+                    .filter(this::isEligibleForRecovery)
+                    .toList();
+
+            executePhase("phase1.infrastructure", command.phase1Enabled(),
+                    () -> runPhase1InfrastructureReadiness(runId, eligibleRunners, observer),
+                    observer);
+
+            boolean phase2Enabled = command.phase2Enabled();
+            executePhase("phase2.sanity", phase2Enabled && command.sanityEnabled(),
+                    () -> runPhase2PortfolioSanity(runId, portfolios, eligibleRunners, command, observer),
+                    observer);
+            executePhase("phase2.zombie", phase2Enabled && command.zombieEnabled(),
+                    () -> runPhase2ZombieDetection(runId, portfolios, eligibleRunners, command, observer),
+                    observer);
+            executePhase("phase2.reservation_ttl", phase2Enabled && command.ttlEnabled(),
+                    () -> runPhase2ReservationTtl(runId, portfolios, eligibleRunners, command, observer),
+                    observer);
+
+            List<RunnerBootRecoveryUseCase.RecoverySummary> summaries = new ArrayList<>();
+            executePhase("phase3.runner_recovery", command.phase3Enabled(),
+                    () -> summaries.addAll(eligibleRunners.stream().map(this::recoverRunner).toList()),
+                    observer);
+
+            observer.onRunCompleted(runId);
+            log.info("bootSequence: completed runId={} portfolios={} runners={}",
+                    runId, portfolios.size(), summaries.size());
+        } catch (RuntimeException e) {
+            observer.onRunFailed(runId, null, e.getMessage());
+            throw e;
+        }
+    }
+
+    private void runPhase1InfrastructureReadiness(String runId,
+                                                  List<StrategyRunner> runners,
+                                                  BootExecutionObserverPort observer) {
+        Set<String> exchanges = runners.stream()
+                .map(StrategyRunner::getExchangeId)
+                .filter(exchange -> exchange != null && !exchange.isBlank())
+                .map(String::toUpperCase)
+                .collect(Collectors.toCollection(java.util.TreeSet::new));
+
+        if (exchanges.isEmpty()) {
+            log.info("bootSequence.phase1: no exchange to validate");
+            return;
+        }
+
+        log.info("bootSequence.phase1: start exchanges={}", exchanges.size());
+
+        for (String exchange : exchanges) {
+            ExchangeBootReadiness readiness = exchangeAdapterRepository.findBootReadinessByName(exchange)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Boot readiness capability is not registered for exchange=" + exchange))
+                    .checkBootReadiness();
+
+            if (!readiness.ready()) {
+                throw triggerFailFast(runId, "phase1.infrastructure", readiness.code(),
+                        "Phase1 readiness failed exchange=" + exchange + " message=" + readiness.message(),
+                        observer);
+            }
+
+            log.info("bootSequence.phase1: exchange={} ready code={} message={}",
+                    exchange, readiness.code(), readiness.message());
+        }
+
+        log.info("bootSequence.phase1: completed exchanges={}", exchanges.size());
+    }
+
+    private void runPhase2PortfolioSanity(String runId,
+                                          List<Portfolio> portfolios,
+                                          List<StrategyRunner> eligibleRunners,
+                                          BootExecutionCommand command,
+                                          BootExecutionObserverPort observer) {
+        BootFailureMode mode = command.failureMode();
+        log.info("bootSequence.phase2.sanity: start portfolios={} mode={} accountQueryPolicy={} threshold={}",
+                portfolios.size(), mode, command.accountQueryPolicy(), command.sanityThreshold());
+
+        for (Portfolio portfolio : portfolios) {
+            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
+
+            if (exchanges.isEmpty()) {
+                log.debug("bootSequence.phase2.sanity: portfolio={} skipped - no eligible runner exchange",
+                        portfolio.getId());
+                continue;
+            }
+
+            for (String exchange : exchanges) {
+                long startedNs = System.nanoTime();
+                PortfolioBootSanityResult result =
+                        portfolioBootSanityUseCase.execute(portfolio.getId(), exchange, command.sanityThreshold());
+                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+                observer.onPortfolioPhaseEvaluated("phase2.sanity", result.status().name(), exchange, mode.name(), durationMs);
+
+                switch (result.status()) {
+                    case PASS, WARN_SURPLUS -> log.info(
+                            "bootSequence.phase2.sanity: portfolio={} exchange={} status={} code={} localTotal={} exchangeTotal={} signedDelta={} deviation={}",
+                            result.portfolioId(), result.exchangeId(), result.status(), result.code(),
+                            result.localTotal(), result.exchangeTotal(), result.signedDelta(), result.absoluteDeviation());
+                    case SKIPPED -> log.warn(
+                            "bootSequence.phase2.sanity: portfolio={} exchange={} status={} code={} message={}",
+                            result.portfolioId(), result.exchangeId(), result.status(), result.code(), result.message());
+                    case FAIL_DEFICIT -> log.error(
+                            "bootSequence.phase2.sanity: portfolio={} exchange={} status={} code={} message={} localTotal={} exchangeTotal={} signedDelta={} deviation={}",
+                            result.portfolioId(), result.exchangeId(), result.status(), result.code(), result.message(),
+                            result.localTotal(), result.exchangeTotal(), result.signedDelta(), result.absoluteDeviation());
+                    case FAILED -> log.warn(
+                            "bootSequence.phase2.sanity: portfolio={} exchange={} status={} code={} message={}",
+                            result.portfolioId(), result.exchangeId(), result.status(), result.code(), result.message());
+                }
+
+                boolean skippedWithFailPolicy = result.status() == PortfolioSanityStatus.SKIPPED
+                        && command.accountQueryPolicy() == BootAccountQueryPolicy.FAIL;
+                boolean criticalFailure = result.status() == PortfolioSanityStatus.FAIL_DEFICIT
+                        || result.status() == PortfolioSanityStatus.FAILED;
+                if ((skippedWithFailPolicy || criticalFailure) && mode == BootFailureMode.FAIL_FAST) {
+                    throw triggerFailFast(runId, "phase2.sanity", result.code(),
+                            "Phase2 sanity failed portfolio=" + result.portfolioId()
+                                    + " exchange=" + result.exchangeId()
+                                    + " message=" + result.message(),
+                            observer);
+                }
+            }
+        }
+
+        log.info("bootSequence.phase2.sanity: completed");
+    }
+
+    private void runPhase2ZombieDetection(String runId,
+                                          List<Portfolio> portfolios,
+                                          List<StrategyRunner> eligibleRunners,
+                                          BootExecutionCommand command,
+                                          BootExecutionObserverPort observer) {
+        BootFailureMode mode = command.failureMode();
+        log.info("bootSequence.phase2.zombie: start portfolios={} mode={} cutoffEnabled={}",
+                portfolios.size(), mode, command.cutoffEnabled());
+
+        for (Portfolio portfolio : portfolios) {
+            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
+            if (exchanges.isEmpty()) {
+                continue;
+            }
+
+            for (String exchange : exchanges) {
+                long startedNs = System.nanoTime();
+                PortfolioZombieDetectionResult result =
+                        portfolioZombieDetectionUseCase.execute(portfolio.getId(), exchange, command.cutoffEnabled());
+                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+                observer.onPortfolioPhaseEvaluated("phase2.zombie", result.status().name(), exchange, mode.name(), durationMs);
+
+                switch (result.status()) {
+                    case CLEAN -> log.info(
+                            "bootSequence.phase2.zombie: portfolio={} exchange={} status={} openOrders={} zombies={}",
+                            result.portfolioId(), result.exchangeId(), result.status(),
+                            result.openOrders(), result.zombieCount());
+                    case DETECTED -> {
+                        boolean persistToDlq = mode == BootFailureMode.FAIL_FAST;
+                        int persistedSamples = persistToDlq ? persistZombieSamplesToDlq(result) : 0;
+                        log.warn(
+                                "bootSequence.phase2.zombie: portfolio={} exchange={} mode={} status={} code={} openOrders={} zombies={} invalidFormat={} unknownRunner={} noLocalMatch={} beforeCutoff={} unknownSymbol={} persistedSamples={} dlqPersisted={}",
+                                result.portfolioId(), result.exchangeId(), mode, result.status(), result.code(),
+                                result.openOrders(), result.zombieCount(), result.invalidFormatCount(),
+                                result.unknownRunnerCount(), result.noLocalMatchCount(), result.beforeCutoffCount(),
+                                result.unknownSymbolCount(), persistedSamples, persistToDlq);
+                        result.samples().forEach(sample -> log.warn(
+                                "bootSequence.phase2.zombie: sample portfolio={} exchange={} reason={} code={} clientOrderId={} exchangeOrderId={} symbol={}",
+                                result.portfolioId(), result.exchangeId(), sample.reason(), sample.code(),
+                                sample.clientOrderId(), sample.exchangeOrderId(), sample.symbol()));
+                    }
+                    case SKIPPED -> log.warn(
+                            "bootSequence.phase2.zombie: portfolio={} exchange={} status={} code={} message={}",
+                            result.portfolioId(), result.exchangeId(), result.status(), result.code(), result.message());
+                    case FAILED -> log.error(
+                            "bootSequence.phase2.zombie: portfolio={} exchange={} status={} code={} message={}",
+                            result.portfolioId(), result.exchangeId(), result.status(), result.code(), result.message());
+                }
+
+                boolean criticalFailure = result.status() == PortfolioZombieDetectionStatus.FAILED
+                        || result.status() == PortfolioZombieDetectionStatus.DETECTED;
+                if (criticalFailure && mode == BootFailureMode.FAIL_FAST) {
+                    throw triggerFailFast(runId, "phase2.zombie", result.code(),
+                            "Phase2 zombie detection failed portfolio=" + result.portfolioId()
+                                    + " exchange=" + result.exchangeId()
+                                    + " message=" + result.message(),
+                            observer);
+                }
+            }
+        }
+
+        log.info("bootSequence.phase2.zombie: completed");
+    }
+
+    private void runPhase2ReservationTtl(String runId,
+                                         List<Portfolio> portfolios,
+                                         List<StrategyRunner> eligibleRunners,
+                                         BootExecutionCommand command,
+                                         BootExecutionObserverPort observer) {
+        long ttlMs = command.ttlMs();
+        BootFailureMode mode = command.failureMode();
+        log.info("bootSequence.phase2.ttl: start portfolios={} mode={} ttlMs={}", portfolios.size(), mode, ttlMs);
+
+        for (Portfolio portfolio : portfolios) {
+            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
+            if (exchanges.isEmpty()) {
+                continue;
+            }
+
+            for (String exchange : exchanges) {
+                List<StrategyRunner> scopedRunners = eligibleRunners.stream()
+                        .filter(runner -> runner.getPortfolioId().equals(portfolio.getId()))
+                        .filter(runner -> exchange.equalsIgnoreCase(runner.getExchangeId()))
+                        .toList();
+
+                long startedNs = System.nanoTime();
+                PortfolioReservationTtlResult result =
+                        portfolioReservationTtlUseCase.execute(portfolio.getId(), exchange, ttlMs, scopedRunners);
+                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+                observer.onPortfolioPhaseEvaluated("phase2.reservation_ttl", result.status().name(), exchange, mode.name(), durationMs);
+
+                switch (result.status()) {
+                    case CLEAN -> log.info(
+                            "bootSequence.phase2.ttl: portfolio={} exchange={} status={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
+                            result.portfolioId(), result.exchangeId(), result.status(), result.ttlMs(),
+                            result.scannedPendingCount(), result.eligibleNoExchangeOrderIdCount(),
+                            result.expiredCount(), result.freshCount(), result.errorCount());
+                    case EXPIRED -> {
+                        log.warn(
+                                "bootSequence.phase2.ttl: portfolio={} exchange={} status={} code={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
+                                result.portfolioId(), result.exchangeId(), result.status(), result.code(), result.ttlMs(),
+                                result.scannedPendingCount(), result.eligibleNoExchangeOrderIdCount(),
+                                result.expiredCount(), result.freshCount(), result.errorCount());
+                        result.samples().forEach(transactionId -> log.warn(
+                                "bootSequence.phase2.ttl: expiredSample portfolio={} exchange={} transactionId={}",
+                                result.portfolioId(), result.exchangeId(), transactionId));
+                    }
+                    case SKIPPED -> log.warn(
+                            "bootSequence.phase2.ttl: portfolio={} exchange={} status={} code={} message={} ttlMs={}",
+                            result.portfolioId(), result.exchangeId(), result.status(), result.code(),
+                            result.message(), result.ttlMs());
+                    case FAILED -> log.error(
+                            "bootSequence.phase2.ttl: portfolio={} exchange={} status={} code={} message={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
+                            result.portfolioId(), result.exchangeId(), result.status(), result.code(), result.message(), result.ttlMs(),
+                            result.scannedPendingCount(), result.eligibleNoExchangeOrderIdCount(),
+                            result.expiredCount(), result.freshCount(), result.errorCount());
+                }
+
+                boolean criticalFailure = result.status() == PortfolioReservationTtlStatus.FAILED;
+                if (criticalFailure && mode == BootFailureMode.FAIL_FAST) {
+                    throw triggerFailFast(runId, "phase2.reservation_ttl", result.code(),
+                            "Phase2 reservation TTL failed portfolio=" + result.portfolioId()
+                                    + " exchange=" + result.exchangeId()
+                                    + " message=" + result.message(),
+                            observer);
+                }
+            }
+        }
+
+        log.info("bootSequence.phase2.ttl: completed");
+    }
+
+    private void executePhase(String phase, boolean enabled, Runnable action, BootExecutionObserverPort observer) {
+        if (!enabled) {
+            observer.onPhaseSkipped(phase);
+            return;
+        }
+
+        long startedNs = System.nanoTime();
+        observer.onPhaseStarted(phase);
+        try {
+            action.run();
+            long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+            observer.onPhaseSucceeded(phase, durationMs);
+        } catch (RuntimeException e) {
+            long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+            observer.onPhaseFailed(phase, durationMs, e.getMessage());
+            throw e;
+        }
+    }
+
+    private IllegalStateException triggerFailFast(String runId,
+                                                  String phase,
+                                                  String code,
+                                                  String message,
+                                                  BootExecutionObserverPort observer) {
+        observer.onFailFastRequested(runId, phase, code, message);
+        return new IllegalStateException(message + " code=" + code);
+    }
+
+    private int persistZombieSamplesToDlq(PortfolioZombieDetectionResult result) {
+        int persisted = 0;
+        for (PortfolioZombieCandidate sample : result.samples()) {
+            UUID runnerId = resolveRunnerIdForZombieSample(result.portfolioId(), sample);
+
+            boolean alreadyOpen = deadLetterEntryRepository.existsUnresolvedByIdentity(
+                    result.portfolioId(),
+                    runnerId,
+                    sample.clientOrderId(),
+                    sample.exchangeOrderId(),
+                    sample.reason()
+            );
+
+            if (alreadyOpen) {
+                continue;
+            }
+
+            DeadLetterEntry entry = new DeadLetterEntry(
+                    result.portfolioId(),
+                    runnerId,
+                    sample.clientOrderId(),
+                    sample.exchangeOrderId(),
+                    "source=boot.phase2.zombie"
+                            + ", exchange=" + result.exchangeId()
+                            + ", runnerId=" + runnerId
+                            + ", code=" + sample.code()
+                            + ", symbol=" + sample.symbol()
+                            + ", reason=" + sample.reason(),
+                    sample.reason()
+            );
+            deadLetterEntryRepository.save(entry);
+            persisted++;
+        }
+        return persisted;
+    }
+
+    private UUID resolveRunnerIdForZombieSample(UUID portfolioId, PortfolioZombieCandidate sample) {
+        String clientOrderId = sample.clientOrderId();
+        if (clientOrderId == null || clientOrderId.isBlank()) {
+            return null;
+        }
+
+        var byTransaction = strategyRunnerRepository.findTransactionByClientOrderId(clientOrderId)
+                .flatMap(tx -> strategyRunnerRepository.findById(tx.getRunnerId())
+                        .filter(runner -> portfolioId.equals(runner.getPortfolioId()))
+                        .map(StrategyRunner::getId));
+        if (byTransaction.isPresent()) {
+            return byTransaction.get();
+        }
+
+        String shortCode = ClientOrderId.getRunnerShortCode(clientOrderId);
+        if (shortCode == null || shortCode.isBlank()) {
+            return null;
+        }
+
+        return strategyRunnerRepository.findByShortCodeAndPortfolioId(shortCode.toLowerCase(Locale.ROOT), portfolioId)
+                .map(StrategyRunner::getId)
+                .orElse(null);
+    }
+
+    private Set<String> resolvePortfolioExchanges(Portfolio portfolio, List<StrategyRunner> eligibleRunners) {
+        return eligibleRunners.stream()
+                .filter(runner -> runner.getPortfolioId().equals(portfolio.getId()))
+                .map(StrategyRunner::getExchangeId)
+                .filter(exchange -> exchange != null && !exchange.isBlank())
+                .map(String::toUpperCase)
+                .collect(Collectors.toCollection(java.util.TreeSet::new));
+    }
+
+    private Stream<StrategyRunner> loadRunnersByPortfolio(Portfolio portfolio) {
+        return strategyRunnerRepository.findByPortfolioId(portfolio.getId()).stream();
+    }
+
+    private boolean isEligibleForRecovery(StrategyRunner runner) {
+        return runner.getStatus() != RunnerStatus.ARCHIVED
+                && runner.getStatus() != RunnerStatus.TERMINATING;
+    }
+
+    private RunnerBootRecoveryUseCase.RecoverySummary recoverRunner(StrategyRunner runner) {
+        RunnerBootRecoveryUseCase.RecoverySummary summary = runnerBootRecoveryUseCase.recoverRunner(runner);
+
+        log.info("bootSequence: runner={} inFlight={} zombies={} limbo={}",
+                summary.runnerId(), summary.inFlightCount(), summary.zombiesCount(), summary.limboCount());
+
+        if (log.isDebugEnabled()) {
+            summary.notes().forEach(note ->
+                    log.debug("bootSequence: runner={} plan={}", summary.runnerId(), note));
+        }
+
+        return summary;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/boot/phase2/PortfolioBootSanityUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/boot/phase2/PortfolioBootSanityUseCase.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.application.usecase.portfolio;
+package com.marmitt.core.application.usecase.boot.phase2;
 
 import com.marmitt.core.domain.portfolio.GlobalBalance;
 import com.marmitt.core.dto.portfolio.PortfolioBootSanityResult;
@@ -13,9 +13,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-/**
- * Phase 2 (Portfolio): sanity check de saldo conforme IG 10.3.
- */
 @Slf4j
 public class PortfolioBootSanityUseCase {
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/boot/phase2/PortfolioReservationTtlUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/boot/phase2/PortfolioReservationTtlUseCase.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.application.usecase.portfolio;
+package com.marmitt.core.application.usecase.boot.phase2;
 
 import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdateExecutor;
 import com.marmitt.core.domain.Symbol;
@@ -16,16 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * Phase 2 (Portfolio): expira reservas locais "zumbis" por TTL durante o boot.
- *
- * <p>Escopo:
- * <ul>
- *   <li>Somente transacoes PENDING.</li>
- *   <li>Somente transacoes sem exchangeOrderId.</li>
- *   <li>Somente quando requestedAt <= now - ttlMs.</li>
- * </ul>
- */
 @Slf4j
 public class PortfolioReservationTtlUseCase {
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/boot/phase2/PortfolioZombieDetectionUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/boot/phase2/PortfolioZombieDetectionUseCase.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.application.usecase.portfolio;
+package com.marmitt.core.application.usecase.boot.phase2;
 
 import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.domain.runner.ClientOrderId;
@@ -26,9 +26,6 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/**
- * Phase 2 (Portfolio): identifica ordens abertas na exchange sem correspondencia local valida.
- */
 @Slf4j
 public class PortfolioZombieDetectionUseCase {
 

--- a/core/src/main/java/com/marmitt/core/dto/boot/BootExecutionCommand.java
+++ b/core/src/main/java/com/marmitt/core/dto/boot/BootExecutionCommand.java
@@ -1,0 +1,21 @@
+package com.marmitt.core.dto.boot;
+
+import com.marmitt.core.enums.BootAccountQueryPolicy;
+import com.marmitt.core.enums.BootFailureMode;
+
+import java.math.BigDecimal;
+
+public record BootExecutionCommand(
+        boolean phase1Enabled,
+        boolean phase2Enabled,
+        boolean phase3Enabled,
+        boolean sanityEnabled,
+        BigDecimal sanityThreshold,
+        boolean zombieEnabled,
+        boolean cutoffEnabled,
+        boolean ttlEnabled,
+        long ttlMs,
+        BootFailureMode failureMode,
+        BootAccountQueryPolicy accountQueryPolicy
+) {
+}

--- a/core/src/main/java/com/marmitt/core/ports/inbound/boot/RunBootSequencePort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/boot/RunBootSequencePort.java
@@ -1,0 +1,8 @@
+package com.marmitt.core.ports.inbound.boot;
+
+import com.marmitt.core.dto.boot.BootExecutionCommand;
+import com.marmitt.core.ports.outbound.boot.BootExecutionObserverPort;
+
+public interface RunBootSequencePort {
+    void execute(BootExecutionCommand command, BootExecutionObserverPort observer);
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/boot/BootExecutionObserverPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/boot/BootExecutionObserverPort.java
@@ -1,0 +1,13 @@
+package com.marmitt.core.ports.outbound.boot;
+
+public interface BootExecutionObserverPort {
+    void onRunStarted(String runId, String mode);
+    void onPhaseSkipped(String phase);
+    void onPhaseStarted(String phase);
+    void onPhaseSucceeded(String phase, long durationMs);
+    void onPhaseFailed(String phase, long durationMs, String message);
+    void onPortfolioPhaseEvaluated(String phase, String status, String exchange, String mode, long durationMs);
+    void onFailFastRequested(String runId, String phase, String code, String message);
+    void onRunCompleted(String runId);
+    void onRunFailed(String runId, String failurePhase, String failureMessage);
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
@@ -1,31 +1,11 @@
 package com.marmitt.application.spring.bootstrap;
 
-import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
-import com.marmitt.core.domain.portfolio.DeadLetterEntry;
+import com.marmitt.core.dto.boot.BootExecutionCommand;
 import com.marmitt.core.dto.boot.BootRunSnapshot;
-import com.marmitt.core.enums.BootAccountQueryPolicy;
-import com.marmitt.core.enums.BootFailureMode;
 import com.marmitt.core.enums.BootPhaseStatus;
 import com.marmitt.core.enums.BootRunStatus;
-import com.marmitt.core.domain.portfolio.Portfolio;
-import com.marmitt.core.domain.runner.ClientOrderId;
-import com.marmitt.core.domain.runner.StrategyRunner;
-import com.marmitt.core.dto.portfolio.PortfolioBootSanityResult;
-import com.marmitt.core.dto.portfolio.PortfolioZombieCandidate;
-import com.marmitt.core.dto.portfolio.PortfolioReservationTtlResult;
-import com.marmitt.core.dto.portfolio.PortfolioZombieDetectionResult;
-import com.marmitt.core.dto.exchange.boot.ExchangeBootReadiness;
-import com.marmitt.core.enums.PortfolioReservationTtlStatus;
-import com.marmitt.core.enums.RunnerStatus;
-import com.marmitt.core.enums.PortfolioSanityStatus;
-import com.marmitt.core.enums.PortfolioZombieDetectionStatus;
-import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
-import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
-import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
-import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import com.marmitt.core.ports.inbound.boot.RunBootSequencePort;
+import com.marmitt.core.ports.outbound.boot.BootExecutionObserverPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,28 +15,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Stream;
 
-/**
- * Orquestrador de boot em nivel de aplicacao.
- *
- * <p>Responsabilidade nesta fase:
- * <ul>
- *   <li>Demonstrar a ordem de fases do boot recovery.</li>
- *   <li>Disparar o RunnerBootRecoveryUseCase para cada runner elegivel.</li>
- *   <li>Executar saneamento/reconciliacao por runner e registrar resumo em log.</li>
- * </ul>
- *
- * <p>Ativacao:
- * <ul>
- *   <li>{@code runner.boot.orchestrator-enabled=true}</li>
- * </ul>
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -67,13 +26,6 @@ import java.util.stream.Stream;
 )
 public class BootOrchestrator {
 
-    private final PortfolioRepositoryPort portfolioRepository;
-    private final StrategyRunnerRepositoryPort strategyRunnerRepository;
-    private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
-    private final PortfolioBootSanityUseCase portfolioBootSanityUseCase;
-    private final PortfolioReservationTtlUseCase portfolioReservationTtlUseCase;
-    private final PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase;
-    private final DeadLetterEntryRepositoryPort deadLetterEntryRepository;
     private final RunnerBootPhase1Properties phase1Properties;
     private final RunnerBootPhase2Properties phase2Properties;
     private final RunnerBootPhase3Properties phase3Properties;
@@ -81,530 +33,105 @@ public class BootOrchestrator {
     private final PortfolioReservationTtlProperties portfolioReservationTtlProperties;
     private final PortfolioZombieDetectionProperties portfolioZombieDetectionProperties;
     private final PortfolioCutoffProperties portfolioCutoffProperties;
-    private final RunnerBootRecoveryUseCase runnerBootRecoveryUseCase;
+    private final RunBootSequencePort runBootSequence;
     private final BootStatusTracker bootStatusTracker;
     private final BootMetricsRecorder bootMetricsRecorder;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationReady() {
-        bootStatusTracker.startRun(phase2Properties.getMode().name());
-        log.info("bootOrchestrator: start runId={} mode={} phase1Enabled={} phase2Enabled={} phase3Enabled={}",
-                bootStatusTracker.currentRunId(),
-                phase2Properties.getMode(),
+        BootExecutionCommand command = new BootExecutionCommand(
                 phase1Properties.isEnabled(),
                 phase2Properties.isEnabled(),
-                phase3Properties.isEnabled());
+                phase3Properties.isEnabled(),
+                portfolioSanityCheckProperties.isEnabled(),
+                portfolioSanityCheckProperties.getThreshold(),
+                portfolioZombieDetectionProperties.isEnabled(),
+                portfolioCutoffProperties.isEnabled(),
+                portfolioReservationTtlProperties.isEnabled(),
+                portfolioReservationTtlProperties.getTtlMs(),
+                phase2Properties.getMode(),
+                phase2Properties.getAccountQueryPolicy()
+        );
 
+        BootExecutionObserverPort observer = buildObserver();
         try {
-            List<Portfolio> portfolios = portfolioRepository.findAll();
-            List<StrategyRunner> eligibleRunners = portfolios.stream()
-                    .flatMap(this::loadRunnersByPortfolio)
-                    .filter(this::isEligibleForRecovery)
-                    .toList();
-
-            executePhase("phase1.infrastructure", phase1Properties.isEnabled(),
-                    () -> runPhase1InfrastructureReadiness(eligibleRunners));
-
-            boolean phase2Enabled = phase2Properties.isEnabled();
-            executePhase("phase2.sanity",
-                    phase2Enabled && portfolioSanityCheckProperties.isEnabled(),
-                    () -> runPhase2PortfolioSanity(portfolios, eligibleRunners));
-            executePhase("phase2.zombie",
-                    phase2Enabled && portfolioZombieDetectionProperties.isEnabled(),
-                    () -> runPhase2ZombieDetection(portfolios, eligibleRunners));
-            executePhase("phase2.reservation_ttl",
-                    phase2Enabled && portfolioReservationTtlProperties.isEnabled(),
-                    () -> runPhase2ReservationTtl(portfolios, eligibleRunners));
-
-            List<RunnerBootRecoveryUseCase.RecoverySummary> summaries = new ArrayList<>();
-            executePhase("phase3.runner_recovery", phase3Properties.isEnabled(),
-                    () -> summaries.addAll(eligibleRunners.stream().map(this::recoverRunner).toList()));
-
-            bootStatusTracker.completeRun();
-            bootMetricsRecorder.recordRun(BootRunStatus.SUCCESS);
-            log.info("bootOrchestrator: completed runId={} portfolios={} runners={}",
-                    bootStatusTracker.currentRunId(), portfolios.size(), summaries.size());
+            runBootSequence.execute(command, observer);
         } catch (RuntimeException e) {
-            BootRunSnapshot snapshot = bootStatusTracker.snapshot();
-            if (snapshot.status() == BootRunStatus.RUNNING) {
-                bootStatusTracker.failRun("boot", e.getMessage());
-            }
-            bootMetricsRecorder.recordRun(BootRunStatus.FAILED);
             log.error("bootOrchestrator: failed runId={} reason={}",
                     bootStatusTracker.currentRunId(), e.getMessage(), e);
             throw e;
         }
     }
 
-    private void runPhase1InfrastructureReadiness(List<StrategyRunner> runners) {
-        Set<String> exchanges = runners.stream()
-                .map(StrategyRunner::getExchangeId)
-                .filter(exchange -> exchange != null && !exchange.isBlank())
-                .map(String::toUpperCase)
-                .collect(java.util.stream.Collectors.toCollection(java.util.TreeSet::new));
-
-        if (exchanges.isEmpty()) {
-            log.info("bootOrchestrator.phase1: no exchange to validate");
-            return;
-        }
-
-        log.info("bootOrchestrator.phase1: start exchanges={}", exchanges.size());
-
-        for (String exchange : exchanges) {
-            ExchangeBootReadiness readiness = exchangeAdapterRepository.findBootReadinessByName(exchange)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Boot readiness capability is not registered for exchange=" + exchange))
-                    .checkBootReadiness();
-
-            if (!readiness.ready()) {
-                throw failFast(
-                        "phase1.infrastructure",
-                        readiness.code(),
-                        "Phase1 readiness failed exchange=" + exchange + " message=" + readiness.message()
-                );
+    private BootExecutionObserverPort buildObserver() {
+        return new BootExecutionObserverPort() {
+            @Override
+            public void onRunStarted(String runId, String mode) {
+                bootStatusTracker.startRun(mode);
+                log.info("bootOrchestrator: start runId={} mode={} phase1Enabled={} phase2Enabled={} phase3Enabled={}",
+                        runId, mode,
+                        phase1Properties.isEnabled(),
+                        phase2Properties.isEnabled(),
+                        phase3Properties.isEnabled());
             }
 
-            log.info("bootOrchestrator.phase1: exchange={} ready code={} message={}",
-                    exchange, readiness.code(), readiness.message());
-        }
-
-        log.info("bootOrchestrator.phase1: completed exchanges={}", exchanges.size());
-    }
-
-    private void runPhase2PortfolioSanity(List<Portfolio> portfolios, List<StrategyRunner> eligibleRunners) {
-        BootFailureMode mode = phase2Properties.getMode();
-        log.info("bootOrchestrator.phase2.sanity: start portfolios={} mode={} accountQueryPolicy={} threshold={}",
-                portfolios.size(), mode, phase2Properties.getAccountQueryPolicy(), portfolioSanityCheckProperties.getThreshold());
-
-        for (Portfolio portfolio : portfolios) {
-            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
-
-            if (exchanges.isEmpty()) {
-                log.debug("bootOrchestrator.phase2.sanity: portfolio={} skipped - no eligible runner exchange",
-                        portfolio.getId());
-                continue;
+            @Override
+            public void onPhaseSkipped(String phase) {
+                bootStatusTracker.completePhase(phase, BootPhaseStatus.SKIPPED, "disabled_by_configuration");
+                bootMetricsRecorder.recordPhase(phase, BootPhaseStatus.SKIPPED, 0L);
+                log.info("bootOrchestrator: phase={} status=SKIPPED reason=disabled_by_configuration runId={}",
+                        phase, bootStatusTracker.currentRunId());
             }
 
-            for (String exchange : exchanges) {
-                long startedNs = System.nanoTime();
-                PortfolioBootSanityResult result =
-                        portfolioBootSanityUseCase.execute(
-                                portfolio.getId(),
-                                exchange,
-                                portfolioSanityCheckProperties.getThreshold()
-                        );
-                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-                bootMetricsRecorder.recordPortfolioPhaseEvaluation(
-                        "phase2.sanity",
-                        result.status().name(),
-                        exchange,
-                        mode.name(),
-                        durationMs
-                );
+            @Override
+            public void onPhaseStarted(String phase) {
+                bootStatusTracker.startPhase(phase);
+            }
 
-                switch (result.status()) {
-                    case PASS, WARN_SURPLUS -> log.info(
-                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} localTotal={} exchangeTotal={} signedDelta={} deviation={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.localTotal(),
-                            result.exchangeTotal(),
-                            result.signedDelta(),
-                            result.absoluteDeviation()
-                    );
-                    case SKIPPED -> log.warn(
-                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} message={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message()
-                    );
-                    case FAIL_DEFICIT -> log.error(
-                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} message={} localTotal={} exchangeTotal={} signedDelta={} deviation={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message(),
-                            result.localTotal(),
-                            result.exchangeTotal(),
-                            result.signedDelta(),
-                            result.absoluteDeviation()
-                    );
-                    case FAILED -> log.warn(
-                            "bootOrchestrator.phase2.sanity: portfolio={} exchange={} status={} code={} message={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message()
-                    );
+            @Override
+            public void onPhaseSucceeded(String phase, long durationMs) {
+                bootStatusTracker.completePhase(phase, BootPhaseStatus.SUCCESS, "ok");
+                bootMetricsRecorder.recordPhase(phase, BootPhaseStatus.SUCCESS, durationMs);
+                log.info("bootOrchestrator: phase={} status=SUCCESS durationMs={} runId={}",
+                        phase, durationMs, bootStatusTracker.currentRunId());
+            }
+
+            @Override
+            public void onPhaseFailed(String phase, long durationMs, String message) {
+                bootStatusTracker.completePhase(phase, BootPhaseStatus.FAILED, message);
+                bootMetricsRecorder.recordPhase(phase, BootPhaseStatus.FAILED, durationMs);
+                bootStatusTracker.failRun(phase, message);
+            }
+
+            @Override
+            public void onPortfolioPhaseEvaluated(String phase, String status, String exchange, String mode, long durationMs) {
+                bootMetricsRecorder.recordPortfolioPhaseEvaluation(phase, status, exchange, mode, durationMs);
+            }
+
+            @Override
+            public void onFailFastRequested(String runId, String phase, String code, String message) {
+                bootMetricsRecorder.recordFailFast(phase, code);
+                applicationEventPublisher.publishEvent(new BootFailFastEvent(runId, phase, code, message, Instant.now()));
+            }
+
+            @Override
+            public void onRunCompleted(String runId) {
+                bootStatusTracker.completeRun();
+                bootMetricsRecorder.recordRun(BootRunStatus.SUCCESS);
+                log.info("bootOrchestrator: completed runId={}", runId);
+            }
+
+            @Override
+            public void onRunFailed(String runId, String failurePhase, String failureMessage) {
+                BootRunSnapshot snapshot = bootStatusTracker.snapshot();
+                if (snapshot.status() == BootRunStatus.RUNNING) {
+                    bootStatusTracker.failRun(
+                            failurePhase != null ? failurePhase : "boot",
+                            failureMessage);
                 }
-
-                boolean skippedWithFailPolicy = result.status() == PortfolioSanityStatus.SKIPPED
-                        && phase2Properties.getAccountQueryPolicy() == BootAccountQueryPolicy.FAIL;
-                boolean criticalFailure = result.status() == PortfolioSanityStatus.FAIL_DEFICIT
-                        || result.status() == PortfolioSanityStatus.FAILED;
-                if ((skippedWithFailPolicy || criticalFailure) && mode == BootFailureMode.FAIL_FAST) {
-                    throw failFast(
-                            "phase2.sanity",
-                            result.code(),
-                            "Phase2 sanity failed portfolio=" + result.portfolioId()
-                                    + " exchange=" + result.exchangeId()
-                                    + " message=" + result.message()
-                    );
-                }
+                bootMetricsRecorder.recordRun(BootRunStatus.FAILED);
             }
-        }
-
-        log.info("bootOrchestrator.phase2.sanity: completed");
-    }
-
-    private void runPhase2ZombieDetection(List<Portfolio> portfolios, List<StrategyRunner> eligibleRunners) {
-        BootFailureMode mode = phase2Properties.getMode();
-        log.info("bootOrchestrator.phase2.zombie: start portfolios={} mode={} cutoffEnabled={}",
-                portfolios.size(), mode, portfolioCutoffProperties.isEnabled());
-
-        for (Portfolio portfolio : portfolios) {
-            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
-            if (exchanges.isEmpty()) {
-                continue;
-            }
-
-            for (String exchange : exchanges) {
-                long startedNs = System.nanoTime();
-                PortfolioZombieDetectionResult result =
-                        portfolioZombieDetectionUseCase.execute(
-                                portfolio.getId(),
-                                exchange,
-                                portfolioCutoffProperties.isEnabled()
-                        );
-                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-                bootMetricsRecorder.recordPortfolioPhaseEvaluation(
-                        "phase2.zombie",
-                        result.status().name(),
-                        exchange,
-                        mode.name(),
-                        durationMs
-                );
-
-                switch (result.status()) {
-                    case CLEAN -> log.info(
-                            "bootOrchestrator.phase2.zombie: portfolio={} exchange={} status={} openOrders={} zombies={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.openOrders(),
-                            result.zombieCount()
-                    );
-                    case DETECTED -> {
-                        boolean persistToDlq = mode == BootFailureMode.FAIL_FAST;
-                        int persistedSamples = persistToDlq ? persistZombieSamplesToDlq(result) : 0;
-                        log.warn(
-                                "bootOrchestrator.phase2.zombie: portfolio={} exchange={} mode={} status={} code={} openOrders={} zombies={} invalidFormat={} unknownRunner={} noLocalMatch={} beforeCutoff={} unknownSymbol={} persistedSamples={} dlqPersisted={}",
-                                result.portfolioId(),
-                                result.exchangeId(),
-                                mode,
-                                result.status(),
-                                result.code(),
-                                result.openOrders(),
-                                result.zombieCount(),
-                                result.invalidFormatCount(),
-                                result.unknownRunnerCount(),
-                                result.noLocalMatchCount(),
-                                result.beforeCutoffCount(),
-                                result.unknownSymbolCount(),
-                                persistedSamples,
-                                persistToDlq
-                        );
-                        result.samples().forEach(sample -> log.warn(
-                                "bootOrchestrator.phase2.zombie: sample portfolio={} exchange={} reason={} code={} clientOrderId={} exchangeOrderId={} symbol={}",
-                                result.portfolioId(),
-                                result.exchangeId(),
-                                sample.reason(),
-                                sample.code(),
-                                sample.clientOrderId(),
-                                sample.exchangeOrderId(),
-                                sample.symbol()
-                        ));
-                    }
-                    case SKIPPED -> log.warn(
-                            "bootOrchestrator.phase2.zombie: portfolio={} exchange={} status={} code={} message={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message()
-                    );
-                    case FAILED -> log.error(
-                            "bootOrchestrator.phase2.zombie: portfolio={} exchange={} status={} code={} message={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message()
-                    );
-                }
-
-                boolean criticalFailure = result.status() == PortfolioZombieDetectionStatus.FAILED
-                        || result.status() == PortfolioZombieDetectionStatus.DETECTED;
-                if (criticalFailure && mode == BootFailureMode.FAIL_FAST) {
-                    throw failFast(
-                            "phase2.zombie",
-                            result.code(),
-                            "Phase2 zombie detection failed portfolio=" + result.portfolioId()
-                                    + " exchange=" + result.exchangeId()
-                                    + " message=" + result.message()
-                    );
-                }
-            }
-        }
-
-        log.info("bootOrchestrator.phase2.zombie: completed");
-    }
-
-    private void runPhase2ReservationTtl(List<Portfolio> portfolios, List<StrategyRunner> eligibleRunners) {
-        long ttlMs = portfolioReservationTtlProperties.getTtlMs();
-        BootFailureMode mode = phase2Properties.getMode();
-        log.info("bootOrchestrator.phase2.ttl: start portfolios={} mode={} ttlMs={}",
-                portfolios.size(), mode, ttlMs);
-
-        for (Portfolio portfolio : portfolios) {
-            Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
-            if (exchanges.isEmpty()) {
-                continue;
-            }
-
-            for (String exchange : exchanges) {
-                List<StrategyRunner> scopedRunners = eligibleRunners.stream()
-                        .filter(runner -> runner.getPortfolioId().equals(portfolio.getId()))
-                        .filter(runner -> exchange.equalsIgnoreCase(runner.getExchangeId()))
-                        .toList();
-
-                long startedNs = System.nanoTime();
-                PortfolioReservationTtlResult result = portfolioReservationTtlUseCase.execute(
-                        portfolio.getId(),
-                        exchange,
-                        ttlMs,
-                        scopedRunners
-                );
-                long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-                bootMetricsRecorder.recordPortfolioPhaseEvaluation(
-                        "phase2.reservation_ttl",
-                        result.status().name(),
-                        exchange,
-                        mode.name(),
-                        durationMs
-                );
-
-                switch (result.status()) {
-                    case CLEAN -> log.info(
-                            "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.ttlMs(),
-                            result.scannedPendingCount(),
-                            result.eligibleNoExchangeOrderIdCount(),
-                            result.expiredCount(),
-                            result.freshCount(),
-                            result.errorCount()
-                    );
-                    case EXPIRED -> {
-                        log.warn(
-                                "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} code={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
-                                result.portfolioId(),
-                                result.exchangeId(),
-                                result.status(),
-                                result.code(),
-                                result.ttlMs(),
-                                result.scannedPendingCount(),
-                                result.eligibleNoExchangeOrderIdCount(),
-                                result.expiredCount(),
-                                result.freshCount(),
-                                result.errorCount()
-                        );
-                        result.samples().forEach(transactionId -> log.warn(
-                                "bootOrchestrator.phase2.ttl: expiredSample portfolio={} exchange={} transactionId={}",
-                                result.portfolioId(),
-                                result.exchangeId(),
-                                transactionId
-                        ));
-                    }
-                    case SKIPPED -> log.warn(
-                            "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} code={} message={} ttlMs={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message(),
-                            result.ttlMs()
-                    );
-                    case FAILED -> log.error(
-                            "bootOrchestrator.phase2.ttl: portfolio={} exchange={} status={} code={} message={} ttlMs={} scannedPending={} eligibleNoExchangeOrderId={} expired={} fresh={} errors={}",
-                            result.portfolioId(),
-                            result.exchangeId(),
-                            result.status(),
-                            result.code(),
-                            result.message(),
-                            result.ttlMs(),
-                            result.scannedPendingCount(),
-                            result.eligibleNoExchangeOrderIdCount(),
-                            result.expiredCount(),
-                            result.freshCount(),
-                            result.errorCount()
-                    );
-                }
-
-                boolean criticalFailure = result.status() == PortfolioReservationTtlStatus.FAILED;
-                if (criticalFailure && mode == BootFailureMode.FAIL_FAST) {
-                    throw failFast(
-                            "phase2.reservation_ttl",
-                            result.code(),
-                            "Phase2 reservation TTL failed portfolio=" + result.portfolioId()
-                                    + " exchange=" + result.exchangeId()
-                                    + " message=" + result.message()
-                    );
-                }
-            }
-        }
-
-        log.info("bootOrchestrator.phase2.ttl: completed");
-    }
-
-    private Set<String> resolvePortfolioExchanges(Portfolio portfolio, List<StrategyRunner> eligibleRunners) {
-        return eligibleRunners.stream()
-                .filter(runner -> runner.getPortfolioId().equals(portfolio.getId()))
-                .map(StrategyRunner::getExchangeId)
-                .filter(exchange -> exchange != null && !exchange.isBlank())
-                .map(String::toUpperCase)
-                .collect(java.util.stream.Collectors.toCollection(java.util.TreeSet::new));
-    }
-
-    private Stream<StrategyRunner> loadRunnersByPortfolio(Portfolio portfolio) {
-        return strategyRunnerRepository.findByPortfolioId(portfolio.getId()).stream();
-    }
-
-    private boolean isEligibleForRecovery(StrategyRunner runner) {
-        return runner.getStatus() != RunnerStatus.ARCHIVED
-                && runner.getStatus() != RunnerStatus.TERMINATING;
-    }
-
-    private RunnerBootRecoveryUseCase.RecoverySummary recoverRunner(StrategyRunner runner) {
-        RunnerBootRecoveryUseCase.RecoverySummary summary = runnerBootRecoveryUseCase.recoverRunner(runner);
-
-        log.info("bootOrchestrator: runner={} inFlight={} zombies={} limbo={}",
-                summary.runnerId(), summary.inFlightCount(), summary.zombiesCount(), summary.limboCount());
-
-        // Verbose somente em debug para nao poluir log de producao.
-        if (log.isDebugEnabled()) {
-            summary.notes().forEach(note ->
-                    log.debug("bootOrchestrator: runner={} plan={}", summary.runnerId(), note));
-        }
-
-        return summary;
-    }
-
-    private void executePhase(String phase, boolean enabled, Runnable action) {
-        if (!enabled) {
-            bootStatusTracker.completePhase(phase, BootPhaseStatus.SKIPPED, "disabled_by_configuration");
-            bootMetricsRecorder.recordPhase(phase, BootPhaseStatus.SKIPPED, 0L);
-            log.info("bootOrchestrator: phase={} status=SKIPPED reason=disabled_by_configuration runId={}",
-                    phase, bootStatusTracker.currentRunId());
-            return;
-        }
-
-        long startedNs = System.nanoTime();
-        bootStatusTracker.startPhase(phase);
-        try {
-            action.run();
-            long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-            bootStatusTracker.completePhase(phase, BootPhaseStatus.SUCCESS, "ok");
-            bootMetricsRecorder.recordPhase(phase, BootPhaseStatus.SUCCESS, durationMs);
-            log.info("bootOrchestrator: phase={} status=SUCCESS durationMs={} runId={}",
-                    phase, durationMs, bootStatusTracker.currentRunId());
-        } catch (RuntimeException e) {
-            long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
-            bootStatusTracker.completePhase(phase, BootPhaseStatus.FAILED, e.getMessage());
-            bootMetricsRecorder.recordPhase(phase, BootPhaseStatus.FAILED, durationMs);
-            bootStatusTracker.failRun(phase, e.getMessage());
-            throw e;
-        }
-    }
-
-    private IllegalStateException failFast(String phase, String code, String message) {
-        bootMetricsRecorder.recordFailFast(phase, code);
-        applicationEventPublisher.publishEvent(new BootFailFastEvent(
-                bootStatusTracker.currentRunId(),
-                phase,
-                code,
-                message,
-                Instant.now()
-        ));
-        return new IllegalStateException(message + " code=" + code);
-    }
-
-    private int persistZombieSamplesToDlq(PortfolioZombieDetectionResult result) {
-        int persisted = 0;
-        for (PortfolioZombieCandidate sample : result.samples()) {
-            UUID runnerId = resolveRunnerIdForZombieSample(result.portfolioId(), sample);
-
-            boolean alreadyOpen = deadLetterEntryRepository.existsUnresolvedByIdentity(
-                    result.portfolioId(),
-                    runnerId,
-                    sample.clientOrderId(),
-                    sample.exchangeOrderId(),
-                    sample.reason()
-            );
-
-            if (alreadyOpen) {
-                continue;
-            }
-
-            DeadLetterEntry entry = new DeadLetterEntry(
-                    result.portfolioId(),
-                    runnerId,
-                    sample.clientOrderId(),
-                    sample.exchangeOrderId(),
-                    "source=boot.phase2.zombie"
-                            + ", exchange=" + result.exchangeId()
-                            + ", runnerId=" + runnerId
-                            + ", code=" + sample.code()
-                            + ", symbol=" + sample.symbol()
-                            + ", reason=" + sample.reason(),
-                    sample.reason()
-            );
-            deadLetterEntryRepository.save(entry);
-            persisted++;
-        }
-        return persisted;
-    }
-
-    private UUID resolveRunnerIdForZombieSample(UUID portfolioId, PortfolioZombieCandidate sample) {
-        String clientOrderId = sample.clientOrderId();
-        if (clientOrderId == null || clientOrderId.isBlank()) {
-            return null;
-        }
-
-        var byTransaction = strategyRunnerRepository.findTransactionByClientOrderId(clientOrderId)
-                .flatMap(tx -> strategyRunnerRepository.findById(tx.getRunnerId())
-                        .filter(runner -> portfolioId.equals(runner.getPortfolioId()))
-                        .map(StrategyRunner::getId));
-        if (byTransaction.isPresent()) {
-            return byTransaction.get();
-        }
-
-        String shortCode = ClientOrderId.getRunnerShortCode(clientOrderId);
-        if (shortCode == null || shortCode.isBlank()) {
-            return null;
-        }
-
-        return strategyRunnerRepository.findByShortCodeAndPortfolioId(shortCode.toLowerCase(Locale.ROOT), portfolioId)
-                .map(StrategyRunner::getId)
-                .orElse(null);
+        };
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootOrchestrator.java
@@ -68,7 +68,7 @@ public class BootOrchestrator {
         return new BootExecutionObserverPort() {
             @Override
             public void onRunStarted(String runId, String mode) {
-                bootStatusTracker.startRun(mode);
+                bootStatusTracker.startRun(runId, mode);
                 log.info("bootOrchestrator: start runId={} mode={} phase1Enabled={} phase2Enabled={} phase3Enabled={}",
                         runId, mode,
                         phase1Properties.isEnabled(),

--- a/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootStatusTracker.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/bootstrap/BootStatusTracker.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @Component
 public class BootStatusTracker {
@@ -27,8 +26,8 @@ public class BootStatusTracker {
     private String failureMessage;
     private final Map<String, PhaseMutable> phases = new LinkedHashMap<>();
 
-    public synchronized void startRun(String mode) {
-        this.runId = UUID.randomUUID().toString();
+    public synchronized void startRun(String runId, String mode) {
+        this.runId = runId;
         this.runStatus = BootRunStatus.RUNNING;
         this.mode = mode;
         this.runStartedAt = Instant.now();

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/BootConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/BootConfig.java
@@ -1,0 +1,67 @@
+package com.marmitt.application.spring.config.core;
+
+import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioBootSanityUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioReservationTtlUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioZombieDetectionUseCase;
+import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
+import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdateExecutor;
+import com.marmitt.core.ports.inbound.boot.RunBootSequencePort;
+import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.GlobalBalanceRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BootConfig {
+
+    @Bean
+    public PortfolioBootSanityUseCase portfolioBootSanityUseCase(
+            GlobalBalanceRepositoryPort globalBalanceRepository,
+            ExchangeAdapterRepositoryPort exchangeAdapterRepository
+    ) {
+        return new PortfolioBootSanityUseCase(globalBalanceRepository, exchangeAdapterRepository);
+    }
+
+    @Bean
+    public PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase(
+            StrategyRunnerRepositoryPort strategyRunnerRepository,
+            ExchangeAdapterRepositoryPort exchangeAdapterRepository
+    ) {
+        return new PortfolioZombieDetectionUseCase(strategyRunnerRepository, exchangeAdapterRepository);
+    }
+
+    @Bean
+    public PortfolioReservationTtlUseCase portfolioReservationTtlUseCase(
+            StrategyRunnerRepositoryPort strategyRunnerRepository,
+            ConciliationOrderUpdateExecutor conciliationOrderUpdate
+    ) {
+        return new PortfolioReservationTtlUseCase(strategyRunnerRepository, conciliationOrderUpdate);
+    }
+
+    @Bean
+    public RunBootSequencePort runBootSequence(
+            PortfolioRepositoryPort portfolioRepository,
+            StrategyRunnerRepositoryPort strategyRunnerRepository,
+            ExchangeAdapterRepositoryPort exchangeAdapterRepository,
+            PortfolioBootSanityUseCase portfolioBootSanityUseCase,
+            PortfolioReservationTtlUseCase portfolioReservationTtlUseCase,
+            PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase,
+            DeadLetterEntryRepositoryPort deadLetterEntryRepository,
+            RunnerBootRecoveryUseCase runnerBootRecoveryUseCase
+    ) {
+        return new RunBootSequenceUseCase(
+                portfolioRepository,
+                strategyRunnerRepository,
+                exchangeAdapterRepository,
+                portfolioBootSanityUseCase,
+                portfolioReservationTtlUseCase,
+                portfolioZombieDetectionUseCase,
+                deadLetterEntryRepository,
+                runnerBootRecoveryUseCase
+        );
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/PortfolioConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/PortfolioConfig.java
@@ -4,16 +4,11 @@ import com.marmitt.application.spring.service.TransactionalManageDeadLetterPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import com.marmitt.core.application.usecase.portfolio.CreatePortfolioUseCase;
 import com.marmitt.core.application.usecase.portfolio.ManageDeadLetterUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
 import com.marmitt.core.application.usecase.portfolio.QueryPortfolioUseCase;
-import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdateExecutor;
 import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
 import com.marmitt.core.ports.inbound.portfolio.QueryPortfolioPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
-import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.GlobalBalanceRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
@@ -45,30 +40,6 @@ public class PortfolioConfig {
                 strategyRunnerRepository,
                 globalBalanceRepository
         );
-    }
-
-    @Bean
-    public PortfolioBootSanityUseCase portfolioBootSanityUseCase(
-            GlobalBalanceRepositoryPort globalBalanceRepository,
-            ExchangeAdapterRepositoryPort exchangeAdapterRepository
-    ) {
-        return new PortfolioBootSanityUseCase(globalBalanceRepository, exchangeAdapterRepository);
-    }
-
-    @Bean
-    public PortfolioZombieDetectionUseCase portfolioZombieDetectionUseCase(
-            StrategyRunnerRepositoryPort strategyRunnerRepository,
-            ExchangeAdapterRepositoryPort exchangeAdapterRepository
-    ) {
-        return new PortfolioZombieDetectionUseCase(strategyRunnerRepository, exchangeAdapterRepository);
-    }
-
-    @Bean
-    public PortfolioReservationTtlUseCase portfolioReservationTtlUseCase(
-            StrategyRunnerRepositoryPort strategyRunnerRepository,
-            ConciliationOrderUpdateExecutor conciliationOrderUpdate
-    ) {
-        return new PortfolioReservationTtlUseCase(strategyRunnerRepository, conciliationOrderUpdate);
     }
 
     @Bean

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
@@ -1,8 +1,9 @@
 package com.marmitt.application.spring.bootstrap;
 
-import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
+import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioBootSanityUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioReservationTtlUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioZombieDetectionUseCase;
 import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
 import com.marmitt.core.domain.portfolio.Portfolio;
 import com.marmitt.core.domain.runner.StrategyRunner;
@@ -184,7 +185,7 @@ class BootOrchestratorBootMinimumTest {
         PortfolioCutoffProperties cutoffProperties = new PortfolioCutoffProperties();
         cutoffProperties.setEnabled(true);
 
-        return new BootOrchestrator(
+        RunBootSequenceUseCase runBootSequence = new RunBootSequenceUseCase(
                 portfolioRepository,
                 strategyRunnerRepository,
                 exchangeAdapterRepository,
@@ -192,6 +193,10 @@ class BootOrchestratorBootMinimumTest {
                 portfolioReservationTtlUseCase,
                 portfolioZombieDetectionUseCase,
                 deadLetterRepository,
+                runnerBootRecoveryUseCase
+        );
+
+        return new BootOrchestrator(
                 phase1Properties,
                 phase2Properties,
                 phase3Properties,
@@ -199,7 +204,7 @@ class BootOrchestratorBootMinimumTest {
                 ttlProperties,
                 zombieProperties,
                 cutoffProperties,
-                runnerBootRecoveryUseCase,
+                runBootSequence,
                 tracker,
                 bootMetricsRecorder,
                 eventPublisher

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
@@ -1,8 +1,9 @@
 package com.marmitt.application.spring.bootstrap;
 
-import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
+import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioBootSanityUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioReservationTtlUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioZombieDetectionUseCase;
 import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
 import com.marmitt.core.domain.portfolio.Portfolio;
@@ -190,7 +191,7 @@ class BootOrchestratorDlqOperationalTest {
         PortfolioCutoffProperties cutoffProperties = new PortfolioCutoffProperties();
         cutoffProperties.setEnabled(true);
 
-        return new BootOrchestrator(
+        RunBootSequenceUseCase runBootSequence = new RunBootSequenceUseCase(
                 portfolioRepository,
                 strategyRunnerRepository,
                 exchangeAdapterRepository,
@@ -198,6 +199,10 @@ class BootOrchestratorDlqOperationalTest {
                 portfolioReservationTtlUseCase,
                 portfolioZombieDetectionUseCase,
                 deadLetterRepository,
+                runnerBootRecoveryUseCase
+        );
+
+        return new BootOrchestrator(
                 phase1Properties,
                 phase2Properties,
                 phase3Properties,
@@ -205,7 +210,7 @@ class BootOrchestratorDlqOperationalTest {
                 ttlProperties,
                 zombieProperties,
                 cutoffProperties,
-                runnerBootRecoveryUseCase,
+                runBootSequence,
                 tracker,
                 bootMetricsRecorder,
                 eventPublisher

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
@@ -1,8 +1,9 @@
 package com.marmitt.application.spring.bootstrap;
 
-import com.marmitt.core.application.usecase.portfolio.PortfolioBootSanityUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioReservationTtlUseCase;
-import com.marmitt.core.application.usecase.portfolio.PortfolioZombieDetectionUseCase;
+import com.marmitt.core.application.usecase.boot.RunBootSequenceUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioBootSanityUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioReservationTtlUseCase;
+import com.marmitt.core.application.usecase.boot.phase2.PortfolioZombieDetectionUseCase;
 import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
 import com.marmitt.core.domain.portfolio.Portfolio;
 import com.marmitt.core.domain.runner.StrategyRunner;
@@ -199,7 +200,7 @@ class BootOrchestratorObservabilityTest {
         PortfolioCutoffProperties cutoffProperties = new PortfolioCutoffProperties();
         cutoffProperties.setEnabled(true);
 
-        return new BootOrchestrator(
+        RunBootSequenceUseCase runBootSequence = new RunBootSequenceUseCase(
                 portfolioRepository,
                 strategyRunnerRepository,
                 exchangeAdapterRepository,
@@ -207,6 +208,10 @@ class BootOrchestratorObservabilityTest {
                 portfolioReservationTtlUseCase,
                 portfolioZombieDetectionUseCase,
                 deadLetterRepository,
+                runnerBootRecoveryUseCase
+        );
+
+        return new BootOrchestrator(
                 phase1Properties,
                 phase2Properties,
                 phase3Properties,
@@ -214,7 +219,7 @@ class BootOrchestratorObservabilityTest {
                 ttlProperties,
                 zombieProperties,
                 cutoffProperties,
-                runnerBootRecoveryUseCase,
+                runBootSequence,
                 tracker,
                 bootMetricsRecorder,
                 eventPublisher


### PR DESCRIPTION
## Summary

- Extracts all boot orchestration logic from `BootOrchestrator` into `RunBootSequenceUseCase` in the core module, isolating business rules from the Spring lifecycle
- Introduces `RunBootSequencePort` (inbound) and `BootExecutionObserverPort` (outbound) so the use case remains framework-agnostic; the Spring adapter builds a composite observer that delegates to `BootStatusTracker`, `BootMetricsRecorder`, and `ApplicationEventPublisher`
- Relocates `PortfolioBootSanityUseCase`, `PortfolioZombieDetectionUseCase`, and `PortfolioReservationTtlUseCase` from `usecase.portfolio` → `usecase.boot.phase2`, making their boot-only scope explicit

## Test plan

- [x] `BootOrchestratorBootMinimumTest` — 3 tests: WARN_ONLY no-DLQ, FAIL_FAST with DLQ samples, FAIL_FAST with failed status
- [x] `BootOrchestratorDlqOperationalTest` — 2 tests: DLQ identity resolution, DLQ deduplication
- [x] `BootOrchestratorObservabilityTest` — 2 tests: metrics recording (WARN_ONLY and FAIL_FAST), event publishing
- [x] Full `./gradlew build -x test` passes on all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)