### PR TITLE
docs(ai): add agent workflow skills

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -13,22 +13,30 @@ Todo agente deve consultar este material antes de implementar, revisar, refatora
 
 ## Leitura base para tarefas de codigo
 
-1. `architecture.md`
-2. `coding-standards.md`
-3. `validation.md`
+1. `project-context.md`
+2. `architecture.md`
+3. `coding-standards.md`
+4. `validation.md`
+5. `git-workflow.md`
 
 ## Contexto minimo por tarefa
 
-- Implementacao: `architecture.md`, `coding-standards.md`, `validation.md`
-- Review de PR ou diff: `architecture.md`, `coding-standards.md`, `validation.md`, `review.md`, `agents/code-review-agent.md`
-- Refactor ou mudanca de responsabilidade entre modulos: `architecture.md`, `coding-standards.md`, `validation.md`, `change-safety.md`
-- Sugestao arquitetural: `architecture.md`, `coding-standards.md`, `change-safety.md`
+- Implementacao: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`
+- Review de PR ou diff: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `review.md`, `agents/code-review-agent.md`
+- Resolver comentarios de PR: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `review.md`, `agents/code-review-agent.md`, `skills/pr-comment-resolver/SKILL.md`
+- Criacao de PR: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `git-workflow.md`, `skills/pr-creator/SKILL.md`
+- Refactor ou mudanca de responsabilidade entre modulos: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `change-safety.md`
+- Sugestao arquitetural: `project-context.md`, `architecture.md`, `coding-standards.md`, `change-safety.md`
 - Atualizacao de documentacao: `docs.md`
 - Publicacao de findings em PR: `skills/pr-review-publisher/SKILL.md`
 
 ## Guias adicionais por tipo de tarefa
 
+- Uso de agentes e skills: consultar `agents/usage.md` para exemplos de comandos e efeitos esperados
+- Git workflow: consultar `git-workflow.md` para branch, commit e base de PR
 - Review de PR ou diff: ler tambem `review.md`
+- Resolver comentarios de PR: ler tambem `skills/pr-comment-resolver/SKILL.md`
+- Criacao de PR: ler tambem `skills/pr-creator/SKILL.md`
 - Refactor ou mudanca de responsabilidade entre modulos: ler tambem `change-safety.md`
 - Atualizacao de documentacao: ler tambem `docs.md`
 

--- a/.ai/agents/README.md
+++ b/.ai/agents/README.md
@@ -13,3 +13,8 @@ Este diretorio concentra prompts especializados reutilizaveis por mais de uma fe
 - o comportamento detalhado do agente deve viver aqui
 - arquivos especificos de ferramenta podem adaptar formato, mas nao devem redefinir a politica
 - quando um agente especializado mudar, atualize primeiro o arquivo em `/.ai/agents/`
+
+## Guia de uso
+
+- `usage.md`: exemplos de comandos para acionar agentes e skills, incluindo o que
+  cada comando deve fazer ou evitar.

--- a/.ai/agents/usage.md
+++ b/.ai/agents/usage.md
@@ -1,0 +1,222 @@
+# Uso de Agentes e Skills
+
+Este guia mostra como pedir trabalho para uma IA neste repositorio e o que cada
+tipo de comando deve acionar. Ele nao substitui `/.ai/README.md`; use este arquivo
+como catalogo pratico de comandos.
+
+## Regra geral
+
+- Peca o resultado desejado de forma explicita.
+- Diga quando a IA deve publicar, responder, resolver threads, fazer commit ou
+  abrir PR. Sem pedido explicito, essas acoes devem parar em rascunho/resumo.
+- Para qualquer tarefa de codigo, a IA deve comecar lendo `/.ai/README.md` e o
+  contexto minimo indicado ali.
+- Agentes definem comportamento; skills operacionalizam workflows especificos.
+
+## Comandos de review
+
+### Revisar sem publicar
+
+Comando:
+
+```text
+Use o code-review-agent para revisar o PR #32.
+```
+
+Deve fazer:
+
+- ler `/.ai/agents/code-review-agent.md` e os documentos exigidos por ele;
+- buscar diff/contexto do PR;
+- reportar findings na conversa, ordenados por severidade;
+- nao publicar comentarios no GitHub.
+
+### Revisar e publicar findings
+
+Comando:
+
+```text
+Use o code-review-agent para revisar o PR #32 e publique os findings no PR.
+```
+
+Deve fazer:
+
+- executar o fluxo de review normal;
+- usar `/.ai/skills/pr-review-publisher/SKILL.md` para publicar;
+- evitar duplicar comentarios existentes;
+- reportar o que foi publicado e o que foi ignorado.
+
+### Revisar diff local
+
+Comando:
+
+```text
+Use o code-review-agent para revisar meu diff local antes do commit.
+```
+
+Deve fazer:
+
+- inspecionar o diff local;
+- aplicar as regras de review do projeto;
+- apontar riscos e lacunas de validacao;
+- nao alterar arquivos, salvo se o usuario pedir explicitamente correcoes.
+
+## Comandos para comentarios de PR
+
+### Resolver comentarios sem publicar respostas
+
+Comando:
+
+```text
+Resolva os comentarios do PR #32, mas deixe as respostas em rascunho.
+```
+
+Deve fazer:
+
+- usar `/.ai/skills/pr-comment-resolver/SKILL.md`;
+- ler threads com contexto completo;
+- classificar comentarios acionaveis, ambiguos, duplicados ou resolvidos;
+- implementar os fixes selecionados;
+- validar as mudancas;
+- entregar rascunhos de resposta para cada thread enderecada.
+
+### Resolver comentarios e responder no PR
+
+Comando:
+
+```text
+Resolva os comentarios do PR #32, suba o codigo e responda os threads no GitHub.
+```
+
+Deve fazer:
+
+- executar o workflow de `pr-comment-resolver`;
+- implementar e validar os fixes;
+- publicar respostas somente nos threads enderecados;
+- resolver threads apenas se o usuario tambem pedir isso explicitamente ou se o
+  comando deixar claro que deve "resolver os threads";
+- reportar links/ids das respostas quando disponiveis.
+
+### Apenas responder um comentario
+
+Comando:
+
+```text
+Responda ao comentario do PR #32 explicando por que nao vamos mover essa regra para o adapter.
+```
+
+Deve fazer:
+
+- localizar o comentario/thread;
+- redigir uma resposta alinhada com `/.ai/architecture.md`;
+- publicar somente se o comando pedir "responda" no PR; caso contrario, deixar
+  o texto em rascunho.
+
+## Comandos de implementacao
+
+### Implementar uma mudanca
+
+Comando:
+
+```text
+Implemente suporte a validacao de symbol filters no adapter Binance.
+```
+
+Deve fazer:
+
+- ler `project-context.md`, `architecture.md`, `coding-standards.md` e
+  `validation.md`;
+- consultar docs profundas do fluxo afetado quando houver;
+- implementar no modulo dono da responsabilidade;
+- validar com o comando mais restrito possivel;
+- resumir arquivos alterados e validacao.
+
+### Implementar e abrir PR
+
+Comando:
+
+```text
+Implemente a mudanca, faca commit, suba a branch e abra um PR draft.
+```
+
+Deve fazer:
+
+- usar `/.ai/skills/pr-creator/SKILL.md` para a etapa de publicacao;
+- implementar e validar;
+- conferir `git status` e escopo do commit;
+- criar ou usar branch conforme `/.ai/git-workflow.md`, por exemplo
+  `feature/<slug>`;
+- criar nova branch a partir de `develop` atualizado;
+- commitar apenas as mudancas relacionadas;
+- fazer rebase da branch sobre `develop` antes de abrir PR;
+- subir branch e abrir PR draft;
+- apontar o PR para `develop`;
+- nao fazer merge.
+
+### Criar PR com mudancas atuais
+
+Comando:
+
+```text
+Crie um PR draft com as mudancas atuais.
+```
+
+Deve fazer:
+
+- usar `/.ai/skills/pr-creator/SKILL.md`;
+- conferir `git status`;
+- identificar mudancas relacionadas e nao relacionadas;
+- criar ou usar branch conforme `/.ai/git-workflow.md`;
+- validar com `./scripts/gradle-run.ps1` quando a mudanca nao for apenas docs;
+- criar commit apenas com arquivos relacionados;
+- fazer rebase da branch sobre `develop` antes de abrir PR;
+- subir a branch;
+- abrir PR draft apontando para `develop`;
+- reportar URL do PR, validacao rodada e arquivos incluidos/excluidos.
+
+## Comandos de refactor
+
+### Refatorar com mudanca de responsabilidade
+
+Comando:
+
+```text
+Refatore esse fluxo para mover a decisao de negocio do spring-application para o core.
+```
+
+Deve fazer:
+
+- ler `/.ai/change-safety.md`;
+- identificar o dono correto da responsabilidade;
+- preservar contratos publicos ou listar consumidores afetados;
+- separar mudanca estrutural de mudanca comportamental quando possivel;
+- validar todos os modulos consumidores afetados.
+
+## Comandos de documentacao
+
+### Atualizar docs canonicas
+
+Comando:
+
+```text
+Atualize a documentacao de agentes para incluir esse novo workflow.
+```
+
+Deve fazer:
+
+- ler `/.ai/docs.md`;
+- atualizar primeiro a fonte canonica em `/.ai`;
+- evitar duplicar regra detalhada em `AGENTS.md`, `CLAUDE.md` ou README;
+- ajustar documentos ponte apenas quando necessario.
+
+## Frases que mudam o nivel de permissao
+
+- "publique no PR": permite publicar comentarios/reviews no GitHub.
+- "responda os threads": permite responder threads do PR.
+- "resolva os threads": permite marcar threads como resolvidas quando a ferramenta
+  suportar isso.
+- "suba o codigo": permite push.
+- "faca commit": permite criar commit com o escopo relacionado.
+- "abra PR": permite criar pull request.
+- "PR draft": cria pull request em modo draft, que tambem e o padrao.
+- "sem publicar" ou "deixe em rascunho": impede writes externos e deixa textos
+  prontos na conversa.

--- a/.ai/git-workflow.md
+++ b/.ai/git-workflow.md
@@ -1,0 +1,84 @@
+# Git Workflow
+
+Este documento define a politica canonica de branch, commit e PR para agentes.
+
+## Branch base
+
+- Toda branch de trabalho deve sair de `develop`.
+- Todo pull request deve apontar para `develop`.
+- Se `develop` nao existir localmente ou remotamente, pare e reporte o bloqueio.
+- Nao crie branch de trabalho a partir de `main`, `master` ou branch de feature
+  sem pedido explicito.
+
+## Nomenclatura de branches
+
+Use convencao Git Flow com prefixo e slug:
+
+- `feature/<slug>` para implementacao nova ou evolucao funcional.
+- `bugfix/<slug>` para correcao de bug em fluxo normal.
+- `hotfix/<slug>` para correcao urgente direcionada a producao, somente com
+  pedido explicito.
+- `docs/<slug>` para mudancas apenas de documentacao.
+- `refactor/<slug>` para refactor sem mudanca comportamental pretendida.
+- `test/<slug>` para mudancas focadas em teste/validacao.
+- `chore/<slug>` para manutencao operacional, build ou tooling.
+
+O slug deve:
+
+- usar lowercase;
+- remover acentos;
+- usar apenas letras, numeros e `-`;
+- separar palavras com `-`;
+- ser curto e descritivo;
+- evitar nomes genericos como `fix`, `changes`, `update` ou `codex`.
+
+Exemplos:
+
+- `feature/binance-symbol-filters`
+- `bugfix/order-conciliation-idempotency`
+- `docs/ai-agent-usage`
+- `refactor/runner-signal-policy`
+- `test/boot-recovery-scenarios`
+- `chore/gradle-cache-wrapper`
+
+## Criacao de branch por agentes
+
+- Se o usuario fornecer nome de branch, use-o apenas se seguir esta convencao.
+- Se o nome fornecido nao seguir a convencao, sugira o nome correto antes de
+  criar a branch.
+- Se o usuario nao fornecer nome, derive o prefixo pelo tipo da tarefa e crie um
+  slug a partir do objetivo.
+- Antes de criar branch, confira `git status --short` e proteja mudancas locais
+  nao relacionadas.
+- Antes de iniciar desenvolvimento em nova branch, atualize `develop` e crie a
+  branch de trabalho a partir dele.
+
+## Rebase com develop
+
+- Antes de iniciar desenvolvimento, atualize `develop`.
+- Antes de abrir PR, faca rebase da branch de trabalho sobre `develop`.
+- Se houver conflito no rebase, pare e reporte o conflito antes de continuar.
+- Nao abra PR enquanto a branch estiver divergente de `develop`.
+- Nao use merge de `develop` na branch de trabalho para substituir o rebase,
+  salvo pedido explicito.
+
+## Commits
+
+- Commit deve conter apenas mudancas relacionadas ao objetivo.
+- Evite `git add .`; stage arquivos explicitamente.
+- Use mensagem curta e orientada ao comportamento.
+- Conventional commit e recomendado quando encaixar:
+  - `feat: ...`
+  - `fix: ...`
+  - `docs: ...`
+  - `refactor: ...`
+  - `test: ...`
+  - `chore: ...`
+
+## Pull requests
+
+- PR deve ser draft por padrao.
+- PR deve apontar para `develop`.
+- Antes de abrir PR, a branch deve estar rebased sobre `develop`.
+- PR deve reportar validacao executada.
+- Nunca fazer merge automaticamente.

--- a/.ai/project-context.md
+++ b/.ai/project-context.md
@@ -1,0 +1,122 @@
+# Contexto do Projeto
+
+Este arquivo e um bootstrap curto para novas sessoes de IA. Ele nao substitui o codigo,
+o Blueprint, o Implementation Guide, nem os documentos de arquitetura em `/.ai`.
+Use-o para se orientar rapidamente e depois consulte a fonte profunda indicada.
+
+## Proposito
+
+CTrade e uma aplicacao modular de trading de criptomoedas. O sistema conecta em
+exchanges, recebe market data, executa estrategias, materializa sinais em ordens,
+concilia atualizacoes de execucao, controla capital/portfolio e recupera estado em
+boot.
+
+O desenho esperado segue clean architecture e arquitetura hexagonal: regra de
+negocio no `core`, calculo de estrategia no `strategy`, provider schemas nos
+`adapter-*`, e composicao/infraestrutura no `spring-application`.
+
+## Mapa de Modulos
+
+- `core/`: dominio, ports, use cases, portfolio/capital, runner, transacoes,
+  posicoes/lotes, conciliacao, boot/recovery e regras de negocio.
+- `strategy/`: estrategias deterministicas de decisao/calculo. A estrategia SMA
+  existente implementa `TradingStrategy`.
+- `spring-application/`: Spring Boot, controllers, configuracao, wiring, eventos,
+  adapters de infraestrutura, persistencia JDBC, boot orchestration e composicao
+  dos adapters.
+- `adapter-binance/`: payloads, mappers, assinatura, REST, WebSocket e User Data
+  Stream especificos da Binance.
+- `adapter-coinbase/`: payloads e processors especificos da Coinbase.
+- `adapter-mock/`: runtime local de exchange, market data, simulacao de ordens,
+  slippage, fees e cenarios para desenvolvimento/testes.
+
+## Fluxos Centrais
+
+- Market data: adapters recebem mensagens externas, traduzem payloads e publicam
+  dados internos para listeners/use cases.
+- Runner e estrategia: o runner monta contexto, chama a estrategia e decide se um
+  sinal vira intencao de trade conforme politicas do dominio.
+- Ordem e conciliacao: intencoes persistem/geram comandos de ordem; updates de
+  exchange reconciliam status, fills parciais, fills finais, cancelamentos e
+  rejeicoes.
+- Portfolio e capital: reservas, liberacoes, execucoes confirmadas, margem,
+  saldos globais e dead letters protegem consistencia financeira.
+- Boot/recovery: o boot executa fases de sanity check, TTL/zombie detection e
+  conciliacao de transacoes/ordens em estado limbo.
+- Resiliencia operacional: eventos duplicados, falhas transitorias, DLQ e recovery
+  precisam convergir estado sem reaplicar efeito financeiro.
+
+## Invariantes Criticas
+
+Antes de alterar dominio, conciliacao, portfolio, runner, boot ou adapters de
+ordem, consulte `docs/PHASE0_INVARIANTS.md`.
+
+Invariantes de alto nivel:
+
+- saldos `available` e `reserved` nao podem ficar negativos;
+- reserva de BUY e liberacao de margem nao podem duplicar efeito financeiro;
+- transicoes de transacao devem ser monotonicas, sem retorno de terminal para
+  transitorio;
+- eventos repetidos nao podem reaplicar saldo, posicao, lot ou match;
+- SELL nao pode exceder quantidade disponivel do lote;
+- lock de SELL deve impedir concorrencia no mesmo alvo;
+- `transaction_match` e PnL nao podem duplicar efeito economico;
+- boot `WARN_ONLY` nao deve bloquear indevidamente e `FAIL_FAST` deve registrar a
+  fase real da falha.
+
+## Fontes de Verdade
+
+- Regras para agentes: `/.ai/README.md`.
+- Fronteiras de modulo: `/.ai/architecture.md`.
+- Padroes de implementacao: `/.ai/coding-standards.md`.
+- Validacao minima: `/.ai/validation.md`.
+- Git workflow: `/.ai/git-workflow.md`.
+- Seguranca de refactor/mudanca de responsabilidade: `/.ai/change-safety.md`.
+- Heuristicas de review: `/.ai/review.md` e `/.ai/agents/code-review-agent.md`.
+- Resolver comentarios de PR: `/.ai/skills/pr-comment-resolver/SKILL.md`.
+- Criacao de PR: `/.ai/skills/pr-creator/SKILL.md`.
+- Visao profunda de capital/execucao/resiliencia: `docs/BLUEPRINT.md`.
+- Guia detalhado de implementacao: `docs/IMPLEMENTATION_GUIDE.md`.
+- Invariantes e matriz de cenarios: `docs/PHASE0_INVARIANTS.md`.
+- Roadmap de testes: `docs/TESTING_ROADMAP.md`.
+- Backlog operacional/testnet: `docs/tasks/BACKLOG.md`.
+- Runbook operacional: `docs/OPERATIONS_RUNBOOK.md`.
+- Referencia de configuracao: `docs/CONFIGURATION_REFERENCE.md`.
+
+## Estado Atual Conhecido
+
+- O projeto e Gradle multi-modulo com Java 21.
+- A aplicacao Spring usa Spring Boot 3.5.4.
+- O runtime atual esta configurado para PostgreSQL via Spring Data JDBC, Flyway e
+  driver Postgres. O `docker-compose.yml` sobe `ctrade-postgres`.
+- O README historico ainda pode citar H2; para persistencia atual, prefira
+  `spring-application/src/main/resources/application.yml` e
+  `spring-application/build.gradle`.
+- O cache Gradle local padrao para agentes e `GRADLE_USER_HOME=.gradle-local`,
+  via `./scripts/gradle-run.ps1`.
+- A trilha Binance testnet tem itens concluidos e pendentes em `docs/tasks/BACKLOG.md`;
+  nao copie esse estado para ca, consulte o backlog.
+
+## Como Comecar uma Tarefa
+
+- Implementacao: leia `/.ai/README.md`, este arquivo, `architecture.md`,
+  `coding-standards.md`, `validation.md` e depois o doc profundo do fluxo afetado.
+- Review: leia `review.md`, `agents/code-review-agent.md`, o diff e os docs do
+  fluxo tocado; publique achados priorizando bug, regressao e fronteira
+  arquitetural.
+- Resolver comentarios de PR: leia `skills/pr-comment-resolver/SKILL.md`, busque
+  threads com contexto completo, implemente fixes rastreaveis e prepare respostas
+  para cada thread enderecada.
+- Criacao de PR: leia `git-workflow.md` e `skills/pr-creator/SKILL.md`, valide o
+  escopo, use branch Git Flow criada a partir de `develop`, commite apenas
+  arquivos relacionados, faca rebase sobre `develop`, suba a branch e abra PR
+  draft para `develop`.
+- Refactor ou mudanca de modulo: leia `change-safety.md`, identifique o dono da
+  responsabilidade antes de editar e valide todos os consumidores afetados.
+- Mudanca em adapter de exchange: mantenha payload/schema no adapter, traduza na
+  borda e compile o adapter mais consumidores diretamente afetados.
+- Mudanca em core/strategy: trate como area de risco alto; prefira teste de
+  comportamento quando houver efeito financeiro, idempotencia ou transicao de
+  estado.
+- Documentacao: atualize `/.ai` quando mudar regra canonica; atualize `docs/`
+  quando mudar blueprint, operacao, roadmap ou guias profundos.

--- a/.ai/skills/pr-comment-resolver/SKILL.md
+++ b/.ai/skills/pr-comment-resolver/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: pr-comment-resolver
+description: Resolve actionable GitHub pull request review comments for the ctrade repository end to end. Use when Codex is asked to address PR comments, requested changes, unresolved review threads, reviewer feedback, or to implement fixes and reply back on a PR. This skill covers inspecting thread-aware review context, deciding which comments require code or explanation, implementing fixes, validating them, drafting replies, and publishing replies/resolving threads only when explicitly requested.
+---
+
+# PR Comment Resolver
+
+Address review comments as a complete workflow: understand the thread, make the
+code change when needed, validate it, and leave a traceable reply plan.
+
+This skill is project-specific. It does not replace the generic GitHub
+`gh-address-comments` workflow; use that GitHub skill/tooling when available for
+thread-aware PR reads.
+
+## Required Reading
+
+Before editing code, read:
+
+- `/.ai/README.md`
+- `/.ai/project-context.md`
+- `/.ai/architecture.md`
+- `/.ai/coding-standards.md`
+- `/.ai/validation.md`
+
+For comments that imply review policy or architectural boundaries, also read:
+
+- `/.ai/review.md`
+- `/.ai/agents/code-review-agent.md`
+- `/.ai/change-safety.md`
+
+For publishing replies or review comments, also read:
+
+- `/.ai/skills/pr-review-publisher/SKILL.md`
+
+## Workflow
+
+1. Resolve the target PR.
+   - Use the PR URL/number if provided.
+   - If the user refers to the current branch, infer the PR from local git and
+     GitHub metadata.
+2. Fetch thread-aware review context.
+   - Prefer the GitHub plugin skill `gh-address-comments` when available.
+   - Use `gh` GraphQL/thread-aware reads when unresolved state, inline anchors,
+     outdated state, or review thread resolution matters.
+   - Do not rely only on flat PR comment lists for actionable review work.
+3. Classify every comment.
+   - Actionable code change.
+   - Explanation-only reply.
+   - Ambiguous or conflicting feedback.
+   - Duplicate, outdated, resolved, or informational feedback.
+4. Confirm scope when needed.
+   - If the user asks to fix everything, address all unresolved actionable
+     comments and call out ambiguous ones.
+   - If comments conflict or could cause regression, stop and explain the
+     tradeoff before editing.
+5. Implement selected fixes.
+   - Keep each change traceable to a comment or feedback cluster.
+   - Preserve module ownership from `/.ai/architecture.md`.
+   - Do not move provider payloads, framework details, or business rules across
+     boundaries for convenience.
+6. Validate with the narrowest meaningful command.
+   - Use `./scripts/gradle-run.ps1` commands from `/.ai/validation.md`.
+   - If behavior is financial, stateful, idempotent, or cross-module, prefer a
+     targeted test in addition to compile when feasible.
+7. Prepare replies.
+   - For each addressed thread, draft a concise reply covering what changed and
+     what validation ran.
+   - For explanation-only or intentionally skipped threads, draft the rationale.
+   - Use `references/response-template.md` when writing replies.
+8. Publish only with explicit permission.
+   - Do not post GitHub replies, resolve review threads, submit reviews, merge,
+     or push unless the user explicitly asks for that action.
+   - If the user says "responda no PR", "publique as respostas", "resolva os
+     threads", or equivalent, use the GitHub connector or `gh` as appropriate.
+
+## Definition of Done
+
+A PR comment resolution task is not complete until the final report includes:
+
+- comments addressed, grouped by thread or behavior area;
+- files/behavior changed;
+- validation commands run and their result;
+- reply drafts or confirmation that replies were posted;
+- comments left unresolved and why.
+
+## Reply Rules
+
+- Keep replies short and specific.
+- Tie the reply to the reviewer concern, not to internal reasoning.
+- Mention validation only when it actually ran.
+- If no code changed, say whether the comment was outdated, non-actionable, or
+  intentionally handled by explanation.
+- If a requested change was rejected, explain the architectural or behavioral
+  reason and identify the safer alternative.
+
+## Reference Map
+
+- `references/response-template.md`: compact templates for addressed,
+  explanation-only, skipped, and blocked review threads.
+

--- a/.ai/skills/pr-comment-resolver/agents/openai.yaml
+++ b/.ai/skills/pr-comment-resolver/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Comment Resolver"
+  short_description: "Resolve PR review comments end to end"
+  default_prompt: "Address the review comments on the current pull request, implement the selected fixes, validate the changes, and draft or publish replies as requested."

--- a/.ai/skills/pr-comment-resolver/references/response-template.md
+++ b/.ai/skills/pr-comment-resolver/references/response-template.md
@@ -1,0 +1,41 @@
+# PR Comment Response Templates
+
+Use these as compact reply shapes. Adapt wording to the actual thread.
+
+## Addressed with code
+
+```
+Addressed in this update. The change now <summarize behavior> in <area/file>.
+
+Validation: `<command>` passed.
+```
+
+## Addressed by explanation
+
+```
+No code change here. <Explain why the current behavior is intentional or why the
+thread is outdated/non-actionable>.
+```
+
+## Skipped intentionally
+
+```
+Leaving this unresolved for now because <reason>. The safer follow-up is
+<specific next step or issue area>.
+```
+
+## Blocked or ambiguous
+
+```
+I need one decision before changing this: <state the concrete ambiguity/tradeoff>.
+The options are <option A> or <option B>, and the impact is <short impact>.
+```
+
+## Published reply checklist
+
+- One reply per addressed thread or coherent thread cluster.
+- Include validation only if it ran.
+- Avoid saying a thread is resolved unless it was actually resolved in GitHub.
+- If posting via a review submission, keep the review body as a brief summary and
+  put thread-specific details in thread replies.
+

--- a/.ai/skills/pr-creator/SKILL.md
+++ b/.ai/skills/pr-creator/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: pr-creator
+description: Create a GitHub pull request for scoped local changes in the ctrade repository. Use when Codex is asked to validate changes, prepare a commit, push a branch, open a PR or draft PR, publish current work for review, or turn local implementation changes into a pull request. This skill covers checking git status, separating related from unrelated changes, running project validation, creating a scoped commit, pushing the branch, opening a draft PR by default, never merging, and reporting the PR URL, validation, and included files.
+---
+
+# PR Creator
+
+Publish local work as a reviewable pull request without losing scope control.
+
+This skill is for creating/updating a PR from local changes. It is not for code
+review findings (`pr-review-publisher`) or for addressing reviewer comments
+(`pr-comment-resolver`).
+
+## Required Reading
+
+Before committing or pushing, read:
+
+- `/.ai/README.md`
+- `/.ai/project-context.md`
+- `/.ai/architecture.md`
+- `/.ai/coding-standards.md`
+- `/.ai/validation.md`
+- `/.ai/git-workflow.md`
+
+For refactors or responsibility moves, also read `/.ai/change-safety.md`.
+
+## Safety Rules
+
+- Commit, push, and PR creation require an explicit user request such as
+  "faca commit", "suba a branch", "abra PR", or "crie um PR".
+- Open PRs as draft by default unless the user explicitly asks for ready review.
+- Always open PRs targeting `develop`.
+- Never merge a PR.
+- Never run `git add .` or equivalent broad staging. Stage explicit related
+  paths only.
+- Never include unrelated dirty work. If unrelated changes exist, leave them
+  unstaged and report them.
+- Do not rewrite, amend, squash, or force-push unless explicitly asked. The
+  required rebase onto `develop` is the only default rebase allowed by this skill.
+- Do not publish secrets, local credentials, generated caches, or build outputs.
+
+## Workflow
+
+1. Inspect repository state.
+   - Run `git status --short`.
+   - Identify current branch and upstream state.
+   - If on `main`, `master`, or `develop`, create a topic branch before commit.
+     Use the branch naming policy from `/.ai/git-workflow.md`.
+   - Before creating a new topic branch, update `develop` and branch from it.
+   - If the user supplied a branch name that does not follow
+     `/.ai/git-workflow.md`, suggest the corrected name before creating it.
+2. Classify changes.
+   - Group modified/untracked files as related, unrelated, generated, or unsafe.
+   - If scope is ambiguous, ask before staging.
+   - Use `git diff` and targeted file reads to understand related changes before
+     writing the commit message or PR body.
+3. Validate.
+   - Use the narrowest meaningful `./scripts/gradle-run.ps1` command from
+     `/.ai/validation.md`.
+   - For docs-only changes, no Gradle command is required; report that validation
+     was documentation-only inspection.
+   - If validation fails, stop before commit unless the user explicitly asks to
+     publish a failing/WIP PR.
+4. Prepare commit.
+   - Stage only related paths.
+   - Use a concise conventional commit style when it fits the change.
+   - Commit message must describe the behavior or workflow changed, not the tool.
+5. Push branch.
+   - Rebase the current branch on `develop` before pushing/opening the PR.
+   - If rebase conflicts occur, stop and report the conflict.
+   - Push the current topic branch to `origin`.
+   - Set upstream when needed.
+6. Open PR.
+   - Prefer GitHub connector tools when available; otherwise use `gh`.
+   - Use `develop` as the PR base branch.
+   - If `develop` cannot be found locally or remotely, stop and report the
+     blocker instead of choosing another base branch.
+   - Do not open the PR until the branch is rebased onto `develop`.
+   - Create as draft unless the user explicitly asks for ready review.
+   - Use `references/pr-body-template.md` for title/body structure.
+7. Report result.
+   - Include PR URL.
+   - Include branch, base, commit hash if available.
+   - Include files staged/committed.
+   - Include validation command and result.
+   - Include unrelated changes left out.
+
+## PR Body Requirements
+
+The PR body should include:
+
+- Summary: 2-4 bullets describing what changed.
+- Validation: exact commands run and outcome, or docs-only inspection.
+- Scope notes: related files included and unrelated files intentionally left out
+  when relevant.
+- Risk notes: only if there is residual risk, skipped validation, or a known
+  follow-up.
+
+## Failure Handling
+
+- Dirty unrelated files: continue only with explicit scoped staging; report what
+  was excluded.
+- Invalid branch name: stop before creating the branch and propose a compliant
+  Git Flow name.
+- Rebase conflict with `develop`: stop before push/PR and report the conflicting
+  files.
+- Missing GitHub auth or network failure: stop after commit only if the commit was
+  already requested and created; otherwise stop before writes.
+- Validation failure: stop before commit/PR by default and report the failing
+  command.
+- Existing PR for branch: update/report the existing PR instead of creating a
+  duplicate.
+- Missing `develop` base branch: stop before PR creation and report the blocker.
+
+## Output Contract
+
+After running this skill, report:
+
+- `PR`: URL or "not created" with reason.
+- `Branch`: local and remote branch.
+- `Commit`: commit hash/message, if created.
+- `Validation`: command and result.
+- `Included`: files committed.
+- `Excluded`: unrelated or unsafe files not included.
+
+## Reference Map
+
+- `references/pr-body-template.md`: compact PR title/body template.

--- a/.ai/skills/pr-creator/agents/openai.yaml
+++ b/.ai/skills/pr-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Creator"
+  short_description: "Validate, commit, push, and open draft PRs"
+  default_prompt: "Create a draft pull request for the current scoped changes: inspect status, validate, commit only related files, push the branch, open the PR, and report the URL and validation."

--- a/.ai/skills/pr-creator/references/pr-body-template.md
+++ b/.ai/skills/pr-creator/references/pr-body-template.md
@@ -1,0 +1,50 @@
+# PR Body Template
+
+Use this as the default PR shape. Keep it concise and factual.
+
+## Title
+
+Use a short imperative or conventional title:
+
+```text
+docs(ai): add PR creator workflow
+```
+
+or:
+
+```text
+Add Binance symbol filter validation
+```
+
+## Body
+
+```md
+## Summary
+- <change 1>
+- <change 2>
+- <change 3 if needed>
+
+## Validation
+- `<command>`: passed
+
+## Notes
+- <optional: unrelated files left out, residual risk, skipped validation, or follow-up>
+```
+
+## Docs-only Validation
+
+```md
+## Validation
+- Docs-only change; inspected the updated Markdown files.
+```
+
+## Failed or Skipped Validation
+
+```md
+## Validation
+- `<command>`: failed with <short reason>
+
+## Notes
+- PR opened as draft/WIP because <explicit user request or reason>.
+```
+


### PR DESCRIPTION
## Summary
- Add a project bootstrap context and agent usage guide under .ai.
- Add Git workflow rules for branch naming, develop base, and rebase expectations.
- Add project skills for PR comment resolution and PR creation workflows.

## Validation
- python C:/Users/mrmar/.codex/skills/.system/skill-creator/scripts/quick_validate.py .ai/skills/pr-comment-resolver: passed
- python C:/Users/mrmar/.codex/skills/.system/skill-creator/scripts/quick_validate.py .ai/skills/pr-creator: passed
- Docs-only change; no Gradle validation required.

## Notes
- PR opened as draft by default and targets develop.
- The global Codex wrapper fix under C:/Users/mrmar/.codex/skills/pr-review-publisher is outside this repository and is not included in this PR.