### PR TITLE
refactor(user-stream): extract UserStreamCredentialPort for session lifecycle

### DIFF
--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceCredentialAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceCredentialAdapter.java
@@ -1,0 +1,73 @@
+package com.marmitt.binance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.binance.auth.BinanceCredentials;
+import com.marmitt.binance.userdata.ListenKeyManager;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamCredentialPort;
+import com.marmitt.core.ports.outbound.http.HttpClientPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class BinanceCredentialAdapter implements UserStreamCredentialPort {
+
+    private static final long KEEPALIVE_INTERVAL_MINUTES = 30;
+
+    private final ListenKeyManager listenKeyManager;
+
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "binance-listenkey-keepalive");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private ScheduledFuture<?> keepAliveTask;
+
+    public BinanceCredentialAdapter(HttpClientPort httpClient,
+                                    ObjectMapper objectMapper,
+                                    BinanceConnectionConfig config) {
+        var credentials = new BinanceCredentials(config.apiKey(), config.apiSecret());
+        this.listenKeyManager = new ListenKeyManager(config.restBaseUrl(), credentials, httpClient, objectMapper);
+    }
+
+    @Override
+    public String getExchangeName() {
+        return "BINANCE";
+    }
+
+    @Override
+    public String obtain(UUID connectionId) throws IOException {
+        if (keepAliveTask != null && !keepAliveTask.isDone()) {
+            keepAliveTask.cancel(false);
+        }
+        if (listenKeyManager.getListenKey() != null) {
+            listenKeyManager.revoke();
+        }
+
+        String listenKey = listenKeyManager.obtainListenKey();
+
+        keepAliveTask = scheduler.scheduleAtFixedRate(
+                listenKeyManager::keepAlive,
+                KEEPALIVE_INTERVAL_MINUTES,
+                KEEPALIVE_INTERVAL_MINUTES,
+                TimeUnit.MINUTES);
+
+        log.info("Binance listen key obtained and keepalive scheduled - connectionId={}", connectionId);
+        return listenKey;
+    }
+
+    @Override
+    public void revoke(UUID connectionId) {
+        if (keepAliveTask != null) {
+            keepAliveTask.cancel(false);
+        }
+        listenKeyManager.revoke();
+        log.info("Binance listen key revoked - connectionId={}", connectionId);
+    }
+}

--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamSessionAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamSessionAdapter.java
@@ -1,41 +1,13 @@
 package com.marmitt.binance;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marmitt.binance.auth.BinanceCredentials;
-import com.marmitt.binance.userdata.ListenKeyManager;
 import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
-import com.marmitt.core.ports.outbound.http.HttpClientPort;
-import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-@Slf4j
 public class BinanceUserStreamSessionAdapter implements UserStreamSessionPort {
 
-    private static final long KEEPALIVE_INTERVAL_MINUTES = 30;
-
-    private final ListenKeyManager listenKeyManager;
     private final String wsBaseUrl;
 
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-        Thread t = new Thread(r, "binance-listenkey-keepalive");
-        t.setDaemon(true);
-        return t;
-    });
-
-    private ScheduledFuture<?> keepAliveTask;
-
-    public BinanceUserStreamSessionAdapter(HttpClientPort httpClient,
-                                           ObjectMapper objectMapper,
-                                           BinanceConnectionConfig config) {
-        var credentials = new BinanceCredentials(config.apiKey(), config.apiSecret());
-        this.listenKeyManager = new ListenKeyManager(config.restBaseUrl(), credentials, httpClient, objectMapper);
-        this.wsBaseUrl        = config.wsBaseUrl();
+    public BinanceUserStreamSessionAdapter(BinanceConnectionConfig config) {
+        this.wsBaseUrl = config.wsBaseUrl();
     }
 
     @Override
@@ -44,32 +16,7 @@ public class BinanceUserStreamSessionAdapter implements UserStreamSessionPort {
     }
 
     @Override
-    public String openSession(UUID connectionId) throws IOException {
-        if (keepAliveTask != null && !keepAliveTask.isDone()) {
-            keepAliveTask.cancel(false);
-        }
-        if (listenKeyManager.getListenKey() != null) {
-            listenKeyManager.revoke();
-        }
-
-        String listenKey = listenKeyManager.obtainListenKey();
-
-        keepAliveTask = scheduler.scheduleAtFixedRate(
-                listenKeyManager::keepAlive,
-                KEEPALIVE_INTERVAL_MINUTES,
-                KEEPALIVE_INTERVAL_MINUTES,
-                TimeUnit.MINUTES);
-
-        log.info("Binance user stream session opened - connectionId={}", connectionId);
-        return wsBaseUrl + "/ws/" + listenKey;
-    }
-
-    @Override
-    public void closeSession(UUID connectionId) {
-        if (keepAliveTask != null) {
-            keepAliveTask.cancel(false);
-        }
-        listenKeyManager.revoke();
-        log.info("Binance user stream session closed - connectionId={}", connectionId);
+    public String buildConnectionUrl(String credential) {
+        return wsBaseUrl + "/ws/" + credential;
     }
 }

--- a/core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java
@@ -7,6 +7,7 @@ import com.marmitt.core.dto.websocket.response.WebSocketConnectionResponse;
 import com.marmitt.core.dto.wrapper.WebSocketConnectionManager;
 import com.marmitt.core.enums.ConnectionStatus;
 import com.marmitt.core.ports.inbound.websocket.ConnectUserStreamPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamCredentialPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.WebSocketConnectionRepositoryPort;
@@ -17,7 +18,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.UUID;
 
 public class ConnectUserStreamUseCase implements ConnectUserStreamPort {
 
@@ -60,14 +60,20 @@ public class ConnectUserStreamUseCase implements ConnectUserStreamPort {
                 : ConnectionResultDto.connecting());
 
         UserStreamSessionPort session = adapterRepository.findUserStreamSessionByName(exchangeName).orElseThrow();
+        Optional<UserStreamCredentialPort> credentialOpt = adapterRepository.findUserStreamCredentialByName(exchangeName);
+
         try {
-            String url = session.openSession(manager.getConnectionId());
+            String credential = "";
+            if (credentialOpt.isPresent()) {
+                credential = credentialOpt.get().obtain(manager.getConnectionId());
+            }
+            String url = session.buildConnectionUrl(credential);
             WebSocketPort webSocket = webSocketRegistry.findUserStreamByExchangeName(exchangeName)
                     .orElseThrow(() -> new IllegalStateException("No user stream WebSocket registered for exchange: " + exchangeName));
             webSocket.connect(url, exchangeName, manager.getConnectionId());
         } catch (IOException | RuntimeException e) {
             log.error("Failed to connect user data stream - exchange={}", exchangeName, e);
-            session.closeSession(manager.getConnectionId());
+            credentialOpt.ifPresent(c -> c.revoke(manager.getConnectionId()));
             manager.setConnectionResult(ConnectionResultDto.failure("connect", "Failed: " + e.getMessage()));
         }
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/websocket/DisconnectWebSocketUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/websocket/DisconnectWebSocketUseCase.java
@@ -46,16 +46,17 @@ public class DisconnectWebSocketUseCase implements DisconnectWebSocketPort {
                 .orElseThrow(() -> new IllegalStateException("No WebSocket registered for exchange: " + exchangeName));
         webSocket.disconnect(exchangeName, connectionId);
 
-        adapterRepository.findUserStreamSessionByName(exchangeName).ifPresent(session -> {
+        if (adapterRepository.findUserStreamSessionByName(exchangeName).isPresent()) {
             WebSocketConnectionManager userManager = connectionRepository.getConnection(ConnectionKey.userStream(exchangeName));
             if (userManager != null) {
                 UUID userConnectionId = userManager.getConnectionId();
                 userManager.setConnectionResult(ConnectionResultDto.disconnecting("Manual disconnection requested", userConnectionId));
-                session.closeSession(userConnectionId);
+                adapterRepository.findUserStreamCredentialByName(exchangeName)
+                        .ifPresent(c -> c.revoke(userConnectionId));
                 webSocketRegistry.findUserStreamByExchangeName(exchangeName)
                         .ifPresent(ws -> ws.disconnect(exchangeName, userConnectionId));
             }
-        });
+        }
 
         return ConnectionResultMapper.toResponse(manager.getConnectionResult(), exchangeName);
     }

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/UserStreamCredentialPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/UserStreamCredentialPort.java
@@ -1,0 +1,13 @@
+package com.marmitt.core.ports.outbound.exchange.streaming;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public interface UserStreamCredentialPort {
+
+    String getExchangeName();
+
+    String obtain(UUID connectionId) throws IOException;
+
+    void revoke(UUID connectionId);
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/UserStreamSessionPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/streaming/UserStreamSessionPort.java
@@ -1,13 +1,8 @@
 package com.marmitt.core.ports.outbound.exchange.streaming;
 
-import java.io.IOException;
-import java.util.UUID;
-
 public interface UserStreamSessionPort {
 
     String getExchangeName();
 
-    String openSession(UUID connectionId) throws IOException;
-
-    void closeSession(UUID connectionId);
+    String buildConnectionUrl(String credential);
 }

--- a/core/src/main/java/com/marmitt/core/ports/outbound/repository/ExchangeAdapterRepositoryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/repository/ExchangeAdapterRepositoryPort.java
@@ -6,6 +6,7 @@ import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamCredentialPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
 
 import java.util.Optional;
@@ -19,6 +20,8 @@ public interface ExchangeAdapterRepositoryPort {
     void registerUserStreamAdapter(ExchangeUserStreamPort adapter);
 
     void registerUserStreamSession(UserStreamSessionPort session);
+
+    void registerUserStreamCredential(UserStreamCredentialPort credential);
 
     void registerOrderExecutionAdapter(String exchangeName, ExchangeOrderExecutionPort adapter);
 
@@ -49,4 +52,6 @@ public interface ExchangeAdapterRepositoryPort {
     Optional<ExchangeUserStreamPort> findUserStreamByName(String exchangeName);
 
     Optional<UserStreamSessionPort> findUserStreamSessionByName(String exchangeName);
+
+    Optional<UserStreamCredentialPort> findUserStreamCredentialByName(String exchangeName);
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceUserStreamConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceUserStreamConfiguration.java
@@ -5,6 +5,7 @@ import com.marmitt.application.spring.adapter.OkHttp3ListenerConverter;
 import com.marmitt.application.spring.adapter.OkHttp3WebSocketAdapter;
 import com.marmitt.application.spring.adapter.binance.OkHttpClientAdapter;
 import com.marmitt.binance.BinanceConnectionConfig;
+import com.marmitt.binance.BinanceCredentialAdapter;
 import com.marmitt.binance.BinanceUserStreamAdapter;
 import com.marmitt.binance.BinanceUserStreamSessionAdapter;
 import com.marmitt.core.enums.StreamChannel;
@@ -43,14 +44,22 @@ public class BinanceUserStreamConfiguration {
     }
 
     @Bean
-    public BinanceUserStreamSessionAdapter binanceUserStreamSessionAdapter(OkHttpClient binanceRestClient,
-                                                                            ObjectMapper objectMapper,
-                                                                            BinanceProperties properties) {
+    public BinanceUserStreamSessionAdapter binanceUserStreamSessionAdapter(BinanceProperties properties) {
+        var config = new BinanceConnectionConfig(
+                properties.getApiKey(), properties.getApiSecret(),
+                properties.getWsBaseUrl(), properties.getRestBaseUrl());
+        return new BinanceUserStreamSessionAdapter(config);
+    }
+
+    @Bean
+    public BinanceCredentialAdapter binanceCredentialAdapter(OkHttpClient binanceRestClient,
+                                                              ObjectMapper objectMapper,
+                                                              BinanceProperties properties) {
         var httpClient = new OkHttpClientAdapter(binanceRestClient);
         var config = new BinanceConnectionConfig(
                 properties.getApiKey(), properties.getApiSecret(),
                 properties.getWsBaseUrl(), properties.getRestBaseUrl());
-        return new BinanceUserStreamSessionAdapter(httpClient, objectMapper, config);
+        return new BinanceCredentialAdapter(httpClient, objectMapper, config);
     }
 
     @Bean

--- a/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryExchangeAdapterRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryExchangeAdapterRepository.java
@@ -6,6 +6,7 @@ import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamCredentialPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import org.slf4j.Logger;
@@ -27,6 +28,7 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
     private final Map<String, ExchangeStreamingPort> streamingAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeUserStreamPort> userStreamAdapters = new ConcurrentHashMap<>();
     private final Map<String, UserStreamSessionPort> userStreamSessionAdapters = new ConcurrentHashMap<>();
+    private final Map<String, UserStreamCredentialPort> userStreamCredentialAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeOrderExecutionPort> orderExecutionAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeOrderQueryPort> orderQueryAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeAccountQueryPort> accountQueryAdapters = new ConcurrentHashMap<>();
@@ -35,10 +37,12 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
 
     public InMemoryExchangeAdapterRepository(List<ExchangeStreamingPort> adapters,
                                              List<ExchangeUserStreamPort> userStreamAdapters,
-                                             List<UserStreamSessionPort> userStreamSessions) {
+                                             List<UserStreamSessionPort> userStreamSessions,
+                                             List<UserStreamCredentialPort> userStreamCredentials) {
         adapters.forEach(this::registerAllCapabilities);
         userStreamAdapters.forEach(this::registerUserStreamAdapter);
         userStreamSessions.forEach(this::registerUserStreamSession);
+        userStreamCredentials.forEach(this::registerUserStreamCredential);
     }
 
     @Override
@@ -57,6 +61,12 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
     public void registerUserStreamSession(UserStreamSessionPort session) {
         userStreamSessionAdapters.put(normalize(session.getExchangeName()), session);
         log.info("User stream session registered - exchange={}", normalize(session.getExchangeName()));
+    }
+
+    @Override
+    public void registerUserStreamCredential(UserStreamCredentialPort credential) {
+        userStreamCredentialAdapters.put(normalize(credential.getExchangeName()), credential);
+        log.info("User stream credential registered - exchange={}", normalize(credential.getExchangeName()));
     }
 
     @Override
@@ -132,6 +142,11 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
     @Override
     public Optional<UserStreamSessionPort> findUserStreamSessionByName(String exchangeName) {
         return Optional.ofNullable(userStreamSessionAdapters.get(normalize(exchangeName)));
+    }
+
+    @Override
+    public Optional<UserStreamCredentialPort> findUserStreamCredentialByName(String exchangeName) {
+        return Optional.ofNullable(userStreamCredentialAdapters.get(normalize(exchangeName)));
     }
 
     private void registerAllCapabilities(ExchangeStreamingPort streamingAdapter) {

--- a/spring-application/src/test/java/com/marmitt/application/spring/userdata/UserDataStreamConciliationIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/userdata/UserDataStreamConciliationIntegrationTest.java
@@ -364,8 +364,7 @@ class UserDataStreamConciliationIntegrationTest {
         UserStreamSessionPort mockUserStreamSession() {
             return new UserStreamSessionPort() {
                 @Override public String getExchangeName() { return "MOCK"; }
-                @Override public String openSession(UUID connectionId) { return "mock://localhost"; }
-                @Override public void closeSession(UUID connectionId) {}
+                @Override public String buildConnectionUrl(String credential) { return "mock://localhost"; }
             };
         }
     }


### PR DESCRIPTION
## Summary

- **`UserStreamSessionPort`** reduzido a descritor puro de URL: apenas `buildConnectionUrl(String credential)`. Sem I/O, sem scheduler, sem estado.
- **`UserStreamCredentialPort`** (novo port core): gerencia o ciclo de vida da credencial com `obtain(UUID)` e `revoke(UUID)`. Exchanges que não precisam de credencial simplesmente não registram esse port.
- **`BinanceUserStreamSessionAdapter`**: agora monta somente a URL WebSocket (`wsBaseUrl + "/ws/" + credential`).
- **`BinanceCredentialAdapter`** (novo): contém toda a lógica HTTP (listen key) e o scheduler de keepalive, isolados dentro do contrato `obtain`/`revoke`.
- **`ConnectUserStreamUseCase`**: obtém credencial (opcional) → constrói URL → conecta. Em caso de falha, chama `revoke` para limpar recursos.
- **`DisconnectWebSocketUseCase`**: chama `credential.revoke()` em vez de `session.closeSession()`.

## Motivação

O `BinanceUserStreamSessionAdapter` anterior fazia HTTP e gerenciava um `ScheduledExecutorService` internamente, violando o princípio de que adapters devem ser DTOs/mappers/descritores. A separação em dois ports permite que qualquer exchange implemente `UserStreamCredentialPort` da forma que precisar (HTTP, token local, noop) sem impactar o descritor de URL.

## Test plan

- [ ] `./gradlew :spring-application:test` — todos os 86 testes passando
- [ ] Exchanges sem `UserStreamCredentialPort` registrado recebem `credential = ""` e continuam funcionando
- [ ] Falha em `obtain()` revoga a credencial e move o estado para `ERROR`