### PR TITLE
test(runtime): follow up PR 79 watchdog review

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java
@@ -21,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -413,20 +412,6 @@ public class RecoverTransactionStatusUseCase implements RecoverTransactionStatus
         }
         if (throwable instanceof ExchangeQueryException exchangeQueryException) {
             return exchangeQueryException.isRetryable();
-        }
-
-        String message = throwable.getMessage() != null
-                ? throwable.getMessage().toLowerCase(Locale.ROOT)
-                : "";
-
-        if (message.contains("timeout")
-                || message.contains("timed out")
-                || message.contains("connection reset")
-                || message.contains("temporarily")
-                || message.contains("rate limit")
-                || message.contains("429")
-                || message.contains("503")) {
-            return true;
         }
 
         Throwable cause = throwable.getCause();

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/RunnerBootRecoveryUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/RunnerBootRecoveryUseCase.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.Locale;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -367,20 +366,6 @@ public class RunnerBootRecoveryUseCase {
             return exchangeQueryException.isRetryable();
         }
         if (throwable instanceof BootQueryTimeoutException) {
-            return true;
-        }
-
-        String message = throwable.getMessage() != null
-                ? throwable.getMessage().toLowerCase(Locale.ROOT)
-                : "";
-
-        if (message.contains("timeout")
-                || message.contains("timed out")
-                || message.contains("connection reset")
-                || message.contains("temporarily")
-                || message.contains("rate limit")
-                || message.contains("429")
-                || message.contains("503")) {
             return true;
         }
 

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
@@ -235,6 +235,33 @@ class RecoverTransactionStatusUseCaseTest {
     }
 
     @Test
+    void executeTreatsGenericRuntimeQueryFailureAsTerminalEvenWhenMessageLooksTransient() {
+        StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+        ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);
+        ExchangeOrderQueryPort orderQueryPort = mock(ExchangeOrderQueryPort.class);
+
+        Transaction transaction = newBuyTransaction();
+        transaction.submit("EX_ORDER_LOCAL");
+        StrategyRunner runner = newRunner(transaction.getRunnerId(), "BINANCE");
+
+        when(repository.findTransactionById(transaction.getId())).thenReturn(Optional.of(transaction));
+        when(repository.findById(transaction.getRunnerId())).thenReturn(Optional.of(runner));
+        when(exchangeRepository.findOrderQueryByName("BINANCE")).thenReturn(Optional.of(orderQueryPort));
+        when(orderQueryPort.queryOrderByClientOrderId(transaction.getSymbol(), transaction.getClientOrderId()))
+                .thenThrow(new RuntimeException("temporary upstream timeout"));
+
+        RecoverTransactionStatusUseCase useCase = newUseCase(repository, exchangeRepository);
+
+        RecoverTransactionStatusResponse response = useCase.execute(
+                new RecoverTransactionStatusRequest(transaction.getId()));
+
+        assertEquals(RecoverTransactionStatusResponse.RecoveryOutcome.FAILED, response.outcome());
+        assertEquals(RecoverTransactionStatusResponse.FailureReason.EXCHANGE_QUERY_TERMINAL_FAILURE,
+                response.failureReason());
+        assertEquals(TransactionStatus.SUBMITTED, transaction.getStatus());
+    }
+
+    @Test
     void executeReturnsInvalidExchangeResponseWhenClientOrderIdDoesNotMatchRequestedTransaction() {
         StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
         ExchangeAdapterRepositoryPort exchangeRepository = mock(ExchangeAdapterRepositoryPort.class);

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerTransactionRecoveryWatchdogIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerTransactionRecoveryWatchdogIntegrationTest.java
@@ -2,6 +2,7 @@ package com.marmitt.application.spring.bootstrap;
 
 import com.marmitt.application.spring.CTradeApplication;
 import com.marmitt.application.spring.config.exchange.MockExchangeAdapter;
+import com.marmitt.core.application.usecase.runner.orderconciliation.ConciliationOrderUpdateExecutor;
 import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
 import com.marmitt.core.domain.runner.ClientOrderId;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -46,9 +48,11 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 
 @Testcontainers
 @SpringBootTest(
@@ -95,7 +99,7 @@ class RunnerTransactionRecoveryWatchdogIntegrationTest {
     @Autowired
     private RunnerTransactionRecoveryProperties properties;
 
-    @Autowired
+    @SpyBean
     private StrategyRunnerRepositoryPort strategyRunnerRepository;
 
     @Autowired
@@ -109,6 +113,9 @@ class RunnerTransactionRecoveryWatchdogIntegrationTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ConciliationOrderUpdateExecutor conciliationOrderUpdateExecutor;
 
     @BeforeEach
     void cleanDatabaseAndResetProperties() {
@@ -159,6 +166,95 @@ class RunnerTransactionRecoveryWatchdogIntegrationTest {
     }
 
     @Test
+    void watchdogShouldRecoverStalePartialOrderFoundAsFilled() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        BigDecimal quantity = new BigDecimal("0.00200000");
+        BigDecimal requestedPrice = new BigDecimal("50000.00000000");
+        BigDecimal reservedAmount = quantity.multiply(requestedPrice);
+        BigDecimal partialQuantity = new BigDecimal("0.00080000");
+        BigDecimal partialPrice = new BigDecimal("49950.00000000");
+        BigDecimal finalPrice = new BigDecimal("50020.00000000");
+
+        Transaction submittedBuy = newTransaction(
+                runner,
+                TransactionType.BUY,
+                quantity,
+                requestedPrice,
+                reservedAmount
+        );
+        submittedBuy.submit("EX_RUNTIME_PARTIAL_FILLED");
+        strategyRunnerRepository.saveTransaction(submittedBuy);
+        assertTrue(globalBalanceRepository.reserveAtomic(portfolioId, reservedAmount));
+
+        conciliationOrderUpdateExecutor.execute(orderData(
+                submittedBuy,
+                OrderDataDto.OrderStatus.PARTIALLY_FILLED,
+                partialQuantity,
+                partialPrice,
+                BigDecimal.ZERO
+        ));
+        Transaction partial = awaitTransactionStatus(submittedBuy.getId(), TransactionStatus.PARTIAL, WAIT_TIMEOUT);
+        markTransactionStale(partial.getId(), Duration.ofHours(2));
+
+        getMockExchangeAdapter().seedQueriedOrderSnapshot(orderData(
+                partial,
+                OrderDataDto.OrderStatus.FILLED,
+                quantity,
+                finalPrice,
+                BigDecimal.ZERO
+        ));
+
+        RecoverStaleTransactionsResponse response = watchdog.runRecoveryCycle();
+
+        Transaction filled = awaitTransactionStatus(partial.getId(), TransactionStatus.FILLED, WAIT_TIMEOUT);
+        assertNotNull(filled);
+        assertEquals(1, response.scanned());
+        assertEquals(1, response.recovered());
+        assertEquals(0, response.routedToDlq());
+        assertEquals(0, response.failed());
+    }
+
+    @Test
+    void watchdogShouldRecoverStaleSubmittedOrderFoundAsCanceled() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+        BigDecimal quantity = new BigDecimal("0.00150000");
+        BigDecimal requestedPrice = new BigDecimal("60000.00000000");
+        BigDecimal reservedAmount = quantity.multiply(requestedPrice);
+
+        Transaction submittedBuy = newTransaction(
+                runner,
+                TransactionType.BUY,
+                quantity,
+                requestedPrice,
+                reservedAmount
+        );
+        submittedBuy.submit("EX_RUNTIME_CANCELED");
+        strategyRunnerRepository.saveTransaction(submittedBuy);
+        assertTrue(globalBalanceRepository.reserveAtomic(portfolioId, reservedAmount));
+        markTransactionStale(submittedBuy.getId(), Duration.ofHours(2));
+
+        getMockExchangeAdapter().seedQueriedOrderSnapshot(orderData(
+                submittedBuy,
+                OrderDataDto.OrderStatus.CANCELED,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO
+        ));
+
+        RecoverStaleTransactionsResponse response = watchdog.runRecoveryCycle();
+
+        Transaction canceled = awaitTransactionStatus(submittedBuy.getId(), TransactionStatus.CANCELED, WAIT_TIMEOUT);
+        assertNotNull(canceled);
+        assertEquals(1, response.scanned());
+        assertEquals(1, response.recovered());
+        assertEquals(0, response.routedToDlq());
+        assertEquals(0, response.failed());
+        assertTrue(deadLetterEntryRepository.findUnresolved(portfolioId, runner.getId(), 10).isEmpty());
+    }
+
+    @Test
     void watchdogShouldRouteMissingOrderToSingleDlqEntryAcrossRepeatedCycles() {
         UUID portfolioId = createPortfolio();
         StrategyRunner runner = createAndActivateRunner(portfolioId);
@@ -190,6 +286,36 @@ class RunnerTransactionRecoveryWatchdogIntegrationTest {
         assertEquals(1, second.routedToDlq());
         assertEquals(1, firstEntries.size());
         assertEquals(1, secondEntries.size());
+    }
+
+    @Test
+    void watchdogShouldSkipCandidateThatBecomesTerminalAfterSelection() {
+        UUID portfolioId = createPortfolio();
+        StrategyRunner runner = createAndActivateRunner(portfolioId);
+
+        Transaction submitted = newSubmittedTransaction(runner, "EX_RUNTIME_SKIPPED");
+        strategyRunnerRepository.saveTransaction(submitted);
+        markTransactionStale(submitted.getId(), Duration.ofHours(2));
+
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            List<Transaction> candidates = (List<Transaction>) invocation.callRealMethod();
+            Transaction reloaded = strategyRunnerRepository.findTransactionById(submitted.getId())
+                    .orElseThrow(() -> new IllegalStateException("Transaction not found before skip simulation"));
+            reloaded.expire();
+            strategyRunnerRepository.saveTransaction(reloaded);
+            return candidates;
+        }).when(strategyRunnerRepository).findByStatusesUpdatedBefore(any(), any(), anyInt());
+
+        RecoverStaleTransactionsResponse response = watchdog.runRecoveryCycle();
+
+        Transaction expired = awaitTransactionStatus(submitted.getId(), TransactionStatus.EXPIRED, WAIT_TIMEOUT);
+        assertNotNull(expired);
+        assertEquals(1, response.scanned());
+        assertEquals(0, response.recovered());
+        assertEquals(0, response.routedToDlq());
+        assertEquals(1, response.skipped());
+        assertEquals(0, response.failed());
     }
 
     @Test


### PR DESCRIPTION
## Context
Follow-up to the review comment left on PR #79 after merge.

## What changed
- adds watchdog integration coverage for `PARTIAL -> FILLED`
- adds watchdog integration coverage for `SUBMITTED -> CANCELED`
- adds watchdog integration coverage for `SKIPPED` when the transaction becomes terminal after candidate selection
- hardens runtime recovery query classification to rely on typed exceptions/cause chain instead of parsing exception messages
- aligns boot recovery retry classification with the same rule to avoid divergent behavior

## Review notes addressed
- missing integration scenarios: addressed in this PR
- retry heuristic based on `message.contains(...)`: removed in this PR
- payload validation concerns: already covered in merged `develop`; no code change needed here

## Validation
- `./scripts/gradle-run.ps1 -q :core:compileJava :spring-application:compileJava`
- `./scripts/gradle-run.ps1 -q :core:test --tests com.marmitt.core.application.usecase.runner.RecoverTransactionStatusUseCaseTest`
- `./scripts/gradle-run.ps1 -q :spring-application:test --tests com.marmitt.application.spring.bootstrap.RunnerTransactionRecoveryWatchdogIntegrationTest`