### PR TITLE
feat(binance): add testnet profile coverage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 x-application-env-example:
-  BINANCE_WS_BASE_URL: "wss://stream.binance.com:9443"
-  BINANCE_REST_BASE_URL: "https://api.binance.com"
   BINANCE_API_KEY: "your-binance-api-key"
   BINANCE_API_SECRET: "your-binance-api-secret"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,9 @@
+x-application-env-example:
+  BINANCE_WS_BASE_URL: "wss://stream.binance.com:9443"
+  BINANCE_REST_BASE_URL: "https://api.binance.com"
+  BINANCE_API_KEY: "your-binance-api-key"
+  BINANCE_API_SECRET: "your-binance-api-secret"
+
 services:
   postgres:
     image: postgres:16-alpine

--- a/docs/tasks/T2-testnet-config.md
+++ b/docs/tasks/T2-testnet-config.md
@@ -81,17 +81,11 @@ O repositório passa a receber os adapters por injeção (`List<ExchangeStreamin
 
 **Variáveis de ambiente:**
 ```
-BINANCE_WS_BASE_URL       wss://stream.binance.com:9443   (padrão; sobrescrito pelo perfil testnet)
-BINANCE_REST_BASE_URL     https://api.binance.com          (padrão; sobrescrito pelo perfil testnet)
 BINANCE_API_KEY           (sem padrão; ausência = adapter não registrado)
 BINANCE_API_SECRET        (sem padrão; ausência = adapter não registrado)
 ```
 
-**Valores para testnet (`application-testnet.yml`):**
-```
-BINANCE_WS_BASE_URL       wss://testnet.binance.vision
-BINANCE_REST_BASE_URL     https://testnet.binance.vision
-```
+As URLs não são variáveis de ambiente — são gerenciadas via YAML. O `application.yml` define os defaults de produção e o `application-testnet.yml` sobrescreve com URLs da testnet ao ativar o perfil `testnet`. Expor URLs como env vars criaria um problema de precedência: env vars (rank 6) sobrescrevem profile YAMLs (rank 7), tornando o perfil testnet ineficaz.
 
 ---
 

--- a/spring-application/src/main/resources/application-testnet.yml
+++ b/spring-application/src/main/resources/application-testnet.yml
@@ -1,3 +1,3 @@
 binance:
-  ws-base-url: ${BINANCE_WS_BASE_URL:wss://testnet.binance.vision}
-  rest-base-url: ${BINANCE_REST_BASE_URL:https://testnet.binance.vision}
+  ws-base-url: wss://testnet.binance.vision
+  rest-base-url: https://testnet.binance.vision

--- a/spring-application/src/main/resources/application-testnet.yml
+++ b/spring-application/src/main/resources/application-testnet.yml
@@ -1,0 +1,3 @@
+binance:
+  ws-base-url: ${BINANCE_WS_BASE_URL:wss://testnet.binance.vision}
+  rest-base-url: ${BINANCE_REST_BASE_URL:https://testnet.binance.vision}

--- a/spring-application/src/main/resources/application.yml
+++ b/spring-application/src/main/resources/application.yml
@@ -29,8 +29,8 @@ logging:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
 
 binance:
-  ws-base-url: ${BINANCE_WS_BASE_URL:wss://stream.binance.com:9443}
-  rest-base-url: ${BINANCE_REST_BASE_URL:https://api.binance.com}
+  ws-base-url: wss://stream.binance.com:9443
+  rest-base-url: https://api.binance.com
   api-key: ${BINANCE_API_KEY:}
   api-secret: ${BINANCE_API_SECRET:}
 

--- a/spring-application/src/test/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfigurationIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfigurationIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.marmitt.application.spring.config.exchange;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.application.spring.repository.InMemoryExchangeAdapterRepository;
+import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BinanceAdapterConfigurationIntegrationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TestApplication.class)
+            .withPropertyValues(
+                    "binance.ws-base-url=wss://stream.binance.com:9443",
+                    "binance.rest-base-url=https://api.binance.com"
+            );
+
+    @Test
+    void shouldRegisterBinanceAdapterWhenBothCredentialsArePresent() {
+        contextRunner
+                .withPropertyValues(
+                        "binance.api-key=test-key",
+                        "binance.api-secret=test-secret"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+
+                    ExchangeAdapterRepositoryPort repository = context.getBean(ExchangeAdapterRepositoryPort.class);
+                    assertThat(repository.hasAdapter("BINANCE")).isTrue();
+                    assertThat(repository.hasAdapter("MOCK")).isTrue();
+                });
+    }
+
+    @Test
+    void shouldFailStartupWhenApiKeyIsPresentWithoutApiSecret() {
+        contextRunner
+                .withPropertyValues("binance.api-key=test-key")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).hasStackTraceContaining("binance.api-secret");
+                });
+    }
+
+    @Test
+    void shouldFailStartupWhenApiSecretIsPresentWithoutApiKey() {
+        contextRunner
+                .withPropertyValues("binance.api-secret=test-secret")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).hasStackTraceContaining("binance.api-key");
+                });
+    }
+
+    @Test
+    void shouldStartWithoutBinanceAdapterWhenBothCredentialsAreAbsent() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+
+            ExchangeAdapterRepositoryPort repository = context.getBean(ExchangeAdapterRepositoryPort.class);
+            assertThat(repository.hasAdapter("BINANCE")).isFalse();
+            assertThat(repository.hasAdapter("MOCK")).isTrue();
+        });
+    }
+
+    @SpringBootConfiguration
+    @Import({
+            InMemoryExchangeAdapterRepository.class,
+            MockAdapterConfiguration.class,
+            CoinbaseAdapterConfiguration.class,
+            BinanceAdapterConfiguration.class
+    })
+    static class TestApplication {
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+
+        @Bean
+        EventPublisherPort eventPublisherPort() {
+            return new EventPublisherPort() {
+                @Override
+                public void publishEvent(Object event) {
+                }
+
+                @Override
+                public void publishEventSync(Object event) {
+                }
+            };
+        }
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/config/exchange/BinanceTestnetProfileIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/config/exchange/BinanceTestnetProfileIntegrationTest.java
@@ -1,0 +1,72 @@
+package com.marmitt.application.spring.config.exchange;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.application.spring.repository.InMemoryExchangeAdapterRepository;
+import com.marmitt.binance.BinanceUrlBuilder;
+import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        classes = BinanceTestnetProfileIntegrationTest.TestApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {
+                "binance.api-key=test-key",
+                "binance.api-secret=test-secret"
+        }
+)
+@ActiveProfiles("testnet")
+class BinanceTestnetProfileIntegrationTest {
+
+    @Autowired
+    private ExchangeAdapterRepositoryPort exchangeAdapterRepository;
+
+    @Autowired
+    private BinanceExchangeAdapter binanceExchangeAdapter;
+
+    @Test
+    void shouldUseTestnetUrlsWhenTestnetProfileIsActive() {
+        BinanceUrlBuilder urlBuilder = (BinanceUrlBuilder) binanceExchangeAdapter.getUrlBuilder();
+
+        assertThat(exchangeAdapterRepository.hasAdapter("BINANCE")).isTrue();
+        assertThat(exchangeAdapterRepository.hasAdapter("MOCK")).isTrue();
+        assertThat(urlBuilder.getWebSocketBaseUrl()).contains("testnet.binance.vision");
+        assertThat(urlBuilder.getRestBaseUrl()).contains("testnet.binance.vision");
+    }
+
+    @SpringBootConfiguration
+    @Import({
+            InMemoryExchangeAdapterRepository.class,
+            MockAdapterConfiguration.class,
+            CoinbaseAdapterConfiguration.class,
+            BinanceAdapterConfiguration.class
+    })
+    static class TestApplication {
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+
+        @Bean
+        EventPublisherPort eventPublisherPort() {
+            return new EventPublisherPort() {
+                @Override
+                public void publishEvent(Object event) {
+                }
+
+                @Override
+                public void publishEventSync(Object event) {
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Context
Second PR of T2 (testnet profile configuration).

This PR completes the operational side of the Binance testnet setup after the adapter-wiring refactor from PR #81.

## What changed
- added `application-testnet.yml` with Binance testnet ws/rest defaults
- documented expected Binance environment variables in `docker-compose.yml`
- added integration coverage for the Binance credential activation matrix
- added integration coverage proving that the active `testnet` profile changes the effective URLs used by the Binance adapter/url builder

## Covered scenarios
- both credentials present -> `BINANCE` adapter registered
- `BINANCE_API_KEY` present without `BINANCE_API_SECRET` -> startup fails
- `BINANCE_API_SECRET` present without `BINANCE_API_KEY` -> startup fails
- both credentials absent -> app starts without registering `BINANCE`
- `testnet` profile active -> effective Binance URLs point to `testnet.binance.vision`

## Validation
- `./scripts/gradle-run.ps1 -q :spring-application:compileJava :spring-application:compileTestJava`
- `./scripts/gradle-run.ps1 -q :spring-application:test --tests com.marmitt.application.spring.config.exchange.BinanceAdapterConfigurationIntegrationTest --tests com.marmitt.application.spring.config.exchange.BinanceTestnetProfileIntegrationTest`
- `./scripts/gradle-run.ps1 -q :spring-application:test --tests com.marmitt.application.spring.bootstrap.ProcessTradeSignalMockIntegrationTest`