### PR TITLE
refactor: move SenderSpecializedProcessorPort out of core (P5)

### DIFF
--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/send/BinanceSenderMessageProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/send/BinanceSenderMessageProcessor.java
@@ -5,14 +5,14 @@ import com.marmitt.binance.BinanceUrlBuilder;
 import com.marmitt.binance.auth.BinanceRequestSigner;
 import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.ports.outbound.exchange.adapter.SenderMessageProcessorPort;
-import com.marmitt.core.ports.outbound.exchange.adapter.SenderSpecializedProcessorPort;
+
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class BinanceSenderMessageProcessor implements SenderMessageProcessorPort {
 
-    private final List<SenderSpecializedProcessorPort> specializedProcessors;
+    private final List<BinanceSenderProcessor> specializedProcessors;
 
     public BinanceSenderMessageProcessor(ObjectMapper objectMapper, BinanceRequestSigner signer, BinanceUrlBuilder urlBuilder) {
         this.specializedProcessors = new ArrayList<>();

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/send/BinanceSenderProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/send/BinanceSenderProcessor.java
@@ -1,9 +1,9 @@
-package com.marmitt.core.ports.outbound.exchange.adapter;
+package com.marmitt.binance.processor.send;
 
 import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.enums.MessageType;
 
-public interface SenderSpecializedProcessorPort {
+interface BinanceSenderProcessor {
 
     String execute(MessageRequest request);
 

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/send/CancelOrderProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/send/CancelOrderProcessor.java
@@ -5,12 +5,12 @@ import com.marmitt.binance.auth.BinanceRequestSigner;
 import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.dto.websocket.request.SendCancelOrderRequest;
 import com.marmitt.core.enums.MessageType;
-import com.marmitt.core.ports.outbound.exchange.adapter.SenderSpecializedProcessorPort;
+
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class CancelOrderProcessor implements SenderSpecializedProcessorPort {
+public class CancelOrderProcessor implements BinanceSenderProcessor {
 
     private final ObjectMapper objectMapper;
     private final BinanceRequestSigner signer;

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/send/OrderProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/send/OrderProcessor.java
@@ -7,12 +7,12 @@ import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.core.enums.MessageType;
 import com.marmitt.core.enums.OrderSide;
 import com.marmitt.core.enums.OrderType;
-import com.marmitt.core.ports.outbound.exchange.adapter.SenderSpecializedProcessorPort;
+
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class OrderProcessor implements SenderSpecializedProcessorPort {
+public class OrderProcessor implements BinanceSenderProcessor {
 
     private final ObjectMapper objectMapper;
     private final BinanceRequestSigner signer;

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/send/StreamProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/send/StreamProcessor.java
@@ -7,13 +7,13 @@ import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.dto.websocket.request.StreamSubscriptionRequest;
 import com.marmitt.core.enums.MessageType;
 import com.marmitt.core.enums.StreamAction;
-import com.marmitt.core.ports.outbound.exchange.adapter.SenderSpecializedProcessorPort;
+
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class StreamProcessor implements SenderSpecializedProcessorPort {
+public class StreamProcessor implements BinanceSenderProcessor {
 
     private final ObjectMapper objectMapper;
     private final BinanceUrlBuilder urlBuilder;

--- a/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/CancelOrderProcessor.java
+++ b/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/CancelOrderProcessor.java
@@ -3,9 +3,9 @@ package com.marmitt.coinbase.processor.send;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.enums.MessageType;
-import com.marmitt.core.ports.outbound.exchange.adapter.SenderSpecializedProcessorPort;
 
-public class CancelOrderProcessor implements SenderSpecializedProcessorPort {
+
+public class CancelOrderProcessor implements CoinbaseSenderProcessor {
 
     private final ObjectMapper objectMapper;
 

--- a/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/CoinbaseSenderMessageProcessor.java
+++ b/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/CoinbaseSenderMessageProcessor.java
@@ -3,7 +3,7 @@ package com.marmitt.coinbase.processor.send;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.ports.outbound.exchange.adapter.SenderMessageProcessorPort;
-import com.marmitt.core.ports.outbound.exchange.adapter.SenderSpecializedProcessorPort;
+
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -12,7 +12,7 @@ import java.util.List;
 @Slf4j
 public class CoinbaseSenderMessageProcessor implements SenderMessageProcessorPort {
 
-    private final List<SenderSpecializedProcessorPort> specializedProcessors;
+    private final List<CoinbaseSenderProcessor> specializedProcessors;
 
     public CoinbaseSenderMessageProcessor(ObjectMapper objectMapper) {
         this.specializedProcessors = new ArrayList<>();

--- a/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/CoinbaseSenderProcessor.java
+++ b/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/CoinbaseSenderProcessor.java
@@ -1,0 +1,11 @@
+package com.marmitt.coinbase.processor.send;
+
+import com.marmitt.core.dto.websocket.request.MessageRequest;
+import com.marmitt.core.enums.MessageType;
+
+interface CoinbaseSenderProcessor {
+
+    String execute(MessageRequest request);
+
+    boolean canProcess(MessageType messageType);
+}

--- a/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/OrderProcessor.java
+++ b/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/OrderProcessor.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.core.enums.MessageType;
-import com.marmitt.core.ports.outbound.exchange.adapter.SenderSpecializedProcessorPort;
 
-public class OrderProcessor implements SenderSpecializedProcessorPort {
+
+public class OrderProcessor implements CoinbaseSenderProcessor {
 
     private final ObjectMapper objectMapper;
 

--- a/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/StreamProcessor.java
+++ b/adapter-coinbase/src/main/java/com/marmitt/coinbase/processor/send/StreamProcessor.java
@@ -6,7 +6,7 @@ import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.dto.websocket.request.StreamSubscriptionRequest;
 import com.marmitt.core.enums.MessageType;
 import com.marmitt.core.enums.StreamAction;
-import com.marmitt.core.ports.outbound.exchange.adapter.SenderSpecializedProcessorPort;
+
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-public class StreamProcessor implements SenderSpecializedProcessorPort {
+public class StreamProcessor implements CoinbaseSenderProcessor {
 
     private final ObjectMapper objectMapper;
 


### PR DESCRIPTION
## Summary

- `SenderSpecializedProcessorPort` era um port no `core` mas representa detalhe interno de roteamento de cada adapter — não é um contrato de domínio
- Substituído por `BinanceSenderProcessor` (package-private em `adapter-binance`) e `CoinbaseSenderProcessor` (package-private em `adapter-coinbase`)
- Mesmo padrão aplicado anteriormente para `ReceivedSpecializedProcessorPort` (PR #85)
- Nenhuma mudança de comportamento — só movimentação de interface

## Relates to

P5 item de `docs/BINANCE_ADAPTER_REVIEW.md`

## Test plan

- [ ] Build: `./gradlew :core:compileJava :adapter-binance:compileJava :adapter-coinbase:compileJava :spring-application:compileJava`

🤖 Generated with [Claude Code](https://claude.com/claude-code)