### PR TITLE
feat(filters): T6 — Exchange Symbol Filters

### DIFF
--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceMarketStreamAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceMarketStreamAdapter.java
@@ -8,6 +8,7 @@ import com.marmitt.binance.filters.OrderFilterValidator;
 import com.marmitt.binance.filters.SymbolFilterCache;
 import com.marmitt.binance.processor.receive.BinanceReceivedMessageProcessor;
 import com.marmitt.binance.processor.send.BinanceSenderMessageProcessor;
+import com.marmitt.binance.rest.BinanceAccountMapper;
 import com.marmitt.binance.rest.BinanceOrderMapper;
 import com.marmitt.binance.rest.BinanceRestRequestBuilder;
 import com.marmitt.binance.rest.RestRequest;
@@ -50,6 +51,7 @@ public class BinanceMarketStreamAdapter implements
     private final BinanceBootReadinessChecker bootReadinessChecker;
     private final BinanceRestRequestBuilder requestBuilder;
     private final BinanceOrderMapper orderMapper;
+    private final BinanceAccountMapper accountMapper;
     private final HttpClientPort httpClient;
     private final OrderFilterValidator filterValidator;
 
@@ -57,10 +59,10 @@ public class BinanceMarketStreamAdapter implements
                                       BinanceConnectionConfig config,
                                       HttpClientPort httpClient,
                                       SymbolFilterCache filterCache) {
-        var apiConfig         = new BinanceApiConfig(config.wsBaseUrl(), config.restBaseUrl());
-        var credentials       = new BinanceCredentials(config.apiKey(), config.apiSecret());
-        var signer            = new BinanceRequestSigner(credentials);
-        var binanceUrlBuilder = new BinanceUrlBuilder(apiConfig);
+        var apiConfig          = new BinanceApiConfig(config.wsBaseUrl(), config.restBaseUrl());
+        var credentials        = new BinanceCredentials(config.apiKey(), config.apiSecret());
+        var signer             = new BinanceRequestSigner(credentials);
+        var binanceUrlBuilder  = new BinanceUrlBuilder(apiConfig);
         var restRequestBuilder = new BinanceRestRequestBuilder(config.restBaseUrl(), signer);
         this.urlBuilder               = binanceUrlBuilder;
         this.senderMessageProcessor   = new BinanceSenderMessageProcessor(objectMapper, signer, binanceUrlBuilder);
@@ -68,6 +70,7 @@ public class BinanceMarketStreamAdapter implements
         this.requestBuilder           = restRequestBuilder;
         this.httpClient               = httpClient;
         this.orderMapper              = new BinanceOrderMapper(objectMapper);
+        this.accountMapper            = new BinanceAccountMapper(objectMapper);
         this.filterValidator          = new OrderFilterValidator(filterCache);
         this.bootReadinessChecker     = new BinanceBootReadinessChecker(
                 config.restBaseUrl(), restRequestBuilder, httpClient, objectMapper);
@@ -90,6 +93,10 @@ public class BinanceMarketStreamAdapter implements
 
     @Override
     public String formatMessage(MessageRequest request) {
+        // P2 fix: apply symbol filters for WebSocket order placement before formatting
+        if (request instanceof SendOrderRequest orderRequest) {
+            request = filterValidator.validate(orderRequest);
+        }
         return senderMessageProcessor.execute(request);
     }
 
@@ -97,6 +104,8 @@ public class BinanceMarketStreamAdapter implements
     public ProcessingResult<? extends ProcessorResponse> processMessage(String rawMessage, MessageContext context) {
         return receivedMessageProcessor.processMessage(rawMessage, context);
     }
+
+    // --- ExchangeOrderExecutionPort ---
 
     @Override
     public OrderDataDto submitOrder(SendOrderRequest request) {
@@ -107,14 +116,7 @@ public class BinanceMarketStreamAdapter implements
             if (response.isSuccessful()) {
                 return orderMapper.fromJson(response.body());
             }
-            ExchangeQueryException.ErrorType errorType = switch (response.statusCode()) {
-                case 400 -> ExchangeQueryException.ErrorType.INVALID_REQUEST;
-                case 401, 403 -> ExchangeQueryException.ErrorType.AUTH;
-                case 429 -> ExchangeQueryException.ErrorType.RATE_LIMIT;
-                default -> ExchangeQueryException.ErrorType.TEMPORARY;
-            };
-            throw new ExchangeQueryException("BINANCE", errorType,
-                    "Order submission failed HTTP " + response.statusCode() + ": " + response.body());
+            throw queryException(response, "Order submission");
         } catch (IOException e) {
             throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.TEMPORARY,
                     "Order submission failed: " + e.getMessage(), e);
@@ -129,44 +131,57 @@ public class BinanceMarketStreamAdapter implements
             if (response.isSuccessful()) {
                 return orderMapper.fromJson(response.body());
             }
-            ExchangeQueryException.ErrorType errorType = switch (response.statusCode()) {
-                case 400 -> ExchangeQueryException.ErrorType.INVALID_REQUEST;
-                case 401, 403 -> ExchangeQueryException.ErrorType.AUTH;
-                case 429 -> ExchangeQueryException.ErrorType.RATE_LIMIT;
-                default -> ExchangeQueryException.ErrorType.TEMPORARY;
-            };
-            throw new ExchangeQueryException("BINANCE", errorType,
-                    "Order cancellation failed HTTP " + response.statusCode() + ": " + response.body());
+            throw queryException(response, "Order cancellation");
         } catch (IOException e) {
             throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.TEMPORARY,
                     "Order cancellation failed: " + e.getMessage(), e);
         }
     }
 
+    // --- ExchangeOrderQueryPort ---
+
     @Override
     public Optional<OrderDataDto> queryOrderByClientOrderId(String symbol, String clientOrderId) {
-        throw restNotImplemented();
+        RestRequest req = requestBuilder.buildQueryOrderByClientOrderId(symbol, clientOrderId);
+        return querySingleOrder(req);
     }
 
     @Override
     public Optional<OrderDataDto> queryOrderByExchangeOrderId(String symbol, String exchangeOrderId) {
-        throw restNotImplemented();
+        RestRequest req = requestBuilder.buildQueryOrderByExchangeOrderId(symbol, exchangeOrderId);
+        return querySingleOrder(req);
     }
 
     @Override
     public List<OrderDataDto> listOpenOrdersBySymbol(String symbol) {
-        throw restNotImplemented();
+        RestRequest req = requestBuilder.buildListOpenOrdersBySymbol(symbol);
+        return queryOrderList(req);
     }
 
     @Override
     public List<OrderDataDto> listAllOpenOrders() {
-        throw restNotImplemented();
+        RestRequest req = requestBuilder.buildListAllOpenOrders();
+        return queryOrderList(req);
     }
+
+    // --- ExchangeAccountQueryPort ---
 
     @Override
     public AccountDataDto queryAccountSnapshot() {
-        throw restNotImplemented();
+        RestRequest req = requestBuilder.buildAccountSnapshot();
+        try {
+            HttpClientPort.HttpResponse response = httpClient.get(req.url(), req.headers());
+            if (response.isSuccessful()) {
+                return accountMapper.fromJson(response.body());
+            }
+            throw queryException(response, "Account snapshot");
+        } catch (IOException e) {
+            throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.TEMPORARY,
+                    "Account snapshot failed: " + e.getMessage(), e);
+        }
     }
+
+    // --- ExchangeBootReadinessPort ---
 
     @Override
     public ExchangeBootReadiness checkBootReadiness() {
@@ -186,9 +201,45 @@ public class BinanceMarketStreamAdapter implements
         }
     }
 
-    private UnsupportedOperationException restNotImplemented() {
-        return new UnsupportedOperationException(
-                "BINANCE REST not yet wired — pending use case implementation."
-        );
+    // --- helpers ---
+
+    private Optional<OrderDataDto> querySingleOrder(RestRequest req) {
+        try {
+            HttpClientPort.HttpResponse response = httpClient.get(req.url(), req.headers());
+            if (response.isSuccessful()) {
+                return Optional.of(orderMapper.fromJson(response.body()));
+            }
+            if (response.statusCode() == 400) {
+                return Optional.empty();
+            }
+            throw queryException(response, "Order query");
+        } catch (IOException e) {
+            throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.TEMPORARY,
+                    "Order query failed: " + e.getMessage(), e);
+        }
+    }
+
+    private List<OrderDataDto> queryOrderList(RestRequest req) {
+        try {
+            HttpClientPort.HttpResponse response = httpClient.get(req.url(), req.headers());
+            if (response.isSuccessful()) {
+                return orderMapper.listFromJson(response.body());
+            }
+            throw queryException(response, "Open orders query");
+        } catch (IOException e) {
+            throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.TEMPORARY,
+                    "Open orders query failed: " + e.getMessage(), e);
+        }
+    }
+
+    private ExchangeQueryException queryException(HttpClientPort.HttpResponse response, String operation) {
+        ExchangeQueryException.ErrorType errorType = switch (response.statusCode()) {
+            case 400 -> ExchangeQueryException.ErrorType.INVALID_REQUEST;
+            case 401, 403 -> ExchangeQueryException.ErrorType.AUTH;
+            case 429 -> ExchangeQueryException.ErrorType.RATE_LIMIT;
+            default -> ExchangeQueryException.ErrorType.TEMPORARY;
+        };
+        return new ExchangeQueryException("BINANCE", errorType,
+                operation + " failed HTTP " + response.statusCode() + ": " + response.body());
     }
 }

--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceMarketStreamAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceMarketStreamAdapter.java
@@ -45,6 +45,8 @@ public class BinanceMarketStreamAdapter implements
         ExchangeAccountQueryPort,
         ExchangeBootReadinessPort {
 
+    private static final int BINANCE_ORDER_NOT_FOUND = -2013;
+
     private final BinanceReceivedMessageProcessor receivedMessageProcessor;
     private final BinanceSenderMessageProcessor senderMessageProcessor;
     private final BinanceUrlBuilder urlBuilder;
@@ -54,6 +56,7 @@ public class BinanceMarketStreamAdapter implements
     private final BinanceAccountMapper accountMapper;
     private final HttpClientPort httpClient;
     private final OrderFilterValidator filterValidator;
+    private final ObjectMapper objectMapper;
 
     public BinanceMarketStreamAdapter(ObjectMapper objectMapper,
                                       BinanceConnectionConfig config,
@@ -72,6 +75,7 @@ public class BinanceMarketStreamAdapter implements
         this.orderMapper              = new BinanceOrderMapper(objectMapper);
         this.accountMapper            = new BinanceAccountMapper(objectMapper);
         this.filterValidator          = new OrderFilterValidator(filterCache);
+        this.objectMapper             = objectMapper;
         this.bootReadinessChecker     = new BinanceBootReadinessChecker(
                 config.restBaseUrl(), restRequestBuilder, httpClient, objectMapper);
     }
@@ -209,13 +213,21 @@ public class BinanceMarketStreamAdapter implements
             if (response.isSuccessful()) {
                 return Optional.of(orderMapper.fromJson(response.body()));
             }
-            if (response.statusCode() == 400) {
+            if (response.statusCode() == 400 && isBinanceOrderNotFound(response.body())) {
                 return Optional.empty();
             }
             throw queryException(response, "Order query");
         } catch (IOException e) {
             throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.TEMPORARY,
                     "Order query failed: " + e.getMessage(), e);
+        }
+    }
+
+    private boolean isBinanceOrderNotFound(String body) {
+        try {
+            return objectMapper.readTree(body).path("code").asInt(0) == BINANCE_ORDER_NOT_FOUND;
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceMarketStreamAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceMarketStreamAdapter.java
@@ -4,11 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marmitt.binance.auth.BinanceCredentials;
 import com.marmitt.binance.auth.BinanceRequestSigner;
 import com.marmitt.binance.boot.BinanceBootReadinessChecker;
+import com.marmitt.binance.filters.OrderFilterValidator;
+import com.marmitt.binance.filters.SymbolFilterCache;
 import com.marmitt.binance.processor.receive.BinanceReceivedMessageProcessor;
 import com.marmitt.binance.processor.send.BinanceSenderMessageProcessor;
+import com.marmitt.binance.rest.BinanceOrderMapper;
 import com.marmitt.binance.rest.BinanceRestRequestBuilder;
+import com.marmitt.binance.rest.RestRequest;
 import com.marmitt.core.dto.exchange.boot.ExchangeBootReadiness;
-import com.marmitt.core.ports.outbound.http.HttpClientPort;
 import com.marmitt.core.dto.processing.ProcessingResult;
 import com.marmitt.core.dto.websocket.MessageContext;
 import com.marmitt.core.dto.websocket.data.AccountDataDto;
@@ -18,12 +21,15 @@ import com.marmitt.core.dto.websocket.request.MessageRequest;
 import com.marmitt.core.dto.websocket.request.SendCancelOrderRequest;
 import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.core.dto.websocket.request.StreamSubscriptionRequest;
+import com.marmitt.core.exceptions.ExchangeQueryException;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeAccountQueryPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeBootReadinessPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
+import com.marmitt.core.ports.outbound.http.HttpClientPort;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -42,22 +48,29 @@ public class BinanceMarketStreamAdapter implements
     private final BinanceSenderMessageProcessor senderMessageProcessor;
     private final BinanceUrlBuilder urlBuilder;
     private final BinanceBootReadinessChecker bootReadinessChecker;
+    private final BinanceRestRequestBuilder requestBuilder;
+    private final BinanceOrderMapper orderMapper;
+    private final HttpClientPort httpClient;
+    private final OrderFilterValidator filterValidator;
 
     public BinanceMarketStreamAdapter(ObjectMapper objectMapper,
                                       BinanceConnectionConfig config,
-                                      HttpClientPort httpClient) {
+                                      HttpClientPort httpClient,
+                                      SymbolFilterCache filterCache) {
         var apiConfig         = new BinanceApiConfig(config.wsBaseUrl(), config.restBaseUrl());
         var credentials       = new BinanceCredentials(config.apiKey(), config.apiSecret());
         var signer            = new BinanceRequestSigner(credentials);
         var binanceUrlBuilder = new BinanceUrlBuilder(apiConfig);
+        var restRequestBuilder = new BinanceRestRequestBuilder(config.restBaseUrl(), signer);
         this.urlBuilder               = binanceUrlBuilder;
         this.senderMessageProcessor   = new BinanceSenderMessageProcessor(objectMapper, signer, binanceUrlBuilder);
         this.receivedMessageProcessor = new BinanceReceivedMessageProcessor(objectMapper);
+        this.requestBuilder           = restRequestBuilder;
+        this.httpClient               = httpClient;
+        this.orderMapper              = new BinanceOrderMapper(objectMapper);
+        this.filterValidator          = new OrderFilterValidator(filterCache);
         this.bootReadinessChecker     = new BinanceBootReadinessChecker(
-                config.restBaseUrl(),
-                new BinanceRestRequestBuilder(config.restBaseUrl(), signer),
-                httpClient,
-                objectMapper);
+                config.restBaseUrl(), restRequestBuilder, httpClient, objectMapper);
     }
 
     @Override
@@ -87,12 +100,47 @@ public class BinanceMarketStreamAdapter implements
 
     @Override
     public OrderDataDto submitOrder(SendOrderRequest request) {
-        throw restNotImplemented();
+        SendOrderRequest validated = filterValidator.validate(request);
+        RestRequest req = requestBuilder.buildSubmitOrder(validated);
+        try {
+            HttpClientPort.HttpResponse response = httpClient.postForm(req.url(), req.headers(), req.body());
+            if (response.isSuccessful()) {
+                return orderMapper.fromJson(response.body());
+            }
+            ExchangeQueryException.ErrorType errorType = switch (response.statusCode()) {
+                case 400 -> ExchangeQueryException.ErrorType.INVALID_REQUEST;
+                case 401, 403 -> ExchangeQueryException.ErrorType.AUTH;
+                case 429 -> ExchangeQueryException.ErrorType.RATE_LIMIT;
+                default -> ExchangeQueryException.ErrorType.TEMPORARY;
+            };
+            throw new ExchangeQueryException("BINANCE", errorType,
+                    "Order submission failed HTTP " + response.statusCode() + ": " + response.body());
+        } catch (IOException e) {
+            throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.TEMPORARY,
+                    "Order submission failed: " + e.getMessage(), e);
+        }
     }
 
     @Override
     public OrderDataDto cancelOrder(SendCancelOrderRequest request) {
-        throw restNotImplemented();
+        RestRequest req = requestBuilder.buildCancelOrder(request);
+        try {
+            HttpClientPort.HttpResponse response = httpClient.delete(req.url(), req.headers());
+            if (response.isSuccessful()) {
+                return orderMapper.fromJson(response.body());
+            }
+            ExchangeQueryException.ErrorType errorType = switch (response.statusCode()) {
+                case 400 -> ExchangeQueryException.ErrorType.INVALID_REQUEST;
+                case 401, 403 -> ExchangeQueryException.ErrorType.AUTH;
+                case 429 -> ExchangeQueryException.ErrorType.RATE_LIMIT;
+                default -> ExchangeQueryException.ErrorType.TEMPORARY;
+            };
+            throw new ExchangeQueryException("BINANCE", errorType,
+                    "Order cancellation failed HTTP " + response.statusCode() + ": " + response.body());
+        } catch (IOException e) {
+            throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.TEMPORARY,
+                    "Order cancellation failed: " + e.getMessage(), e);
+        }
     }
 
     @Override

--- a/adapter-binance/src/main/java/com/marmitt/binance/filters/OrderFilterValidator.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/filters/OrderFilterValidator.java
@@ -1,0 +1,79 @@
+package com.marmitt.binance.filters;
+
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Slf4j
+public class OrderFilterValidator {
+
+    private final SymbolFilterCache filterCache;
+
+    public OrderFilterValidator(SymbolFilterCache filterCache) {
+        this.filterCache = filterCache;
+    }
+
+    public SendOrderRequest validate(SendOrderRequest request) {
+        String symbol = request.getSymbol();
+        SymbolFilters filters = filterCache.getFilters(symbol);
+
+        BigDecimal quantity = applyLotSize(symbol, request.getQuantity(), filters);
+        BigDecimal price = applyPriceFilter(request.getPrice(), filters);
+        validateNotional(symbol, quantity, price, filters);
+
+        if (quantity.compareTo(request.getQuantity()) != 0) {
+            log.info("Quantity adjusted for {}: {} -> {} (stepSize={})",
+                    symbol, request.getQuantity(), quantity, filters.stepSize());
+        }
+
+        return new SendOrderRequest(
+                request.getExchangeName(),
+                symbol,
+                quantity,
+                price,
+                request.getOrderType(),
+                request.getOrderSide(),
+                request.getClientOrderId()
+        );
+    }
+
+    private BigDecimal applyLotSize(String symbol, BigDecimal quantity, SymbolFilters filters) {
+        BigDecimal stepSize = filters.stepSize();
+        if (stepSize.compareTo(BigDecimal.ZERO) == 0) return quantity;
+
+        BigDecimal adjusted = quantity.divide(stepSize, 0, RoundingMode.FLOOR).multiply(stepSize).stripTrailingZeros();
+
+        if (adjusted.compareTo(filters.minQty()) < 0) {
+            throw new OrderFilterViolationException(
+                    "Quantity " + quantity + " rounds down to " + adjusted.toPlainString() +
+                    ", below minQty " + filters.minQty().toPlainString() + " for " + symbol);
+        }
+        if (filters.maxQty().compareTo(BigDecimal.ZERO) > 0 && adjusted.compareTo(filters.maxQty()) > 0) {
+            throw new OrderFilterViolationException(
+                    "Quantity " + adjusted.toPlainString() +
+                    " exceeds maxQty " + filters.maxQty().toPlainString() + " for " + symbol);
+        }
+
+        return adjusted;
+    }
+
+    private BigDecimal applyPriceFilter(BigDecimal price, SymbolFilters filters) {
+        if (price == null || price.compareTo(BigDecimal.ZERO) == 0) return price;
+        BigDecimal tickSize = filters.tickSize();
+        if (tickSize.compareTo(BigDecimal.ZERO) == 0) return price;
+        return price.divide(tickSize, 0, RoundingMode.HALF_UP).multiply(tickSize).stripTrailingZeros();
+    }
+
+    private void validateNotional(String symbol, BigDecimal quantity, BigDecimal price, SymbolFilters filters) {
+        if (price == null || price.compareTo(BigDecimal.ZERO) == 0) return;
+        BigDecimal notional = price.multiply(quantity);
+        if (notional.compareTo(filters.minNotional()) < 0) {
+            throw new OrderFilterViolationException(
+                    "Notional " + notional.toPlainString() +
+                    " (price=" + price.toPlainString() + ", qty=" + quantity.toPlainString() +
+                    ") is below minNotional " + filters.minNotional().toPlainString() + " for " + symbol);
+        }
+    }
+}

--- a/adapter-binance/src/main/java/com/marmitt/binance/filters/OrderFilterViolationException.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/filters/OrderFilterViolationException.java
@@ -1,0 +1,8 @@
+package com.marmitt.binance.filters;
+
+public class OrderFilterViolationException extends RuntimeException {
+
+    public OrderFilterViolationException(String message) {
+        super(message);
+    }
+}

--- a/adapter-binance/src/main/java/com/marmitt/binance/filters/SymbolFilterCache.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/filters/SymbolFilterCache.java
@@ -1,0 +1,109 @@
+package com.marmitt.binance.filters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.ports.outbound.http.HttpClientPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public class SymbolFilterCache {
+
+    private static final String EXCHANGE_INFO_PATH = "/api/v3/exchangeInfo";
+
+    private final String restBaseUrl;
+    private final HttpClientPort httpClient;
+    private final ObjectMapper objectMapper;
+    private final ConcurrentHashMap<String, SymbolFilters> cache = new ConcurrentHashMap<>();
+
+    public SymbolFilterCache(String restBaseUrl, HttpClientPort httpClient, ObjectMapper objectMapper) {
+        this.restBaseUrl = restBaseUrl;
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public SymbolFilters getFilters(String symbol) {
+        return cache.computeIfAbsent(symbol, this::loadFilters);
+    }
+
+    public void loadAndCache(String symbol) {
+        cache.put(symbol, loadFilters(symbol));
+    }
+
+    public void invalidateAll() {
+        cache.clear();
+        log.info("Symbol filter cache invalidated");
+    }
+
+    private SymbolFilters loadFilters(String symbol) {
+        try {
+            String url = restBaseUrl + EXCHANGE_INFO_PATH + "?symbol=" + symbol;
+            HttpClientPort.HttpResponse response = httpClient.get(url, Map.of());
+            if (!response.isSuccessful()) {
+                throw new SymbolFilterLoadException(symbol,
+                        "exchangeInfo returned HTTP " + response.statusCode());
+            }
+            return parseFilters(symbol, response.body());
+        } catch (IOException e) {
+            throw new SymbolFilterLoadException(symbol, "HTTP call failed: " + e.getMessage(), e);
+        }
+    }
+
+    private SymbolFilters parseFilters(String symbol, String json) {
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            for (JsonNode symbolNode : root.path("symbols")) {
+                if (symbol.equals(symbolNode.path("symbol").asText())) {
+                    return parseSymbolFilters(symbol, symbolNode.path("filters"));
+                }
+            }
+            throw new SymbolFilterLoadException(symbol, "symbol not found in exchangeInfo response");
+        } catch (SymbolFilterLoadException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SymbolFilterLoadException(symbol, "failed to parse exchangeInfo: " + e.getMessage(), e);
+        }
+    }
+
+    private SymbolFilters parseSymbolFilters(String symbol, JsonNode filters) {
+        BigDecimal stepSize = null, minQty = null, maxQty = null;
+        BigDecimal tickSize = null;
+        BigDecimal minNotional = null;
+
+        for (JsonNode filter : filters) {
+            switch (filter.path("filterType").asText()) {
+                case "LOT_SIZE" -> {
+                    stepSize = decimal(filter, "stepSize");
+                    minQty = decimal(filter, "minQty");
+                    maxQty = decimal(filter, "maxQty");
+                }
+                case "PRICE_FILTER" -> tickSize = decimal(filter, "tickSize");
+                case "MIN_NOTIONAL", "NOTIONAL" -> {
+                    if (minNotional == null) minNotional = decimal(filter, "minNotional");
+                }
+            }
+        }
+
+        if (stepSize == null || minQty == null || maxQty == null) {
+            throw new SymbolFilterLoadException(symbol, "LOT_SIZE filter missing from exchangeInfo");
+        }
+        if (tickSize == null) {
+            throw new SymbolFilterLoadException(symbol, "PRICE_FILTER filter missing from exchangeInfo");
+        }
+        if (minNotional == null) {
+            throw new SymbolFilterLoadException(symbol, "MIN_NOTIONAL/NOTIONAL filter missing from exchangeInfo");
+        }
+
+        log.info("Loaded filters for {}: stepSize={}, minQty={}, maxQty={}, tickSize={}, minNotional={}",
+                symbol, stepSize, minQty, maxQty, tickSize, minNotional);
+        return new SymbolFilters(stepSize, minQty, maxQty, tickSize, minNotional);
+    }
+
+    private BigDecimal decimal(JsonNode node, String field) {
+        return new BigDecimal(node.path(field).asText("0"));
+    }
+}

--- a/adapter-binance/src/main/java/com/marmitt/binance/filters/SymbolFilterLoadException.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/filters/SymbolFilterLoadException.java
@@ -1,0 +1,12 @@
+package com.marmitt.binance.filters;
+
+public class SymbolFilterLoadException extends RuntimeException {
+
+    public SymbolFilterLoadException(String symbol, String reason) {
+        super("Failed to load symbol filters for " + symbol + ": " + reason);
+    }
+
+    public SymbolFilterLoadException(String symbol, String reason, Throwable cause) {
+        super("Failed to load symbol filters for " + symbol + ": " + reason, cause);
+    }
+}

--- a/adapter-binance/src/main/java/com/marmitt/binance/filters/SymbolFilters.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/filters/SymbolFilters.java
@@ -1,0 +1,11 @@
+package com.marmitt.binance.filters;
+
+import java.math.BigDecimal;
+
+record SymbolFilters(
+        BigDecimal stepSize,
+        BigDecimal minQty,
+        BigDecimal maxQty,
+        BigDecimal tickSize,
+        BigDecimal minNotional
+) {}

--- a/adapter-binance/src/main/java/com/marmitt/binance/rest/BinanceAccountMapper.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/rest/BinanceAccountMapper.java
@@ -10,15 +10,15 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-class BinanceAccountMapper {
+public class BinanceAccountMapper {
 
     private final ObjectMapper objectMapper;
 
-    BinanceAccountMapper(ObjectMapper objectMapper) {
+    public BinanceAccountMapper(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    AccountDataDto fromJson(String json) {
+    public AccountDataDto fromJson(String json) {
         try {
             JsonNode root = objectMapper.readTree(json);
             Map<String, BigDecimal> balances = new LinkedHashMap<>();

--- a/adapter-binance/src/main/java/com/marmitt/binance/rest/BinanceOrderMapper.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/rest/BinanceOrderMapper.java
@@ -12,11 +12,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-class BinanceOrderMapper {
+public class BinanceOrderMapper {
 
     private final ObjectMapper objectMapper;
 
-    BinanceOrderMapper(ObjectMapper objectMapper) {
+    public BinanceOrderMapper(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
@@ -54,7 +54,7 @@ class BinanceOrderMapper {
         );
     }
 
-    OrderDataDto fromJson(String json) {
+    public OrderDataDto fromJson(String json) {
         try {
             return fromNode(objectMapper.readTree(json));
         } catch (Exception e) {

--- a/adapter-binance/src/main/java/com/marmitt/binance/rest/BinanceOrderMapper.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/rest/BinanceOrderMapper.java
@@ -63,7 +63,7 @@ public class BinanceOrderMapper {
         }
     }
 
-    List<OrderDataDto> listFromJson(String json) {
+    public List<OrderDataDto> listFromJson(String json) {
         try {
             JsonNode root = objectMapper.readTree(json);
             List<OrderDataDto> result = new ArrayList<>();

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -16,6 +16,7 @@ Trilha de tarefas para habilitar operação com a API da Binance (testnet), pré
 | T8  | Kill Switch                     | Média        | Codex       | Pendente      |
 | T9  | Observabilidade Docker Compose  | Média        | Codex       | Pendente      |
 | T10 | Otimização da suíte de integração | Média      | Codex       | Pendente      |
+| T11 | Order Quantity Normalization Before Persist | Média | Codex  | Pendente      |
 
 ## Ordem de execução
 
@@ -35,6 +36,18 @@ T7  Boot Readiness real
 T8  Kill Switch     T9  Observabilidade
        ↓
    staging começa
+```
+
+## Ordem de execução
+
+```
+T8  Kill Switch     T9  Observabilidade
+       ↓
+T10  Otimização da suíte de integração
+       ↓
+T11  Order Quantity Normalization      ← pré-requisito para produção
+       ↓
+   produção
 ```
 
 ## Critério de pronto da trilha

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -11,8 +11,8 @@ Trilha de tarefas para habilitar operação com a API da Binance (testnet), pré
 | T3  | HMAC-SHA256 Signing             | Alta         | Claude      | Concluído     |
 | T4  | User Data Stream                | Alta         | Claude      | Concluído     |
 | T5  | REST API Binance                | Alta         | Claude      | Concluído     |
-| T6  | Exchange Symbol Filters         | Média        | Codex       | Pendente      |
-| T7  | Boot Readiness real             | Média        | Codex       | Pendente      |
+| T6  | Exchange Symbol Filters         | Média        | Codex       | Concluído     |
+| T7  | Boot Readiness real             | Média        | Codex       | Concluído     |
 | T8  | Kill Switch                     | Média        | Codex       | Pendente      |
 | T9  | Observabilidade Docker Compose  | Média        | Codex       | Pendente      |
 | T10 | Otimização da suíte de integração | Média      | Codex       | Pendente      |

--- a/docs/tasks/T11-order-quantity-normalization.md
+++ b/docs/tasks/T11-order-quantity-normalization.md
@@ -1,0 +1,57 @@
+# T11 — Order Quantity Normalization Before Persist
+
+**Complexidade:** Média  
+**Responsável:** Codex  
+**Dependências:** T6  
+**Status:** Pendente
+
+---
+
+## Descrição
+
+Quando `OrderFilterValidator` aplica floor em uma quantidade não alinhada ao `stepSize` (ex: `0.001234` → `0.00123`), a `Transaction` já foi persistida e o capital já foi reservado com a quantidade original. O fill da Binance confirma `0.00123`, mas a reserva foi feita para `0.001234`.
+
+Resultado: over-reservation da diferença (`qty % stepSize`) até a próxima reconciliação de saldo — o portfolio pensa que tem menos capital do que de fato tem. O erro é conservador (não causa perda real) mas afeta a precisão da contabilidade de capital e deve ser corrigido antes de produção.
+
+**Raiz do problema:** a normalização de quantidade ocorre em `OrderDispatchAdapter`, depois que `BuySignalHandler.persistenceAction.persist()` e a reserva de capital já aconteceram. O core não conhece regras de filter da exchange.
+
+---
+
+## Escopo técnico
+
+### Port novo no core
+
+```java
+// core/.../ports/outbound/exchange/rest/OrderQuantityNormalizerPort.java
+public interface OrderQuantityNormalizerPort {
+    String getExchangeName();
+    BigDecimal normalizeQuantity(String symbol, BigDecimal quantity);
+    BigDecimal normalizePrice(String symbol, BigDecimal price);
+}
+```
+
+### Implementação no adapter-binance
+
+`BinanceOrderNormalizer` implementa o port usando `SymbolFilterCache` — mesma lógica de floor/round de `OrderFilterValidator`, mas exposta como port outbound.
+
+### Injeção no use case de signal
+
+`ProcessTradeSignalUseCase` recebe uma lista de `OrderQuantityNormalizerPort` (um por exchange) e normaliza quantidade e preço **antes** de criar o `BuyExecutionContext` / `SellExecutionContext`. A quantidade que entra no persist, na reserva de capital e no dispatch é sempre a quantidade já normalizada.
+
+### Remoção da normalização do dispatch
+
+Após a normalização ser movida para antes do persist, `OrderFilterValidator.validate()` mantém apenas as checagens de rejeição (`minQty`, `maxQty`, `minNotional`) — sem mais floor/round. Se a quantidade não estiver alinhada ao chegar no dispatch, lança `OrderFilterViolationException` (bug do chamador).
+
+---
+
+## Critérios de aceitação
+
+1. A quantidade e o preço persistidos na `Transaction` são idênticos aos enviados para a exchange.
+2. A reserva de capital (`BuySignalHandler`) usa a quantidade pós-normalização.
+3. O lock de posição SELL (`SellSignalHandler`) usa a quantidade pós-normalização.
+4. Se a exchange não tiver normalizador registrado (ex: MOCK), o use case usa a quantidade original sem modificação.
+5. Testes de integração verificam que `transaction.quantity == order.sentQuantity` após fill.
+
+## Observação
+
+O caminho de **rejeição** (qty < minQty, notional < minNotional) já está correto desde T6/`5bd53f7`: `OrderFilterViolationException` é capturada em `OrderDispatchAdapter.dispatch()` e o domínio é desfeito via `orderConciliation.execute(REJECTED)`. Esta tarefa cobre apenas o caminho de **ajuste** (floor de quantidade válida).

--- a/docs/tasks/T6-symbol-filters.md
+++ b/docs/tasks/T6-symbol-filters.md
@@ -3,7 +3,7 @@
 **Complexidade:** Média  
 **Responsável:** Codex  
 **Dependências:** T5  
-**Status:** Pendente
+**Status:** Concluído
 
 ---
 

--- a/docs/tasks/T7-boot-readiness.md
+++ b/docs/tasks/T7-boot-readiness.md
@@ -3,7 +3,7 @@
 **Complexidade:** Média  
 **Responsável:** Codex  
 **Dependências:** T2, T5  
-**Status:** Pendente
+**Status:** Concluído
 
 ---
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceMarketStreamConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceMarketStreamConfiguration.java
@@ -6,6 +6,7 @@ import com.marmitt.application.spring.adapter.OkHttp3WebSocketAdapter;
 import com.marmitt.application.spring.adapter.binance.OkHttpClientAdapter;
 import com.marmitt.binance.BinanceConnectionConfig;
 import com.marmitt.binance.BinanceMarketStreamAdapter;
+import com.marmitt.binance.filters.SymbolFilterCache;
 import com.marmitt.core.enums.StreamChannel;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
 import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
@@ -41,9 +42,23 @@ public class BinanceMarketStreamConfiguration {
     }
 
     @Bean
+    public SymbolFilterCache binanceSymbolFilterCache(ObjectMapper objectMapper,
+                                                      BinanceProperties properties,
+                                                      OkHttpClient binanceRestClient) {
+        SymbolFilterCache cache = new SymbolFilterCache(
+                properties.getRestBaseUrl(),
+                new OkHttpClientAdapter(binanceRestClient),
+                objectMapper);
+        // Eager-load configured symbols at startup; SymbolFilterLoadException propagates and aborts boot
+        properties.getSymbols().forEach(cache::loadAndCache);
+        return cache;
+    }
+
+    @Bean
     public BinanceMarketStreamAdapter binanceMarketStreamAdapter(ObjectMapper objectMapper,
                                                                  BinanceProperties properties,
-                                                                 OkHttpClient binanceRestClient) {
+                                                                 OkHttpClient binanceRestClient,
+                                                                 SymbolFilterCache binanceSymbolFilterCache) {
         BinanceConnectionConfig config = new BinanceConnectionConfig(
                 properties.getApiKey(),
                 properties.getApiSecret(),
@@ -54,6 +69,7 @@ public class BinanceMarketStreamConfiguration {
         OkHttpClient bootReadinessClient = binanceRestClient.newBuilder()
                 .callTimeout(Duration.ofSeconds(10))
                 .build();
-        return new BinanceMarketStreamAdapter(objectMapper, config, new OkHttpClientAdapter(bootReadinessClient));
+        return new BinanceMarketStreamAdapter(objectMapper, config,
+                new OkHttpClientAdapter(bootReadinessClient), binanceSymbolFilterCache);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceProperties.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceProperties.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Validated
 @ConfigurationProperties(prefix = "binance")
 public class BinanceProperties {
@@ -19,6 +22,8 @@ public class BinanceProperties {
 
     @NotBlank(message = "binance.api-secret is required when binance.api-key is defined")
     private String apiSecret;
+
+    private List<String> symbols = new ArrayList<>();
 
     public String getWsBaseUrl() {
         return wsBaseUrl;
@@ -50,5 +55,13 @@ public class BinanceProperties {
 
     public void setApiSecret(String apiSecret) {
         this.apiSecret = apiSecret;
+    }
+
+    public List<String> getSymbols() {
+        return symbols;
+    }
+
+    public void setSymbols(List<String> symbols) {
+        this.symbols = symbols;
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/AdminController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.marmitt.application.spring.controller;
+
+import com.marmitt.binance.filters.SymbolFilterCache;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final List<SymbolFilterCache> filterCaches;
+
+    public AdminController(List<SymbolFilterCache> filterCaches) {
+        this.filterCaches = filterCaches;
+    }
+
+    @PostMapping("/filters/refresh")
+    public ResponseEntity<Void> refreshFilters() {
+        filterCaches.forEach(SymbolFilterCache::invalidateAll);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
@@ -1,6 +1,7 @@
 package com.marmitt.application.spring.infrastructure.exchange;
 
 import com.marmitt.binance.filters.OrderFilterViolationException;
+import com.marmitt.binance.filters.SymbolFilterLoadException;
 import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
@@ -45,7 +46,7 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
             if (!tryDispatchViaRest(request, command.exchangeId())) {
                 dispatchViaStreaming(request, command.exchangeId());
             }
-        } catch (OrderFilterViolationException ex) {
+        } catch (OrderFilterViolationException | SymbolFilterLoadException ex) {
             log.warn("dispatch: order rejected by local filter - clientOrderId={} exchange={} reason={}",
                     command.clientOrderId(), command.exchangeId(), ex.getMessage());
             orderConciliation.execute(toRejectedOrder(command, ex.getMessage()));

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
@@ -1,5 +1,7 @@
 package com.marmitt.application.spring.infrastructure.exchange;
 
+import com.marmitt.binance.filters.OrderFilterViolationException;
+import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.dto.websocket.request.SendOrderRequest;
@@ -13,6 +15,9 @@ import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
 import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
+
+import java.math.BigDecimal;
+import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -36,8 +41,15 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
     public void dispatch(OrderDispatchCommand command) {
         SendOrderRequest request = toSendOrderRequest(command, command.exchangeId());
 
-        if (!tryDispatchViaRest(request, command.exchangeId())) {
-            dispatchViaStreaming(request, command.exchangeId());
+        try {
+            if (!tryDispatchViaRest(request, command.exchangeId())) {
+                dispatchViaStreaming(request, command.exchangeId());
+            }
+        } catch (OrderFilterViolationException ex) {
+            log.warn("dispatch: order rejected by local filter - clientOrderId={} exchange={} reason={}",
+                    command.clientOrderId(), command.exchangeId(), ex.getMessage());
+            orderConciliation.execute(toRejectedOrder(command, ex.getMessage()));
+            return;
         }
 
         log.debug("dispatch: order sent - clientOrderId={} exchange={} symbol={} type={}",
@@ -94,6 +106,26 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
                 OrderType.LIMIT,
                 side,
                 command.clientOrderId()
+        );
+    }
+
+    private OrderDataDto toRejectedOrder(OrderDispatchCommand command, String rejectReason) {
+        OrderDataDto.OrderSide side = command.type() == TransactionType.BUY
+                ? OrderDataDto.OrderSide.BUY : OrderDataDto.OrderSide.SELL;
+        return new OrderDataDto(
+                null,
+                command.clientOrderId(),
+                Symbol.of(command.symbol()),
+                side,
+                OrderDataDto.OrderType.LIMIT,
+                command.quantity(),
+                BigDecimal.ZERO,
+                command.price(),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                OrderDataDto.OrderStatus.REJECTED,
+                rejectReason,
+                Instant.now()
         );
     }
 

--- a/spring-application/src/test/java/com/marmitt/application/spring/config/exchange/BinanceSymbolFilterIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/config/exchange/BinanceSymbolFilterIntegrationTest.java
@@ -1,0 +1,180 @@
+package com.marmitt.application.spring.config.exchange;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.application.spring.adapter.binance.OkHttpClientAdapter;
+import com.marmitt.binance.filters.OrderFilterViolationException;
+import com.marmitt.binance.filters.OrderFilterValidator;
+import com.marmitt.binance.filters.SymbolFilterCache;
+import com.marmitt.binance.filters.SymbolFilterLoadException;
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
+import com.marmitt.core.enums.OrderSide;
+import com.marmitt.core.enums.OrderType;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BinanceSymbolFilterIntegrationTest {
+
+    private static final String SYMBOL = "BTCUSDT";
+
+    private static final String EXCHANGE_INFO_BTCUSDT = """
+            {
+              "symbols": [{
+                "symbol": "BTCUSDT",
+                "filters": [
+                  {"filterType":"LOT_SIZE","minQty":"0.00001","maxQty":"9000","stepSize":"0.00001"},
+                  {"filterType":"PRICE_FILTER","minPrice":"0.01","maxPrice":"1000000","tickSize":"0.01"},
+                  {"filterType":"MIN_NOTIONAL","minNotional":"10.00"}
+                ]
+              }]
+            }
+            """;
+
+    private MockWebServer server;
+    private SymbolFilterCache cache;
+    private OrderFilterValidator validator;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        String baseUrl = "http://" + server.getHostName() + ":" + server.getPort();
+        var httpClient = new OkHttpClientAdapter(new OkHttpClient());
+        cache = new SymbolFilterCache(baseUrl, httpClient, new ObjectMapper());
+        validator = new OrderFilterValidator(cache);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    void shouldPassValidOrderWithoutModification() {
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(EXCHANGE_INFO_BTCUSDT));
+
+        SendOrderRequest request = orderRequest("0.001", "50000.00");
+        SendOrderRequest result = validator.validate(request);
+
+        assertThat(result.getQuantity()).isEqualByComparingTo("0.001");
+        assertThat(result.getPrice()).isEqualByComparingTo("50000.00");
+    }
+
+    @Test
+    void shouldAdjustQuantityToFloorStepSize() {
+        // stepSize=0.00001 → 0.001234 / 0.00001 = 123.4 → floor=123 → 0.00123
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(EXCHANGE_INFO_BTCUSDT));
+
+        SendOrderRequest request = orderRequest("0.001234", "50000.00");
+        SendOrderRequest result = validator.validate(request);
+
+        assertThat(result.getQuantity()).isEqualByComparingTo("0.00123");
+    }
+
+    @Test
+    void shouldRejectQuantityBelowMinQtyAfterFloor() {
+        String exchangeInfo = exchangeInfoWithLotSize("0.001", "0.001", "9000");
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(exchangeInfo));
+
+        SendOrderRequest request = orderRequest("0.0005", "50000.00");
+
+        assertThatThrownBy(() -> validator.validate(request))
+                .isInstanceOf(OrderFilterViolationException.class)
+                .hasMessageContaining("minQty")
+                .hasMessageContaining(SYMBOL);
+    }
+
+    @Test
+    void shouldRejectOrderWhenNotionalIsBelowMinNotional() {
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(EXCHANGE_INFO_BTCUSDT));
+
+        SendOrderRequest request = orderRequest("0.00001", "1.00");
+
+        assertThatThrownBy(() -> validator.validate(request))
+                .isInstanceOf(OrderFilterViolationException.class)
+                .hasMessageContaining("minNotional")
+                .hasMessageContaining(SYMBOL);
+    }
+
+    @Test
+    void shouldRoundPriceToTickSize() {
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(EXCHANGE_INFO_BTCUSDT));
+
+        SendOrderRequest request = orderRequest("0.001", "43521.755");
+        SendOrderRequest result = validator.validate(request);
+
+        assertThat(result.getPrice()).isEqualByComparingTo("43521.76");
+    }
+
+    @Test
+    void shouldThrowOnExchangeInfoHttpFailure() {
+        server.enqueue(new MockResponse().setResponseCode(500).setBody("Internal Server Error"));
+
+        assertThatThrownBy(() -> cache.loadAndCache(SYMBOL))
+                .isInstanceOf(SymbolFilterLoadException.class)
+                .hasMessageContaining(SYMBOL)
+                .hasMessageContaining("HTTP 500");
+    }
+
+    @Test
+    void shouldInvalidateCacheAndReloadFiltersOnNextUse() {
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(EXCHANGE_INFO_BTCUSDT));
+        cache.loadAndCache(SYMBOL);
+
+        cache.invalidateAll();
+
+        String updatedExchangeInfo = exchangeInfoWithLotSize("0.001", "0.001", "9000");
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(updatedExchangeInfo));
+
+        SendOrderRequest request = orderRequest("0.001", "50000.00");
+        SendOrderRequest result = validator.validate(request);
+
+        assertThat(result.getQuantity()).isEqualByComparingTo("0.001");
+    }
+
+    @Test
+    void shouldSkipNotionalCheckForMarketOrders() {
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(EXCHANGE_INFO_BTCUSDT));
+
+        SendOrderRequest request = new SendOrderRequest(
+                "BINANCE", SYMBOL, new BigDecimal("0.001"), null,
+                OrderType.MARKET, OrderSide.BUY, "client-1");
+
+        SendOrderRequest result = validator.validate(request);
+
+        assertThat(result.getQuantity()).isEqualByComparingTo("0.001");
+        assertThat(result.getPrice()).isNull();
+    }
+
+    private SendOrderRequest orderRequest(String quantity, String price) {
+        return new SendOrderRequest(
+                "BINANCE", SYMBOL,
+                new BigDecimal(quantity), new BigDecimal(price),
+                OrderType.LIMIT, OrderSide.BUY, "client-1");
+    }
+
+    private String exchangeInfoWithLotSize(String stepSize, String minQty, String maxQty) {
+        return """
+                {
+                  "symbols": [{
+                    "symbol": "BTCUSDT",
+                    "filters": [
+                      {"filterType":"LOT_SIZE","minQty":"%s","maxQty":"%s","stepSize":"%s"},
+                      {"filterType":"PRICE_FILTER","minPrice":"0.01","maxPrice":"1000000","tickSize":"0.01"},
+                      {"filterType":"MIN_NOTIONAL","minNotional":"10.00"}
+                    ]
+                  }]
+                }
+                """.formatted(minQty, maxQty, stepSize);
+    }
+}


### PR DESCRIPTION
## Summary

- Implementa validação local de ordens contra filtros da Binance (`LOT_SIZE`, `PRICE_FILTER`, `MIN_NOTIONAL`) antes de qualquer envio REST
- Filtros carregados de `GET /api/v3/exchangeInfo` no startup para símbolos configurados em `binance.symbols`; cache invalidável via `POST /api/admin/filters/refresh` sem restart
- `submitOrder` e `cancelOrder` implementados com REST real em `BinanceMarketStreamAdapter`; validação de filtro aplicada antes do submit

## Arquivos novos

| Arquivo | Responsabilidade |
|---|---|
| `adapter-binance/.../filters/SymbolFilterCache.java` | Carrega e cacheia filtros por símbolo |
| `adapter-binance/.../filters/OrderFilterValidator.java` | Aplica LOT_SIZE (floor), PRICE_FILTER (HALF_UP), MIN_NOTIONAL |
| `adapter-binance/.../filters/SymbolFilters.java` | Record com stepSize, minQty, maxQty, tickSize, minNotional |
| `adapter-binance/.../filters/SymbolFilterLoadException.java` | Falha de startup se exchangeInfo indisponível |
| `adapter-binance/.../filters/OrderFilterViolationException.java` | Rejeição local antes de chegar na exchange |
| `spring-application/.../controller/AdminController.java` | `POST /api/admin/filters/refresh` |
| `BinanceSymbolFilterIntegrationTest.java` | 8 cenários com MockWebServer |

## Test plan

- [x] `shouldPassValidOrderWithoutModification` — ordem válida passa sem alteração
- [x] `shouldAdjustQuantityToFloorStepSize` — quantidade não múltipla de stepSize é ajustada por floor
- [x] `shouldRejectQuantityBelowMinQtyAfterFloor` — rejeição local com mensagem incluindo símbolo e minQty
- [x] `shouldRejectOrderWhenNotionalIsBelowMinNotional` — rejeição com mensagem incluindo símbolo
- [x] `shouldRoundPriceToTickSize` — preço arredondado para o tick mais próximo (HALF_UP)
- [x] `shouldThrowOnExchangeInfoHttpFailure` — startup falha com `SymbolFilterLoadException` se exchangeInfo retorna erro
- [x] `shouldInvalidateCacheAndReloadFiltersOnNextUse` — cache invalidado, próxima ordem recarrega filtros
- [x] `shouldSkipNotionalCheckForMarketOrders` — ordens MARKET (price=null) passam sem cheque de notional
- [x] Suite completa `spring-application` — BUILD SUCCESSFUL, zero regressões

🤖 Generated with [Claude Code](https://claude.com/claude-code)