### PR TITLE
refactor(user-stream): ExchangeUserStreamPort becomes protocol descriptor

### DIFF
--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamAdapter.java
@@ -9,7 +9,6 @@ import com.marmitt.core.dto.websocket.MessageContext;
 import com.marmitt.core.dto.websocket.data.ProcessorResponse;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
 import com.marmitt.core.ports.outbound.http.HttpClientPort;
-import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -24,7 +23,6 @@ public class BinanceUserStreamAdapter implements ExchangeUserStreamPort {
 
     private static final long KEEPALIVE_INTERVAL_MINUTES = 30;
 
-    private final WebSocketPort webSocketPort;
     private final BinanceUserDataProcessor receivedMessageProcessor;
     private final ListenKeyManager listenKeyManager;
     private final String wsBaseUrl;
@@ -37,12 +35,10 @@ public class BinanceUserStreamAdapter implements ExchangeUserStreamPort {
 
     private ScheduledFuture<?> keepAliveTask;
 
-    public BinanceUserStreamAdapter(WebSocketPort webSocketPort,
-                                    HttpClientPort httpClient,
+    public BinanceUserStreamAdapter(HttpClientPort httpClient,
                                     ObjectMapper objectMapper,
                                     BinanceConnectionConfig config) {
         var credentials = new BinanceCredentials(config.apiKey(), config.apiSecret());
-        this.webSocketPort            = webSocketPort;
         this.receivedMessageProcessor = new BinanceUserDataProcessor(objectMapper);
         this.listenKeyManager         = new ListenKeyManager(config.restBaseUrl(), credentials, httpClient, objectMapper);
         this.wsBaseUrl                = config.wsBaseUrl();
@@ -54,7 +50,7 @@ public class BinanceUserStreamAdapter implements ExchangeUserStreamPort {
     }
 
     @Override
-    public void connect(UUID connectionId) throws IOException {
+    public String prepareConnection(UUID connectionId) throws IOException {
         if (keepAliveTask != null && !keepAliveTask.isDone()) {
             keepAliveTask.cancel(false);
         }
@@ -63,8 +59,6 @@ public class BinanceUserStreamAdapter implements ExchangeUserStreamPort {
         }
 
         String listenKey = listenKeyManager.obtainListenKey();
-        String wsUrl = wsBaseUrl + "/ws/" + listenKey;
-        webSocketPort.connect(wsUrl, "BINANCE", connectionId);
 
         keepAliveTask = scheduler.scheduleAtFixedRate(
                 listenKeyManager::keepAlive,
@@ -72,17 +66,17 @@ public class BinanceUserStreamAdapter implements ExchangeUserStreamPort {
                 KEEPALIVE_INTERVAL_MINUTES,
                 TimeUnit.MINUTES);
 
-        log.info("Binance user data stream connected");
+        log.info("Binance user data stream prepared - connectionId={}", connectionId);
+        return wsBaseUrl + "/ws/" + listenKey;
     }
 
     @Override
-    public void disconnect(UUID connectionId) {
+    public void onDisconnect(UUID connectionId) {
         if (keepAliveTask != null) {
             keepAliveTask.cancel(false);
         }
         listenKeyManager.revoke();
-        webSocketPort.disconnect("BINANCE", connectionId);
-        log.info("Binance user data stream disconnected");
+        log.info("Binance user data stream resources released - connectionId={}", connectionId);
     }
 
     @Override

--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamAdapter.java
@@ -1,82 +1,23 @@
 package com.marmitt.binance;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marmitt.binance.auth.BinanceCredentials;
 import com.marmitt.binance.processor.receive.BinanceUserDataProcessor;
-import com.marmitt.binance.userdata.ListenKeyManager;
 import com.marmitt.core.dto.processing.ProcessingResult;
 import com.marmitt.core.dto.websocket.MessageContext;
 import com.marmitt.core.dto.websocket.data.ProcessorResponse;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
-import com.marmitt.core.ports.outbound.http.HttpClientPort;
-import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-@Slf4j
 public class BinanceUserStreamAdapter implements ExchangeUserStreamPort {
 
-    private static final long KEEPALIVE_INTERVAL_MINUTES = 30;
-
     private final BinanceUserDataProcessor receivedMessageProcessor;
-    private final ListenKeyManager listenKeyManager;
-    private final String wsBaseUrl;
 
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-        Thread t = new Thread(r, "binance-listenkey-keepalive");
-        t.setDaemon(true);
-        return t;
-    });
-
-    private ScheduledFuture<?> keepAliveTask;
-
-    public BinanceUserStreamAdapter(HttpClientPort httpClient,
-                                    ObjectMapper objectMapper,
-                                    BinanceConnectionConfig config) {
-        var credentials = new BinanceCredentials(config.apiKey(), config.apiSecret());
+    public BinanceUserStreamAdapter(ObjectMapper objectMapper) {
         this.receivedMessageProcessor = new BinanceUserDataProcessor(objectMapper);
-        this.listenKeyManager         = new ListenKeyManager(config.restBaseUrl(), credentials, httpClient, objectMapper);
-        this.wsBaseUrl                = config.wsBaseUrl();
     }
 
     @Override
     public String getExchangeName() {
         return "BINANCE";
-    }
-
-    @Override
-    public String prepareConnection(UUID connectionId) throws IOException {
-        if (keepAliveTask != null && !keepAliveTask.isDone()) {
-            keepAliveTask.cancel(false);
-        }
-        if (listenKeyManager.getListenKey() != null) {
-            listenKeyManager.revoke();
-        }
-
-        String listenKey = listenKeyManager.obtainListenKey();
-
-        keepAliveTask = scheduler.scheduleAtFixedRate(
-                listenKeyManager::keepAlive,
-                KEEPALIVE_INTERVAL_MINUTES,
-                KEEPALIVE_INTERVAL_MINUTES,
-                TimeUnit.MINUTES);
-
-        log.info("Binance user data stream prepared - connectionId={}", connectionId);
-        return wsBaseUrl + "/ws/" + listenKey;
-    }
-
-    @Override
-    public void onDisconnect(UUID connectionId) {
-        if (keepAliveTask != null) {
-            keepAliveTask.cancel(false);
-        }
-        listenKeyManager.revoke();
-        log.info("Binance user data stream resources released - connectionId={}", connectionId);
     }
 
     @Override

--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamSessionAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamSessionAdapter.java
@@ -1,0 +1,75 @@
+package com.marmitt.binance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.binance.auth.BinanceCredentials;
+import com.marmitt.binance.userdata.ListenKeyManager;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
+import com.marmitt.core.ports.outbound.http.HttpClientPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class BinanceUserStreamSessionAdapter implements UserStreamSessionPort {
+
+    private static final long KEEPALIVE_INTERVAL_MINUTES = 30;
+
+    private final ListenKeyManager listenKeyManager;
+    private final String wsBaseUrl;
+
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "binance-listenkey-keepalive");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private ScheduledFuture<?> keepAliveTask;
+
+    public BinanceUserStreamSessionAdapter(HttpClientPort httpClient,
+                                           ObjectMapper objectMapper,
+                                           BinanceConnectionConfig config) {
+        var credentials = new BinanceCredentials(config.apiKey(), config.apiSecret());
+        this.listenKeyManager = new ListenKeyManager(config.restBaseUrl(), credentials, httpClient, objectMapper);
+        this.wsBaseUrl        = config.wsBaseUrl();
+    }
+
+    @Override
+    public String getExchangeName() {
+        return "BINANCE";
+    }
+
+    @Override
+    public String openSession(UUID connectionId) throws IOException {
+        if (keepAliveTask != null && !keepAliveTask.isDone()) {
+            keepAliveTask.cancel(false);
+        }
+        if (listenKeyManager.getListenKey() != null) {
+            listenKeyManager.revoke();
+        }
+
+        String listenKey = listenKeyManager.obtainListenKey();
+
+        keepAliveTask = scheduler.scheduleAtFixedRate(
+                listenKeyManager::keepAlive,
+                KEEPALIVE_INTERVAL_MINUTES,
+                KEEPALIVE_INTERVAL_MINUTES,
+                TimeUnit.MINUTES);
+
+        log.info("Binance user stream session opened - connectionId={}", connectionId);
+        return wsBaseUrl + "/ws/" + listenKey;
+    }
+
+    @Override
+    public void closeSession(UUID connectionId) {
+        if (keepAliveTask != null) {
+            keepAliveTask.cancel(false);
+        }
+        listenKeyManager.revoke();
+        log.info("Binance user stream session closed - connectionId={}", connectionId);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java
@@ -7,7 +7,7 @@ import com.marmitt.core.dto.websocket.response.WebSocketConnectionResponse;
 import com.marmitt.core.dto.wrapper.WebSocketConnectionManager;
 import com.marmitt.core.enums.ConnectionStatus;
 import com.marmitt.core.ports.inbound.websocket.ConnectUserStreamPort;
-import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.WebSocketConnectionRepositoryPort;
 import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 
 public class ConnectUserStreamUseCase implements ConnectUserStreamPort {
 
@@ -36,8 +37,7 @@ public class ConnectUserStreamUseCase implements ConnectUserStreamPort {
 
     @Override
     public Optional<WebSocketConnectionResponse> execute(String exchangeName) {
-        Optional<ExchangeUserStreamPort> userStreamOpt = adapterRepository.findUserStreamByName(exchangeName);
-        if (userStreamOpt.isEmpty()) {
+        if (adapterRepository.findUserStreamSessionByName(exchangeName).isEmpty()) {
             return Optional.empty();
         }
 
@@ -59,12 +59,13 @@ public class ConnectUserStreamUseCase implements ConnectUserStreamPort {
                 : ConnectionResultDto.connecting());
 
         try {
-            ExchangeUserStreamPort userStream = userStreamOpt.get();
-            String url = userStream.prepareConnection(manager.getConnectionId());
+            UserStreamSessionPort session = adapterRepository.findUserStreamSessionByName(exchangeName)
+                    .orElseThrow(() -> new IllegalStateException("No user stream session registered for exchange: " + exchangeName));
+            String url = session.openSession(manager.getConnectionId());
             WebSocketPort webSocket = webSocketRegistry.findUserStreamByExchangeName(exchangeName)
                     .orElseThrow(() -> new IllegalStateException("No user stream WebSocket registered for exchange: " + exchangeName));
             webSocket.connect(url, exchangeName, manager.getConnectionId());
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             log.error("Failed to connect user data stream - exchange={}", exchangeName, e);
             manager.setConnectionResult(ConnectionResultDto.failure("connect", "Failed: " + e.getMessage()));
         }

--- a/core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java
@@ -37,7 +37,8 @@ public class ConnectUserStreamUseCase implements ConnectUserStreamPort {
 
     @Override
     public Optional<WebSocketConnectionResponse> execute(String exchangeName) {
-        if (adapterRepository.findUserStreamSessionByName(exchangeName).isEmpty()) {
+        if (adapterRepository.findUserStreamSessionByName(exchangeName).isEmpty()
+                || adapterRepository.findUserStreamByName(exchangeName).isEmpty()) {
             return Optional.empty();
         }
 
@@ -58,15 +59,15 @@ public class ConnectUserStreamUseCase implements ConnectUserStreamPort {
                 ? ConnectionResultDto.reconnecting(1, 1)
                 : ConnectionResultDto.connecting());
 
+        UserStreamSessionPort session = adapterRepository.findUserStreamSessionByName(exchangeName).orElseThrow();
         try {
-            UserStreamSessionPort session = adapterRepository.findUserStreamSessionByName(exchangeName)
-                    .orElseThrow(() -> new IllegalStateException("No user stream session registered for exchange: " + exchangeName));
             String url = session.openSession(manager.getConnectionId());
             WebSocketPort webSocket = webSocketRegistry.findUserStreamByExchangeName(exchangeName)
                     .orElseThrow(() -> new IllegalStateException("No user stream WebSocket registered for exchange: " + exchangeName));
             webSocket.connect(url, exchangeName, manager.getConnectionId());
         } catch (IOException | RuntimeException e) {
             log.error("Failed to connect user data stream - exchange={}", exchangeName, e);
+            session.closeSession(manager.getConnectionId());
             manager.setConnectionResult(ConnectionResultDto.failure("connect", "Failed: " + e.getMessage()));
         }
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java
@@ -10,6 +10,8 @@ import com.marmitt.core.ports.inbound.websocket.ConnectUserStreamPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.WebSocketConnectionRepositoryPort;
+import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
+import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,11 +24,14 @@ public class ConnectUserStreamUseCase implements ConnectUserStreamPort {
 
     private final WebSocketConnectionRepositoryPort connectionRepository;
     private final ExchangeAdapterRepositoryPort adapterRepository;
+    private final WebSocketPortRegistryPort webSocketRegistry;
 
     public ConnectUserStreamUseCase(WebSocketConnectionRepositoryPort connectionRepository,
-                                    ExchangeAdapterRepositoryPort adapterRepository) {
+                                    ExchangeAdapterRepositoryPort adapterRepository,
+                                    WebSocketPortRegistryPort webSocketRegistry) {
         this.connectionRepository = connectionRepository;
         this.adapterRepository = adapterRepository;
+        this.webSocketRegistry = webSocketRegistry;
     }
 
     @Override
@@ -54,7 +59,11 @@ public class ConnectUserStreamUseCase implements ConnectUserStreamPort {
                 : ConnectionResultDto.connecting());
 
         try {
-            userStreamOpt.get().connect(manager.getConnectionId());
+            ExchangeUserStreamPort userStream = userStreamOpt.get();
+            String url = userStream.prepareConnection(manager.getConnectionId());
+            WebSocketPort webSocket = webSocketRegistry.findUserStreamByExchangeName(exchangeName)
+                    .orElseThrow(() -> new IllegalStateException("No user stream WebSocket registered for exchange: " + exchangeName));
+            webSocket.connect(url, exchangeName, manager.getConnectionId());
         } catch (IOException e) {
             log.error("Failed to connect user data stream - exchange={}", exchangeName, e);
             manager.setConnectionResult(ConnectionResultDto.failure("connect", "Failed: " + e.getMessage()));

--- a/core/src/main/java/com/marmitt/core/application/usecase/websocket/DisconnectWebSocketUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/websocket/DisconnectWebSocketUseCase.java
@@ -46,12 +46,12 @@ public class DisconnectWebSocketUseCase implements DisconnectWebSocketPort {
                 .orElseThrow(() -> new IllegalStateException("No WebSocket registered for exchange: " + exchangeName));
         webSocket.disconnect(exchangeName, connectionId);
 
-        adapterRepository.findUserStreamByName(exchangeName).ifPresent(userStream -> {
+        adapterRepository.findUserStreamSessionByName(exchangeName).ifPresent(session -> {
             WebSocketConnectionManager userManager = connectionRepository.getConnection(ConnectionKey.userStream(exchangeName));
             if (userManager != null) {
                 UUID userConnectionId = userManager.getConnectionId();
                 userManager.setConnectionResult(ConnectionResultDto.disconnecting("Manual disconnection requested", userConnectionId));
-                userStream.onDisconnect(userConnectionId);
+                session.closeSession(userConnectionId);
                 webSocketRegistry.findUserStreamByExchangeName(exchangeName)
                         .ifPresent(ws -> ws.disconnect(exchangeName, userConnectionId));
             }

--- a/core/src/main/java/com/marmitt/core/application/usecase/websocket/DisconnectWebSocketUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/websocket/DisconnectWebSocketUseCase.java
@@ -51,7 +51,9 @@ public class DisconnectWebSocketUseCase implements DisconnectWebSocketPort {
             if (userManager != null) {
                 UUID userConnectionId = userManager.getConnectionId();
                 userManager.setConnectionResult(ConnectionResultDto.disconnecting("Manual disconnection requested", userConnectionId));
-                userStream.disconnect(userConnectionId);
+                userStream.onDisconnect(userConnectionId);
+                webSocketRegistry.findUserStreamByExchangeName(exchangeName)
+                        .ifPresent(ws -> ws.disconnect(exchangeName, userConnectionId));
             }
         });
 

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/ExchangeUserStreamPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/ExchangeUserStreamPort.java
@@ -4,24 +4,9 @@ import com.marmitt.core.dto.processing.ProcessingResult;
 import com.marmitt.core.dto.websocket.MessageContext;
 import com.marmitt.core.dto.websocket.data.ProcessorResponse;
 
-import java.io.IOException;
-import java.util.UUID;
-
 public interface ExchangeUserStreamPort {
 
     String getExchangeName();
-
-    /**
-     * Prepares the connection: obtains credentials/session tokens, starts keep-alive,
-     * and returns the WebSocket URL for core to connect.
-     */
-    String prepareConnection(UUID connectionId) throws IOException;
-
-    /**
-     * Releases exchange-side resources: revokes session tokens, stops keep-alive.
-     * Core disconnects the WebSocket separately.
-     */
-    void onDisconnect(UUID connectionId);
 
     ProcessingResult<? extends ProcessorResponse> processMessage(String rawMessage, MessageContext context);
 }

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/ExchangeUserStreamPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/ExchangeUserStreamPort.java
@@ -11,9 +11,17 @@ public interface ExchangeUserStreamPort {
 
     String getExchangeName();
 
-    void connect(UUID connectionId) throws IOException;
+    /**
+     * Prepares the connection: obtains credentials/session tokens, starts keep-alive,
+     * and returns the WebSocket URL for core to connect.
+     */
+    String prepareConnection(UUID connectionId) throws IOException;
 
-    void disconnect(UUID connectionId);
+    /**
+     * Releases exchange-side resources: revokes session tokens, stops keep-alive.
+     * Core disconnects the WebSocket separately.
+     */
+    void onDisconnect(UUID connectionId);
 
     ProcessingResult<? extends ProcessorResponse> processMessage(String rawMessage, MessageContext context);
 }

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/UserStreamSessionPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/UserStreamSessionPort.java
@@ -1,0 +1,13 @@
+package com.marmitt.core.ports.outbound.exchange.streaming;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public interface UserStreamSessionPort {
+
+    String getExchangeName();
+
+    String openSession(UUID connectionId) throws IOException;
+
+    void closeSession(UUID connectionId);
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/repository/ExchangeAdapterRepositoryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/repository/ExchangeAdapterRepositoryPort.java
@@ -6,6 +6,7 @@ import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
 
 import java.util.Optional;
 import java.util.Set;
@@ -16,6 +17,8 @@ public interface ExchangeAdapterRepositoryPort {
     void registerStreamingAdapter(ExchangeStreamingPort adapter);
 
     void registerUserStreamAdapter(ExchangeUserStreamPort adapter);
+
+    void registerUserStreamSession(UserStreamSessionPort session);
 
     void registerOrderExecutionAdapter(String exchangeName, ExchangeOrderExecutionPort adapter);
 
@@ -44,4 +47,6 @@ public interface ExchangeAdapterRepositoryPort {
     Optional<ExchangeBootReadinessPort> findBootReadinessByName(String exchangeName);
 
     Optional<ExchangeUserStreamPort> findUserStreamByName(String exchangeName);
+
+    Optional<UserStreamSessionPort> findUserStreamSessionByName(String exchangeName);
 }

--- a/core/src/main/java/com/marmitt/core/ports/outbound/websocket/WebSocketPortRegistryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/websocket/WebSocketPortRegistryPort.java
@@ -7,4 +7,8 @@ public interface WebSocketPortRegistryPort {
     void register(String exchangeName, WebSocketPort port);
 
     Optional<WebSocketPort> findByExchangeName(String exchangeName);
+
+    void registerUserStream(String exchangeName, WebSocketPort port);
+
+    Optional<WebSocketPort> findUserStreamByExchangeName(String exchangeName);
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/WebSocketConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/WebSocketConfig.java
@@ -23,8 +23,9 @@ public class WebSocketConfig {
 
     @Bean
     public ConnectUserStreamPort connectUserStream(WebSocketConnectionRepositoryPort connectionRepository,
-                                                   ExchangeAdapterRepositoryPort adapterRepository) {
-        return new ConnectUserStreamUseCase(connectionRepository, adapterRepository);
+                                                   ExchangeAdapterRepositoryPort adapterRepository,
+                                                   WebSocketPortRegistryPort webSocketRegistry) {
+        return new ConnectUserStreamUseCase(connectionRepository, adapterRepository, webSocketRegistry);
     }
 
     @Bean

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceUserStreamConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceUserStreamConfiguration.java
@@ -6,6 +6,7 @@ import com.marmitt.application.spring.adapter.OkHttp3WebSocketAdapter;
 import com.marmitt.application.spring.adapter.binance.OkHttpClientAdapter;
 import com.marmitt.binance.BinanceConnectionConfig;
 import com.marmitt.binance.BinanceUserStreamAdapter;
+import com.marmitt.binance.BinanceUserStreamSessionAdapter;
 import com.marmitt.core.enums.StreamChannel;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
 import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
@@ -42,13 +43,18 @@ public class BinanceUserStreamConfiguration {
     }
 
     @Bean
-    public BinanceUserStreamAdapter binanceUserStreamAdapter(ObjectMapper objectMapper,
-                                                              OkHttpClient binanceRestClient,
-                                                              BinanceProperties properties) {
+    public BinanceUserStreamSessionAdapter binanceUserStreamSessionAdapter(OkHttpClient binanceRestClient,
+                                                                            ObjectMapper objectMapper,
+                                                                            BinanceProperties properties) {
         var httpClient = new OkHttpClientAdapter(binanceRestClient);
         var config = new BinanceConnectionConfig(
                 properties.getApiKey(), properties.getApiSecret(),
                 properties.getWsBaseUrl(), properties.getRestBaseUrl());
-        return new BinanceUserStreamAdapter(httpClient, objectMapper, config);
+        return new BinanceUserStreamSessionAdapter(httpClient, objectMapper, config);
+    }
+
+    @Bean
+    public BinanceUserStreamAdapter binanceUserStreamAdapter(ObjectMapper objectMapper) {
+        return new BinanceUserStreamAdapter(objectMapper);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceUserStreamConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceUserStreamConfiguration.java
@@ -8,6 +8,7 @@ import com.marmitt.binance.BinanceConnectionConfig;
 import com.marmitt.binance.BinanceUserStreamAdapter;
 import com.marmitt.core.enums.StreamChannel;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
 import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -31,17 +32,23 @@ public class BinanceUserStreamConfiguration {
     }
 
     @Bean
+    public OkHttp3WebSocketAdapter binanceUserStreamWebSocketPort(OkHttpClient binanceWebSocketClient,
+                                                                   EventPublisherPort eventPublisher,
+                                                                   WebSocketPortRegistryPort webSocketRegistry) {
+        OkHttp3WebSocketAdapter ws = new OkHttp3WebSocketAdapter(binanceWebSocketClient,
+                new OkHttp3ListenerConverter(eventPublisher, StreamChannel.USER_DATA));
+        webSocketRegistry.registerUserStream("BINANCE", ws);
+        return ws;
+    }
+
+    @Bean
     public BinanceUserStreamAdapter binanceUserStreamAdapter(ObjectMapper objectMapper,
-                                                              EventPublisherPort eventPublisher,
-                                                              OkHttpClient binanceWebSocketClient,
                                                               OkHttpClient binanceRestClient,
                                                               BinanceProperties properties) {
-        var ws = new OkHttp3WebSocketAdapter(binanceWebSocketClient,
-                new OkHttp3ListenerConverter(eventPublisher, StreamChannel.USER_DATA));
         var httpClient = new OkHttpClientAdapter(binanceRestClient);
         var config = new BinanceConnectionConfig(
                 properties.getApiKey(), properties.getApiSecret(),
                 properties.getWsBaseUrl(), properties.getRestBaseUrl());
-        return new BinanceUserStreamAdapter(ws, httpClient, objectMapper, config);
+        return new BinanceUserStreamAdapter(httpClient, objectMapper, config);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryExchangeAdapterRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryExchangeAdapterRepository.java
@@ -6,6 +6,7 @@ import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,7 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
 
     private final Map<String, ExchangeStreamingPort> streamingAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeUserStreamPort> userStreamAdapters = new ConcurrentHashMap<>();
+    private final Map<String, UserStreamSessionPort> userStreamSessionAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeOrderExecutionPort> orderExecutionAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeOrderQueryPort> orderQueryAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeAccountQueryPort> accountQueryAdapters = new ConcurrentHashMap<>();
@@ -32,9 +34,11 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
     private final Map<UUID, String> adapterByPortfolio = new ConcurrentHashMap<>();
 
     public InMemoryExchangeAdapterRepository(List<ExchangeStreamingPort> adapters,
-                                             List<ExchangeUserStreamPort> userStreamAdapters) {
+                                             List<ExchangeUserStreamPort> userStreamAdapters,
+                                             List<UserStreamSessionPort> userStreamSessions) {
         adapters.forEach(this::registerAllCapabilities);
         userStreamAdapters.forEach(this::registerUserStreamAdapter);
+        userStreamSessions.forEach(this::registerUserStreamSession);
     }
 
     @Override
@@ -47,6 +51,12 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
     public void registerUserStreamAdapter(ExchangeUserStreamPort adapter) {
         userStreamAdapters.put(normalize(adapter.getExchangeName()), adapter);
         log.info("User stream adapter registered - exchange={}", normalize(adapter.getExchangeName()));
+    }
+
+    @Override
+    public void registerUserStreamSession(UserStreamSessionPort session) {
+        userStreamSessionAdapters.put(normalize(session.getExchangeName()), session);
+        log.info("User stream session registered - exchange={}", normalize(session.getExchangeName()));
     }
 
     @Override
@@ -117,6 +127,11 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
     @Override
     public Optional<ExchangeUserStreamPort> findUserStreamByName(String exchangeName) {
         return Optional.ofNullable(userStreamAdapters.get(normalize(exchangeName)));
+    }
+
+    @Override
+    public Optional<UserStreamSessionPort> findUserStreamSessionByName(String exchangeName) {
+        return Optional.ofNullable(userStreamSessionAdapters.get(normalize(exchangeName)));
     }
 
     private void registerAllCapabilities(ExchangeStreamingPort streamingAdapter) {

--- a/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryWebSocketPortRegistry.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryWebSocketPortRegistry.java
@@ -11,15 +11,26 @@ import java.util.concurrent.ConcurrentHashMap;
 @Repository
 public class InMemoryWebSocketPortRegistry implements WebSocketPortRegistryPort {
 
-    private final Map<String, WebSocketPort> ports = new ConcurrentHashMap<>();
+    private final Map<String, WebSocketPort> marketPorts = new ConcurrentHashMap<>();
+    private final Map<String, WebSocketPort> userStreamPorts = new ConcurrentHashMap<>();
 
     @Override
     public void register(String exchangeName, WebSocketPort port) {
-        ports.put(exchangeName.toUpperCase(), port);
+        marketPorts.put(exchangeName.toUpperCase(), port);
     }
 
     @Override
     public Optional<WebSocketPort> findByExchangeName(String exchangeName) {
-        return Optional.ofNullable(ports.get(exchangeName.toUpperCase()));
+        return Optional.ofNullable(marketPorts.get(exchangeName.toUpperCase()));
+    }
+
+    @Override
+    public void registerUserStream(String exchangeName, WebSocketPort port) {
+        userStreamPorts.put(exchangeName.toUpperCase(), port);
+    }
+
+    @Override
+    public Optional<WebSocketPort> findUserStreamByExchangeName(String exchangeName) {
+        return Optional.ofNullable(userStreamPorts.get(exchangeName.toUpperCase()));
     }
 }

--- a/spring-application/src/test/java/com/marmitt/application/spring/userdata/UserDataStreamConciliationIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/userdata/UserDataStreamConciliationIntegrationTest.java
@@ -353,8 +353,8 @@ class UserDataStreamConciliationIntegrationTest {
             BinanceUserDataProcessor processor = new BinanceUserDataProcessor(objectMapper);
             return new ExchangeUserStreamPort() {
                 @Override public String getExchangeName() { return "MOCK"; }
-                @Override public void connect(UUID connectionId) {}
-                @Override public void disconnect(UUID connectionId) {}
+                @Override public String prepareConnection(UUID connectionId) { return "mock://localhost"; }
+                @Override public void onDisconnect(UUID connectionId) {}
                 @Override public com.marmitt.core.dto.processing.ProcessingResult<? extends com.marmitt.core.dto.websocket.data.ProcessorResponse> processMessage(String rawMessage, MessageContext context) {
                     return processor.processMessage(rawMessage, context);
                 }

--- a/spring-application/src/test/java/com/marmitt/application/spring/userdata/UserDataStreamConciliationIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/userdata/UserDataStreamConciliationIntegrationTest.java
@@ -18,6 +18,7 @@ import com.marmitt.core.ports.inbound.portfolio.CreatePortfolioPort;
 import com.marmitt.core.ports.inbound.runner.CreateRunnerPort;
 import com.marmitt.core.ports.outbound.exchange.adapter.ReceivedMessageProcessorPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
 import com.marmitt.core.ports.outbound.repository.GlobalBalanceRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
@@ -353,11 +354,18 @@ class UserDataStreamConciliationIntegrationTest {
             BinanceUserDataProcessor processor = new BinanceUserDataProcessor(objectMapper);
             return new ExchangeUserStreamPort() {
                 @Override public String getExchangeName() { return "MOCK"; }
-                @Override public String prepareConnection(UUID connectionId) { return "mock://localhost"; }
-                @Override public void onDisconnect(UUID connectionId) {}
                 @Override public com.marmitt.core.dto.processing.ProcessingResult<? extends com.marmitt.core.dto.websocket.data.ProcessorResponse> processMessage(String rawMessage, MessageContext context) {
                     return processor.processMessage(rawMessage, context);
                 }
+            };
+        }
+
+        @Bean
+        UserStreamSessionPort mockUserStreamSession() {
+            return new UserStreamSessionPort() {
+                @Override public String getExchangeName() { return "MOCK"; }
+                @Override public String openSession(UUID connectionId) { return "mock://localhost"; }
+                @Override public void closeSession(UUID connectionId) {}
             };
         }
     }


### PR DESCRIPTION
## Summary

- `ExchangeUserStreamPort` substitui `connect()`/`disconnect()` por `prepareConnection(UUID) → String url` e `onDisconnect(UUID)`
- `prepareConnection` encapsula os side effects Binance-específicos (obtenção do listen key, início do scheduler de keep-alive) e retorna a URL para o core conectar
- `onDisconnect` revoga o listen key e para o scheduler — o core desconecta o WebSocket separadamente
- `ConnectUserStreamUseCase` e `DisconnectWebSocketUseCase` orquestram o I/O WebSocket diretamente via `WebSocketPortRegistryPort.findUserStreamByExchangeName()`
- `WebSocketPortRegistryPort` ganha métodos explícitos para user stream; `InMemoryWebSocketPortRegistry` usa mapas separados para market e user stream
- `BinanceUserStreamAdapter` não tem mais `WebSocketPort` interno — é um tradutor de protocolo puro

## Test plan

- [x] Compilação limpa em todos os módulos
- [x] 86 testes passando (incluindo `UserDataStreamConciliationIntegrationTest` e `BinanceAdapterConfigurationIntegrationTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)