### PR TITLE
refactor(binance): consolidate buildStreamName into BinanceUrlBuilder (P4)

### DIFF
--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceUrlBuilder.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceUrlBuilder.java
@@ -42,7 +42,7 @@ public class BinanceUrlBuilder implements ExchangeUrlBuilderPort {
         return config.getRestBaseUrl();
     }
 
-    private String buildStreamName(CurrencyPair currencyPair) {
+    public String buildStreamName(CurrencyPair currencyPair) {
         String lowerSymbol = (currencyPair.baseCurrency() + currencyPair.quoteCurrency()).toLowerCase();
         return switch (currencyPair.streamType()) {
             case TICKER     -> lowerSymbol + "@ticker";

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/send/BinanceSenderMessageProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/send/BinanceSenderMessageProcessor.java
@@ -1,6 +1,7 @@
 package com.marmitt.binance.processor.send;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.binance.BinanceUrlBuilder;
 import com.marmitt.binance.auth.BinanceRequestSigner;
 import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.ports.outbound.exchange.adapter.SenderMessageProcessorPort;
@@ -13,9 +14,9 @@ public class BinanceSenderMessageProcessor implements SenderMessageProcessorPort
 
     private final List<SenderSpecializedProcessorPort> specializedProcessors;
 
-    public BinanceSenderMessageProcessor(ObjectMapper objectMapper, BinanceRequestSigner signer) {
+    public BinanceSenderMessageProcessor(ObjectMapper objectMapper, BinanceRequestSigner signer, BinanceUrlBuilder urlBuilder) {
         this.specializedProcessors = new ArrayList<>();
-        specializedProcessors.add(new StreamProcessor(objectMapper));
+        specializedProcessors.add(new StreamProcessor(objectMapper, urlBuilder));
         specializedProcessors.add(new OrderProcessor(objectMapper, signer));
         specializedProcessors.add(new CancelOrderProcessor(objectMapper, signer));
     }

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/send/StreamProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/send/StreamProcessor.java
@@ -1,6 +1,7 @@
 package com.marmitt.binance.processor.send;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.binance.BinanceUrlBuilder;
 import com.marmitt.core.dto.common.CurrencyPair;
 import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.dto.websocket.request.StreamSubscriptionRequest;
@@ -15,9 +16,11 @@ import java.util.Map;
 public class StreamProcessor implements SenderSpecializedProcessorPort {
 
     private final ObjectMapper objectMapper;
+    private final BinanceUrlBuilder urlBuilder;
 
-    public StreamProcessor(ObjectMapper objectMapper) {
+    public StreamProcessor(ObjectMapper objectMapper, BinanceUrlBuilder urlBuilder) {
         this.objectMapper = objectMapper;
+        this.urlBuilder = urlBuilder;
     }
 
     @Override
@@ -38,7 +41,7 @@ public class StreamProcessor implements SenderSpecializedProcessorPort {
 
         try {
             List<String> streams = streamRequest.getCurrencyPairs().stream()
-                    .map(this::buildStreamName)
+                    .map(urlBuilder::buildStreamName)
                     .toList();
 
             Map<String, Object> message = new HashMap<>();
@@ -51,16 +54,5 @@ public class StreamProcessor implements SenderSpecializedProcessorPort {
             throw new RuntimeException("Failed to process stream subscription errorMessage", e);
         }
     }
-
-    private String buildStreamName(CurrencyPair currencyPair) {
-        String lowerSymbol = (currencyPair.baseCurrency() + currencyPair.quoteCurrency()).toLowerCase();
-        return switch (currencyPair.streamType()) {
-            case TICKER -> lowerSymbol + "@ticker";
-            case TRADE -> lowerSymbol + "@trade";
-            case BOOK_TICKER -> lowerSymbol + "@bookTicker";
-            case DEPTH -> lowerSymbol + "@depth";
-        };
-    }
-
 
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfiguration.java
@@ -27,7 +27,7 @@ public class BinanceAdapterConfiguration {
         var credentials = new BinanceCredentials(properties.getApiKey(), properties.getApiSecret());
         var signer      = new BinanceRequestSigner(credentials);
         var urlBuilder  = new BinanceUrlBuilder(config);
-        var sender      = new BinanceSenderMessageProcessor(objectMapper, signer);
+        var sender      = new BinanceSenderMessageProcessor(objectMapper, signer, urlBuilder);
         var receiver    = new BinanceReceivedMessageProcessor(objectMapper);
         var ws          = new OkHttp3WebSocketAdapter(new OkHttp3ListenerConverter(eventPublisher));
         return new BinanceExchangeAdapter(ws, receiver, sender, urlBuilder);


### PR DESCRIPTION
## Summary

- `buildStreamName(CurrencyPair)` existia identicamente em `BinanceUrlBuilder` e `StreamProcessor`
- Remove a cópia de `StreamProcessor`; delega para `BinanceUrlBuilder.buildStreamName` (agora público)
- `BinanceUrlBuilder` é o único ponto de verdade para construção de stream names
- `BinanceSenderMessageProcessor` recebe o `urlBuilder` e passa para `StreamProcessor`
- `BinanceAdapterConfiguration` (composition root) já tinha o `urlBuilder` — apenas propaga

## Relates to

P4 item de `docs/BINANCE_ADAPTER_REVIEW.md`

## Test plan

- [ ] Build: `./gradlew :adapter-binance:compileJava :spring-application:compileJava`
- [ ] SUBSCRIBE/UNSUBSCRIBE WebSocket gera stream names corretos (btcusdt@ticker, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)