### PR TITLE
refactor(exchange): register adapters as spring beans

### DIFF
--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceUrlBuilder.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceUrlBuilder.java
@@ -9,30 +9,39 @@ import java.util.stream.Collectors;
 
 public class BinanceUrlBuilder implements ExchangeUrlBuilderPort {
 
+    private final Configuration configuration;
+
+    public BinanceUrlBuilder(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
     @Override
     public String buildConnectionUrl(StreamSubscriptionRequest parameters) {
         List<CurrencyPair> currencyPairs = parameters.getCurrencyPairs();
-        
         if (currencyPairs.isEmpty()) {
             throw new IllegalArgumentException("At least one currency pair is required");
         }
 
-        // Se é apenas um símbolo, usa single stream
         if (currencyPairs.size() == 1) {
             CurrencyPair pair = currencyPairs.getFirst();
             String binanceSymbol = buildStreamName(pair);
-//            String stream = binanceSymbol.toLowerCase() + "@ticker";
-            return Configuration.BASE_URL + Configuration.SINGLE_STREAM_PATH + "/" + binanceSymbol;
+            return configuration.getWebSocketBaseUrl() + Configuration.SINGLE_STREAM_PATH + "/" + binanceSymbol;
         }
 
-        // Para múltiplos símbolos, usa combined stream
         List<String> streams = currencyPairs.stream()
                 .map(this::buildStreamName)
-//                .map(currency -> currency.toLowerCase() + "@ticker")
                 .collect(Collectors.toList());
-        
+
         String streamQuery = String.join("/", streams);
-        return Configuration.BASE_URL + Configuration.COMBINED_STREAM_PATH + "?streams=" + streamQuery;
+        return configuration.getWebSocketBaseUrl() + Configuration.COMBINED_STREAM_PATH + "?streams=" + streamQuery;
+    }
+
+    public String getWebSocketBaseUrl() {
+        return configuration.getWebSocketBaseUrl();
+    }
+
+    public String getRestBaseUrl() {
+        return configuration.getRestBaseUrl();
     }
 
     private String buildStreamName(CurrencyPair currencyPair) {

--- a/adapter-binance/src/main/java/com/marmitt/binance/Configuration.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/Configuration.java
@@ -1,11 +1,33 @@
 package com.marmitt.binance;
 
+import java.util.Objects;
+
 public class Configuration {
-    
-    public static final String BASE_URL = "wss://stream.binance.com:9443";
+
     public static final String SINGLE_STREAM_PATH = "/ws";
     public static final String COMBINED_STREAM_PATH = "/stream";
-    
-    private Configuration() {
+
+    private final String webSocketBaseUrl;
+    private final String restBaseUrl;
+
+    public Configuration(String webSocketBaseUrl, String restBaseUrl) {
+        this.webSocketBaseUrl = requireNonBlank(webSocketBaseUrl, "webSocketBaseUrl");
+        this.restBaseUrl = requireNonBlank(restBaseUrl, "restBaseUrl");
+    }
+
+    public String getWebSocketBaseUrl() {
+        return webSocketBaseUrl;
+    }
+
+    public String getRestBaseUrl() {
+        return restBaseUrl;
+    }
+
+    private static String requireNonBlank(String value, String field) {
+        Objects.requireNonNull(value, field + " cannot be null");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(field + " cannot be blank");
+        }
+        return value;
     }
 }

--- a/docs/tasks/T2-testnet-config.md
+++ b/docs/tasks/T2-testnet-config.md
@@ -67,14 +67,14 @@ O repositório passa a receber os adapters por injeção (`List<ExchangeStreamin
 ## Escopo técnico
 
 **Arquivos a criar:**
-- `spring-application/.../config/BinanceAdapterConfiguration.java` — bean condicional com `@ConditionalOnExpression`
-- `spring-application/.../config/BinanceProperties.java` — `@ConfigurationProperties` com `@NotBlank` em ambos os campos de credencial
+- `spring-application/.../config/exchange/BinanceAdapterConfiguration.java` — bean condicional com `@ConditionalOnExpression`
+- `spring-application/.../config/exchange/BinanceProperties.java` — `@ConfigurationProperties` com `@NotBlank` em ambos os campos de credencial
 - `spring-application/src/main/resources/application-testnet.yml` — perfil testnet
 
 **Arquivos a modificar:**
 - `adapter-binance/.../Configuration.java` — remover URLs hardcoded; receber por construtor
-- `spring-application/.../config/exchange/BinanceExchangeAdapter.java` — receber `BinanceProperties` por construtor
-- `spring-application/.../config/MockExchangeAdapter.java` (ou configuração equivalente) — converter em `@Bean` explícito dentro de uma `MockAdapterConfiguration`
+- `spring-application/.../config/exchange/BinanceExchangeAdapter.java` — receber configuração por construtor
+- `spring-application/.../config/exchange/MockExchangeAdapter.java` — passar a ser registrado por `MockAdapterConfiguration`
 - `spring-application/.../repository/InMemoryExchangeAdapterRepository.java` — remover `@PostConstruct`; receber `List<ExchangeStreamingPort>` por injeção
 - `spring-application/src/main/resources/application.yml` — adicionar bloco `binance:` com defaults de produção
 - `docker-compose.yml` — documentar variáveis de ambiente esperadas (valores de exemplo, sem secrets reais)
@@ -110,10 +110,10 @@ BINANCE_REST_BASE_URL     https://testnet.binance.vision
 
 ## Testes de integração obrigatórios
 
-| Cenário | Verificações obrigatórias |
-|---------|--------------------------|
-| Ambas as credenciais presentes e válidas | `hasAdapter("BINANCE") == true`; `hasAdapter("MOCK") == true` |
-| `BINANCE_API_KEY` presente, `BINANCE_API_SECRET` ausente | Startup falha; mensagem de erro referencia `binance.api-secret` |
-| `BINANCE_API_SECRET` presente, `BINANCE_API_KEY` ausente | Startup falha; mensagem de erro referencia `binance.api-key` |
-| Ambas as credenciais ausentes | Aplicação sobe; `hasAdapter("BINANCE") == false`; `hasAdapter("MOCK") == true` |
-| Perfil `testnet` ativo com credenciais presentes | A URL efetiva usada pelo URL builder do adapter (WebSocket e REST) contém `testnet.binance.vision`; verificar via campo exposto no adapter ou propriedade resolvida — não apenas o binding da propriedade |
+| Cenário                                                  | Verificações obrigatórias                                                                                                                                                                                 |
+|----------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Ambas as credenciais presentes e válidas                 | `hasAdapter("BINANCE") == true`; `hasAdapter("MOCK") == true`                                                                                                                                             |
+| `BINANCE_API_KEY` presente, `BINANCE_API_SECRET` ausente | Startup falha; mensagem de erro referencia `binance.api-secret`                                                                                                                                           |
+| `BINANCE_API_SECRET` presente, `BINANCE_API_KEY` ausente | Startup falha; mensagem de erro referencia `binance.api-key`                                                                                                                                              |
+| Ambas as credenciais ausentes                            | Aplicação sobe; `hasAdapter("BINANCE") == false`; `hasAdapter("MOCK") == true`                                                                                                                            |
+| Perfil `testnet` ativo com credenciais presentes         | A URL efetiva usada pelo URL builder do adapter (WebSocket e REST) contém `testnet.binance.vision`; verificar via campo exposto no adapter ou propriedade resolvida — não apenas o binding da propriedade |

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfiguration.java
@@ -1,0 +1,25 @@
+package com.marmitt.application.spring.config.exchange;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(BinanceProperties.class)
+@ConditionalOnExpression("!'${binance.api-key:}'.isBlank() || !'${binance.api-secret:}'.isBlank()")
+public class BinanceAdapterConfiguration {
+
+    @Bean
+    public BinanceExchangeAdapter binanceExchangeAdapter(ObjectMapper objectMapper,
+                                                         EventPublisherPort eventPublisher,
+                                                         BinanceProperties properties) {
+        com.marmitt.binance.Configuration configuration = new com.marmitt.binance.Configuration(
+                properties.getWsBaseUrl(),
+                properties.getRestBaseUrl()
+        );
+        return new BinanceExchangeAdapter(objectMapper, eventPublisher, configuration);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceExchangeAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceExchangeAdapter.java
@@ -3,6 +3,7 @@ package com.marmitt.application.spring.config.exchange;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marmitt.application.spring.adapter.OkHttp3ListenerConverter;
 import com.marmitt.application.spring.adapter.OkHttp3WebSocketAdapter;
+import com.marmitt.binance.Configuration;
 import com.marmitt.binance.BinanceUrlBuilder;
 import com.marmitt.binance.processor.receive.BinanceReceivedMessageProcessor;
 import com.marmitt.binance.processor.send.BinanceSenderMessageProcessor;
@@ -45,12 +46,16 @@ public class BinanceExchangeAdapter implements
     private final ReceivedMessageProcessorPort receivedMessageProcessor;
     private final SenderMessageProcessorPort senderMessageProcessor;
     private final ExchangeUrlBuilderPort urlBuilder;
+    private final Configuration configuration;
 
-    public BinanceExchangeAdapter(ObjectMapper objectMapper, EventPublisherPort eventPublisher) {
+    public BinanceExchangeAdapter(ObjectMapper objectMapper,
+                                  EventPublisherPort eventPublisher,
+                                  Configuration configuration) {
         this.webSocketPort = new OkHttp3WebSocketAdapter(new OkHttp3ListenerConverter(eventPublisher));
         this.receivedMessageProcessor = new BinanceReceivedMessageProcessor(objectMapper);
         this.senderMessageProcessor = new BinanceSenderMessageProcessor(objectMapper);
-        this.urlBuilder = new BinanceUrlBuilder();
+        this.configuration = configuration;
+        this.urlBuilder = new BinanceUrlBuilder(configuration);
     }
 
     @Override
@@ -81,6 +86,10 @@ public class BinanceExchangeAdapter implements
     @Override
     public ExchangeUrlBuilderPort getUrlBuilder() {
         return urlBuilder;
+    }
+
+    public Configuration getConfiguration() {
+        return configuration;
     }
 
     @Override

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceProperties.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceProperties.java
@@ -1,0 +1,54 @@
+package com.marmitt.application.spring.config.exchange;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "binance")
+public class BinanceProperties {
+
+    @NotBlank(message = "binance.ws-base-url cannot be blank")
+    private String wsBaseUrl;
+
+    @NotBlank(message = "binance.rest-base-url cannot be blank")
+    private String restBaseUrl;
+
+    @NotBlank(message = "binance.api-key is required when binance.api-secret is defined")
+    private String apiKey;
+
+    @NotBlank(message = "binance.api-secret is required when binance.api-key is defined")
+    private String apiSecret;
+
+    public String getWsBaseUrl() {
+        return wsBaseUrl;
+    }
+
+    public void setWsBaseUrl(String wsBaseUrl) {
+        this.wsBaseUrl = wsBaseUrl;
+    }
+
+    public String getRestBaseUrl() {
+        return restBaseUrl;
+    }
+
+    public void setRestBaseUrl(String restBaseUrl) {
+        this.restBaseUrl = restBaseUrl;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getApiSecret() {
+        return apiSecret;
+    }
+
+    public void setApiSecret(String apiSecret) {
+        this.apiSecret = apiSecret;
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/CoinbaseAdapterConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/CoinbaseAdapterConfiguration.java
@@ -1,0 +1,16 @@
+package com.marmitt.application.spring.config.exchange;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CoinbaseAdapterConfiguration {
+
+    @Bean
+    public CoinbaseExchangeAdapter coinbaseExchangeAdapter(ObjectMapper objectMapper,
+                                                           EventPublisherPort eventPublisher) {
+        return new CoinbaseExchangeAdapter(objectMapper, eventPublisher);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockAdapterConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockAdapterConfiguration.java
@@ -1,0 +1,16 @@
+package com.marmitt.application.spring.config.exchange;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MockAdapterConfiguration {
+
+    @Bean
+    public MockExchangeAdapter mockExchangeAdapter(ObjectMapper objectMapper,
+                                                   EventPublisherPort eventPublisher) {
+        return new MockExchangeAdapter(objectMapper, eventPublisher);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryExchangeAdapterRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryExchangeAdapterRepository.java
@@ -1,29 +1,26 @@
 package com.marmitt.application.spring.repository;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marmitt.application.spring.config.exchange.BinanceExchangeAdapter;
-import com.marmitt.application.spring.config.exchange.CoinbaseExchangeAdapter;
-import com.marmitt.application.spring.config.exchange.MockExchangeAdapter;
-import com.marmitt.core.ports.outbound.events.EventPublisherPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeAccountQueryPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeBootReadinessPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
-import jakarta.annotation.PostConstruct;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-@Slf4j
 @Repository
 public class InMemoryExchangeAdapterRepository implements ExchangeAdapterRepositoryPort {
+
+    private static final Logger log = LoggerFactory.getLogger(InMemoryExchangeAdapterRepository.class);
 
     private final Map<String, ExchangeStreamingPort> streamingAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeOrderExecutionPort> orderExecutionAdapters = new ConcurrentHashMap<>();
@@ -32,19 +29,8 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
     private final Map<String, ExchangeBootReadinessPort> bootReadinessAdapters = new ConcurrentHashMap<>();
     private final Map<UUID, String> adapterByPortfolio = new ConcurrentHashMap<>();
 
-    private final EventPublisherPort eventPublisher;
-    private final ObjectMapper objectMapper;
-
-    public InMemoryExchangeAdapterRepository(EventPublisherPort eventPublisher, ObjectMapper objectMapper) {
-        this.eventPublisher = eventPublisher;
-        this.objectMapper = objectMapper;
-    }
-
-    @PostConstruct
-    public void initExchangeAdapters() {
-        registerAllCapabilities(new BinanceExchangeAdapter(objectMapper, eventPublisher));
-        registerAllCapabilities(new CoinbaseExchangeAdapter(objectMapper, eventPublisher));
-        registerAllCapabilities(new MockExchangeAdapter(objectMapper, eventPublisher));
+    public InMemoryExchangeAdapterRepository(List<ExchangeStreamingPort> adapters) {
+        adapters.forEach(this::registerAllCapabilities);
     }
 
     @Override

--- a/spring-application/src/main/resources/application.yml
+++ b/spring-application/src/main/resources/application.yml
@@ -28,6 +28,12 @@ logging:
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
 
+binance:
+  ws-base-url: ${BINANCE_WS_BASE_URL:wss://stream.binance.com:9443}
+  rest-base-url: ${BINANCE_REST_BASE_URL:https://api.binance.com}
+  api-key: ${BINANCE_API_KEY:}
+  api-secret: ${BINANCE_API_SECRET:}
+
 event:
   retry:
     max-attempts: 5


### PR DESCRIPTION
## Context
First PR of T2 (testnet profile configuration).

This PR focuses on the wiring refactor required before the testnet profile and startup matrix can be added safely.

## What changed
- moved exchange adapter registration from `InMemoryExchangeAdapterRepository` into Spring bean wiring
- added explicit Spring configuration classes for `MOCK` and `COINBASE`
- added conditional Spring configuration for `BINANCE`
- introduced `BinanceProperties` for ws/rest base URLs and credentials
- removed Binance WebSocket base URL hardcode from `adapter-binance`
- made `BinanceUrlBuilder` depend on injected configuration instead of static constants
- added default Binance production properties in `application.yml`
- updated `docs/tasks/T2-testnet-config.md` to reflect the concrete file paths used by this refactor

## Intentionally left for the next PR
- `application-testnet.yml`
- startup matrix integration tests for missing/present credentials
- `docker-compose.yml` environment variable documentation

## Validation
- `./scripts/gradle-run.ps1 -q :adapter-binance:compileJava :spring-application:compileJava :spring-application:compileTestJava`
- `./scripts/gradle-run.ps1 -q :spring-application:test --tests com.marmitt.application.spring.bootstrap.ProcessTradeSignalMockIntegrationTest`