### PR TITLE
feat(core): route runtime missing orders to dlq

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
@@ -230,16 +230,17 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
                                                                     StrategyRunner runner,
                                                                     String exchangeId,
                                                                     TransactionStatus statusBefore) {
-        boolean alreadyOpen = deadLetterEntryRepository.existsUnresolvedByIdentity(
-                runner.getPortfolioId(),
-                transaction.getRunnerId(),
-                transaction.getClientOrderId(),
-                transaction.getExchangeOrderId(),
-                DlqReason.RECONCILIATION_CONFLICT
-        );
+        boolean alreadyOpen;
+        try {
+            alreadyOpen = deadLetterEntryRepository.existsUnresolvedByIdentity(
+                    runner.getPortfolioId(),
+                    transaction.getRunnerId(),
+                    transaction.getClientOrderId(),
+                    transaction.getExchangeOrderId(),
+                    DlqReason.RECONCILIATION_CONFLICT
+            );
 
-        if (!alreadyOpen) {
-            try {
+            if (!alreadyOpen) {
                 deadLetterEntryRepository.save(new DeadLetterEntry(
                         runner.getPortfolioId(),
                         transaction.getRunnerId(),
@@ -248,18 +249,18 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
                         buildRuntimeNotFoundDlqPayload(transaction, exchangeId, statusBefore),
                         DlqReason.RECONCILIATION_CONFLICT
                 ));
-            } catch (RuntimeException e) {
-                log.error("runtimeRecovery: failed to persist DLQ transactionId={} runnerId={} exchange={}",
-                        transaction.getId(), transaction.getRunnerId(), exchangeId, e);
-                return RecoverTransactionStatusResponse.failed(
-                        transaction.getId(),
-                        transaction.getRunnerId(),
-                        exchangeId,
-                        statusBefore,
-                        RecoverTransactionStatusResponse.FailureReason.DLQ_PERSISTENCE_FAILURE,
-                        "Failed to persist runtime recovery DLQ entry: " + e.getMessage()
-                );
             }
+        } catch (RuntimeException e) {
+            log.error("runtimeRecovery: failed to persist DLQ transactionId={} runnerId={} exchange={}",
+                    transaction.getId(), transaction.getRunnerId(), exchangeId, e);
+            return RecoverTransactionStatusResponse.failed(
+                    transaction.getId(),
+                    transaction.getRunnerId(),
+                    exchangeId,
+                    statusBefore,
+                    RecoverTransactionStatusResponse.FailureReason.DLQ_PERSISTENCE_FAILURE,
+                    "Failed to persist runtime recovery DLQ entry: " + e.getMessage()
+            );
         }
 
         return RecoverTransactionStatusResponse.recovered(

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
@@ -2,15 +2,18 @@ package com.marmitt.core.application.usecase.runner;
 
 import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdateExecutor;
 import com.marmitt.core.domain.Symbol;
+import com.marmitt.core.domain.portfolio.DeadLetterEntry;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
 import com.marmitt.core.dto.runner.request.RecoverTransactionStatusRequest;
 import com.marmitt.core.dto.runner.response.RecoverTransactionStatusResponse;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.exceptions.ExchangeQueryException;
 import com.marmitt.core.ports.inbound.runner.RecoverTransactionStatusPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
+import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import lombok.extern.slf4j.Slf4j;
@@ -33,13 +36,16 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
 
     private final StrategyRunnerRepositoryPort strategyRunnerRepository;
     private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
+    private final DeadLetterEntryRepositoryPort deadLetterEntryRepository;
     private final ConciliationOrderUpdateExecutor conciliationOrderUpdateExecutor;
 
     public RecoverTransactionStatusUseCase(StrategyRunnerRepositoryPort strategyRunnerRepository,
                                            ExchangeAdapterRepositoryPort exchangeAdapterRepository,
+                                           DeadLetterEntryRepositoryPort deadLetterEntryRepository,
                                            ConciliationOrderUpdateExecutor conciliationOrderUpdateExecutor) {
         this.strategyRunnerRepository = strategyRunnerRepository;
         this.exchangeAdapterRepository = exchangeAdapterRepository;
+        this.deadLetterEntryRepository = deadLetterEntryRepository;
         this.conciliationOrderUpdateExecutor = conciliationOrderUpdateExecutor;
     }
 
@@ -190,6 +196,15 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
             );
         }
 
+        return switch (request.missingOrderPolicy()) {
+            case APPLY_TERMINAL_FALLBACK -> applyTerminalFallback(transaction, exchangeId, statusBefore);
+            case REGISTER_DLQ -> routeMissingOrderToDlq(transaction, runner, exchangeId, statusBefore);
+        };
+    }
+
+    private RecoverTransactionStatusResponse applyTerminalFallback(Transaction transaction,
+                                                                   String exchangeId,
+                                                                   TransactionStatus statusBefore) {
         OrderDataDto.OrderStatus fallbackStatus = transaction.getStatus() == TransactionStatus.PARTIAL
                 ? OrderDataDto.OrderStatus.CANCELED
                 : OrderDataDto.OrderStatus.EXPIRED;
@@ -208,6 +223,55 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
                 transaction.getStatus(),
                 action,
                 "Exchange did not find order; applied local " + fallbackStatus + " fallback."
+        );
+    }
+
+    private RecoverTransactionStatusResponse routeMissingOrderToDlq(Transaction transaction,
+                                                                    StrategyRunner runner,
+                                                                    String exchangeId,
+                                                                    TransactionStatus statusBefore) {
+        boolean alreadyOpen = deadLetterEntryRepository.existsUnresolvedByIdentity(
+                runner.getPortfolioId(),
+                transaction.getRunnerId(),
+                transaction.getClientOrderId(),
+                transaction.getExchangeOrderId(),
+                DlqReason.RECONCILIATION_CONFLICT
+        );
+
+        if (!alreadyOpen) {
+            try {
+                deadLetterEntryRepository.save(new DeadLetterEntry(
+                        runner.getPortfolioId(),
+                        transaction.getRunnerId(),
+                        transaction.getClientOrderId(),
+                        transaction.getExchangeOrderId(),
+                        buildRuntimeNotFoundDlqPayload(transaction, exchangeId, statusBefore),
+                        DlqReason.RECONCILIATION_CONFLICT
+                ));
+            } catch (RuntimeException e) {
+                log.error("runtimeRecovery: failed to persist DLQ transactionId={} runnerId={} exchange={}",
+                        transaction.getId(), transaction.getRunnerId(), exchangeId, e);
+                return RecoverTransactionStatusResponse.failed(
+                        transaction.getId(),
+                        transaction.getRunnerId(),
+                        exchangeId,
+                        statusBefore,
+                        RecoverTransactionStatusResponse.FailureReason.DLQ_PERSISTENCE_FAILURE,
+                        "Failed to persist runtime recovery DLQ entry: " + e.getMessage()
+                );
+            }
+        }
+
+        return RecoverTransactionStatusResponse.recovered(
+                transaction.getId(),
+                transaction.getRunnerId(),
+                exchangeId,
+                statusBefore,
+                transaction.getStatus(),
+                RecoverTransactionStatusResponse.RecoveryAction.ROUTED_TO_DLQ,
+                alreadyOpen
+                        ? "Exchange did not find order; existing unresolved DLQ entry kept."
+                        : "Exchange did not find order; transaction routed to DLQ."
         );
     }
 
@@ -323,6 +387,20 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
                 reason,
                 Instant.now()
         );
+    }
+
+    private String buildRuntimeNotFoundDlqPayload(Transaction transaction,
+                                                  String exchangeId,
+                                                  TransactionStatus statusBefore) {
+        return "source=runner.recovery.transaction"
+                + ", exchange=" + exchangeId
+                + ", runnerId=" + transaction.getRunnerId()
+                + ", transactionId=" + transaction.getId()
+                + ", clientOrderId=" + transaction.getClientOrderId()
+                + ", exchangeOrderId=" + transaction.getExchangeOrderId()
+                + ", symbol=" + transaction.getSymbol()
+                + ", statusBefore=" + statusBefore
+                + ", outcome=ORDER_NOT_FOUND_ON_EXCHANGE";
     }
 
     private boolean isRetryableQueryFailure(Throwable throwable) {

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/RunnerBootRecoveryUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/RunnerBootRecoveryUseCase.java
@@ -247,7 +247,7 @@ public class RunnerBootRecoveryUseCase {
         for (Transaction tx : ctx.limbo()) {
             try {
                 RecoverTransactionStatusResponse response = recoverTransactionStatusUseCase.execute(
-                        new RecoverTransactionStatusRequest(tx.getId()),
+                        RecoverTransactionStatusRequest.forBoot(tx.getId()),
                         (orderQuery, transaction, runner) -> queryOrderByClientOrderIdWithRetry(ctx, transaction)
                 );
 

--- a/core/src/main/java/com/marmitt/core/dto/runner/request/RecoverTransactionStatusRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/runner/request/RecoverTransactionStatusRequest.java
@@ -3,9 +3,30 @@ package com.marmitt.core.dto.runner.request;
 import java.util.Objects;
 import java.util.UUID;
 
-public record RecoverTransactionStatusRequest(UUID transactionId) {
+public record RecoverTransactionStatusRequest(
+        UUID transactionId,
+        MissingOrderPolicy missingOrderPolicy
+) {
 
     public RecoverTransactionStatusRequest {
         Objects.requireNonNull(transactionId, "transactionId cannot be null");
+        Objects.requireNonNull(missingOrderPolicy, "missingOrderPolicy cannot be null");
+    }
+
+    public RecoverTransactionStatusRequest(UUID transactionId) {
+        this(transactionId, MissingOrderPolicy.REGISTER_DLQ);
+    }
+
+    public static RecoverTransactionStatusRequest forBoot(UUID transactionId) {
+        return new RecoverTransactionStatusRequest(transactionId, MissingOrderPolicy.APPLY_TERMINAL_FALLBACK);
+    }
+
+    public static RecoverTransactionStatusRequest forRuntimeWatchdog(UUID transactionId) {
+        return new RecoverTransactionStatusRequest(transactionId, MissingOrderPolicy.REGISTER_DLQ);
+    }
+
+    public enum MissingOrderPolicy {
+        APPLY_TERMINAL_FALLBACK,
+        REGISTER_DLQ
     }
 }

--- a/core/src/main/java/com/marmitt/core/dto/runner/response/RecoverTransactionStatusResponse.java
+++ b/core/src/main/java/com/marmitt/core/dto/runner/response/RecoverTransactionStatusResponse.java
@@ -90,7 +90,8 @@ public record RecoverTransactionStatusResponse(
         NONE,
         RECONCILED_FROM_EXCHANGE,
         MARKED_EXPIRED,
-        MARKED_CANCELED
+        MARKED_CANCELED,
+        ROUTED_TO_DLQ
     }
 
     public enum FailureReason {
@@ -101,6 +102,7 @@ public record RecoverTransactionStatusResponse(
         ORDER_QUERY_UNSUPPORTED,
         EXCHANGE_QUERY_RETRYABLE_FAILURE,
         EXCHANGE_QUERY_TERMINAL_FAILURE,
-        INVALID_EXCHANGE_RESPONSE
+        INVALID_EXCHANGE_RESPONSE,
+        DLQ_PERSISTENCE_FAILURE
     }
 }

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
@@ -10,6 +10,7 @@ import com.marmitt.core.dto.runner.request.RecoverTransactionStatusRequest;
 import com.marmitt.core.dto.runner.response.RecoverTransactionStatusResponse;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.enums.AccountingPolicyType;
+import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.enums.ExecutionPolicy;
 import com.marmitt.core.enums.RunnerStatus;
 import com.marmitt.core.enums.TransactionStatus;
@@ -17,6 +18,7 @@ import com.marmitt.core.enums.TransactionType;
 import com.marmitt.core.exceptions.ExchangeQueryException;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
+import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import org.junit.jupiter.api.Test;
@@ -63,11 +65,7 @@ class RecoverTransactionStatusUseCaseTest {
                         "EX_ORDER_REMOTE"
                 )));
 
-        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
-                repository,
-                exchangeRepository,
-                newExecutor(repository)
-        );
+        RecoverTransactionStatusUseCase useCase = newUseCase(repository, exchangeRepository);
 
         RecoverTransactionStatusResponse response = useCase.execute(
                 new RecoverTransactionStatusRequest(transaction.getId()));
@@ -81,7 +79,7 @@ class RecoverTransactionStatusUseCaseTest {
     }
 
     @Test
-    void executeMarksSubmittedTransactionExpiredWhenExchangeDoesNotFindOrder() {
+    void executeMarksSubmittedTransactionExpiredWhenExchangeDoesNotFindOrderInBootMode() {
         StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
         ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
         ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
@@ -97,14 +95,10 @@ class RecoverTransactionStatusUseCaseTest {
         when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
                 .thenReturn(Optional.empty());
 
-        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
-                repository,
-                exchangeRepository,
-                newExecutor(repository)
-        );
+        RecoverTransactionStatusUseCase useCase = newUseCase(repository, exchangeRepository);
 
         RecoverTransactionStatusResponse response = useCase.execute(
-                new RecoverTransactionStatusRequest(transaction.getId()));
+                RecoverTransactionStatusRequest.forBoot(transaction.getId()));
 
         assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.RECOVERED, response.outcome());
         assertEquals(RecoverTransactionStatusResponse.RecoveryAction.MARKED_EXPIRED, response.action());
@@ -113,7 +107,7 @@ class RecoverTransactionStatusUseCaseTest {
     }
 
     @Test
-    void executeMarksPartialTransactionCanceledWhenExchangeDoesNotFindOrder() {
+    void executeMarksPartialTransactionCanceledWhenExchangeDoesNotFindOrderInBootMode() {
         StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
         ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
         ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
@@ -130,19 +124,56 @@ class RecoverTransactionStatusUseCaseTest {
         when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
                 .thenReturn(Optional.empty());
 
-        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
-                repository,
-                exchangeRepository,
-                newExecutor(repository)
-        );
+        RecoverTransactionStatusUseCase useCase = newUseCase(repository, exchangeRepository);
 
         RecoverTransactionStatusResponse response = useCase.execute(
-                new RecoverTransactionStatusRequest(transaction.getId()));
+                RecoverTransactionStatusRequest.forBoot(transaction.getId()));
 
         assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.RECOVERED, response.outcome());
         assertEquals(RecoverTransactionStatusResponse.RecoveryAction.MARKED_CANCELED, response.action());
         assertEquals(TransactionStatus.CANCELED, response.statusAfter());
         assertEquals(TransactionStatus.CANCELED, transaction.getStatus());
+    }
+
+    @Test
+    void executeRoutesSubmittedTransactionToDlqWhenExchangeDoesNotFindOrderInRuntimeMode() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+        DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
+        ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        StrategyRunner runner = newRunner(transaction.getRunnerId(), "BINANCE");
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+        when(repository.findById(transaction.getRunnerId())).thenReturn(Optional.of(runner));
+        when(exchangeRepository.findOrderQueryByName("BINANCE")).thenReturn(Optional.of(orderQueryPort));
+        when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
+                .thenReturn(Optional.empty());
+        when(deadLetterRepository.existsUnresolvedByIdentity(
+                runner.getPortfolioId(),
+                transaction.getRunnerId(),
+                transaction.getClientOrderId(),
+                transaction.getExchangeOrderId(),
+                DlqReason.RECONCILIATION_CONFLICT
+        )).thenReturn(false);
+
+        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                deadLetterRepository,
+                newExecutor(repository)
+        );
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                RecoverTransactionStatusRequest.forRuntimeWatchdog(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.RECOVERED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.RecoveryAction.ROUTED_TO_DLQ, response.action());
+        assertEquals(TransactionStatus.SUBMITTED, response.statusAfter());
+        assertEquals(TransactionStatus.SUBMITTED, transaction.getStatus());
+        verify(deadLetterRepository).save(any());
     }
 
     @Test
@@ -161,11 +192,7 @@ class RecoverTransactionStatusUseCaseTest {
         when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
                 .thenThrow(new UnsupportedOperationException("not supported"));
 
-        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
-                repository,
-                exchangeRepository,
-                newExecutor(repository)
-        );
+        RecoverTransactionStatusUseCase useCase = newUseCase(repository, exchangeRepository);
 
         RecoverTransactionStatusResponse response = useCase.execute(
                 new RecoverTransactionStatusRequest(transaction.getId()));
@@ -196,11 +223,7 @@ class RecoverTransactionStatusUseCaseTest {
                         "Temporary upstream timeout"
                 ));
 
-        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
-                repository,
-                exchangeRepository,
-                newExecutor(repository)
-        );
+        RecoverTransactionStatusUseCase useCase = newUseCase(repository, exchangeRepository);
 
         RecoverTransactionStatusResponse response = useCase.execute(
                 new RecoverTransactionStatusRequest(transaction.getId()));
@@ -235,11 +258,7 @@ class RecoverTransactionStatusUseCaseTest {
                         null
                 )));
 
-        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
-                repository,
-                exchangeRepository,
-                newExecutor(repository)
-        );
+        RecoverTransactionStatusUseCase useCase = newUseCase(repository, exchangeRepository);
 
         RecoverTransactionStatusResponse response = useCase.execute(
                 new RecoverTransactionStatusRequest(transaction.getId()));
@@ -274,11 +293,7 @@ class RecoverTransactionStatusUseCaseTest {
                         null
                 )));
 
-        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
-                repository,
-                exchangeRepository,
-                newExecutor(repository)
-        );
+        RecoverTransactionStatusUseCase useCase = newUseCase(repository, exchangeRepository);
 
         RecoverTransactionStatusResponse response = useCase.execute(
                 new RecoverTransactionStatusRequest(transaction.getId()));
@@ -300,11 +315,7 @@ class RecoverTransactionStatusUseCaseTest {
 
         when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
 
-        RecoverTransactionStatusUseCase useCase = new RecoverTransactionStatusUseCase(
-                repository,
-                exchangeRepository,
-                newExecutor(repository)
-        );
+        RecoverTransactionStatusUseCase useCase = newUseCase(repository, exchangeRepository);
 
         RecoverTransactionStatusResponse response = useCase.execute(
                 new RecoverTransactionStatusRequest(transaction.getId()));
@@ -314,6 +325,16 @@ class RecoverTransactionStatusUseCaseTest {
         assertEquals(TransactionStatus.FILLED, response.statusBefore());
         assertEquals(TransactionStatus.FILLED, response.statusAfter());
         assertNull(response.exchangeId());
+    }
+
+    private static RecoverTransactionStatusUseCase newUseCase(StrategyRunnerRepositoryPort repository,
+                                                              ExchangeAdapterRepositoryPort exchangeRepository) {
+        return new RecoverTransactionStatusUseCase(
+                repository,
+                exchangeRepository,
+                mock(DeadLetterEntryRepositoryPort.class),
+                newExecutor(repository)
+        );
     }
 
     private static ConciliationOrderUpdateExecutor newExecutor(StrategyRunnerRepositoryPort repository) {

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
@@ -159,11 +159,13 @@ public class RunnerConfig {
     public RecoverTransactionStatusUseCase recoverTransactionStatusUseCase(
             StrategyRunnerRepositoryPort strategyRunnerRepository,
             ExchangeAdapterRepositoryPort exchangeAdapterRepository,
+            DeadLetterEntryRepositoryPort deadLetterEntryRepository,
             ConciliationOrderUpdateExecutor conciliationOrderUpdateExecutor
     ) {
         return new RecoverTransactionStatusUseCase(
                 strategyRunnerRepository,
                 exchangeAdapterRepository,
+                deadLetterEntryRepository,
                 conciliationOrderUpdateExecutor
         );
     }


### PR DESCRIPTION
## Context
This PR advances T1 (Transaction Recovery) by separating the runtime recovery policy from the boot recovery policy.

## What changed
- added `MissingOrderPolicy` to `RecoverTransactionStatusRequest`
- kept boot recovery using terminal fallback on `order not found`
- changed runtime recovery to route `order not found` to DLQ with identity deduplication
- added `ROUTED_TO_DLQ` action and `DLQ_PERSISTENCE_FAILURE` failure reason
- wired `DeadLetterEntryRepositoryPort` into `RecoverTransactionStatusUseCase`
- updated `RecoverTransactionStatusUseCaseTest` to cover boot fallback and runtime DLQ behavior

## Scope notes
- this PR does not add the scheduled watchdog yet
- `.claude/settings.local.json` and `docs/tasks/` were intentionally left out of the PR

## Validation
- `./scripts/gradle-run.ps1 -q :core:test --tests com.marmitt.core.application.usecase.runner.RecoverTransactionStatusUseCaseTest`
- `./scripts/gradle-run.ps1 -q :spring-application:compileJava`
- `:core:compileJava` timed out in the local wrapper session, but the targeted `:core:test` compile and execution passed