### PR TITLE
docs: add core flow maps

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -21,18 +21,20 @@ Todo agente deve consultar este material antes de implementar, revisar, refatora
 
 ## Contexto minimo por tarefa
 
-- Implementacao: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`
-- Review de PR ou diff: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `review.md`, `agents/code-review-agent.md`
+- Implementacao: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md` e flow map aplicavel em `flows/`
+- Review de PR ou diff: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `review.md`, `agents/code-review-agent.md` e flow map aplicavel em `flows/`
 - Resolver comentarios de PR: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `review.md`, `agents/code-review-agent.md`, `skills/pr-comment-resolver/SKILL.md`
 - Criacao de PR: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `git-workflow.md`, `skills/pr-creator/SKILL.md`
-- Refactor ou mudanca de responsabilidade entre modulos: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `change-safety.md`
-- Sugestao arquitetural: `project-context.md`, `architecture.md`, `coding-standards.md`, `change-safety.md`
+- Refactor ou mudanca de responsabilidade entre modulos: `project-context.md`, `architecture.md`, `coding-standards.md`, `validation.md`, `change-safety.md` e flow map aplicavel em `flows/`
+- Sugestao arquitetural: `project-context.md`, `architecture.md`, `coding-standards.md`, `change-safety.md` e flow map aplicavel em `flows/` quando envolver fluxo existente
 - Atualizacao de documentacao: `docs.md`
 - Publicacao de findings em PR: `skills/pr-review-publisher/SKILL.md`
 
 ## Guias adicionais por tipo de tarefa
 
 - Uso de agentes e skills: consultar `agents/usage.md` para exemplos de comandos e efeitos esperados
+- Flow maps: consultar `flows/README.md` para entender fluxos implementados antes de alterar feature ou bug
+- Impacto documental: toda alteracao de codigo deve avaliar se `/.ai`, `/.ai/flows` ou `docs/` precisam ser atualizados; quando nao houver impacto, declarar isso no fechamento da tarefa ou PR
 - Git workflow: consultar `git-workflow.md` para branch, commit e base de PR
 - Review de PR ou diff: ler tambem `review.md`
 - Resolver comentarios de PR: ler tambem `skills/pr-comment-resolver/SKILL.md`

--- a/.ai/docs.md
+++ b/.ai/docs.md
@@ -5,16 +5,26 @@
 Atualize documentacao quando houver:
 
 - novo modulo, pacote ou fluxo relevante
+- novo flow map ou mudanca relevante em fluxo implementado
 - mudanca de fronteira arquitetural
 - novo contrato importante
 - mudanca no processo de validacao
 - alteracao de comportamento operacional relevante
+
+Toda alteracao de codigo deve avaliar impacto na documentacao base. Atualize
+`/.ai/flows/*`, `/.ai/project-context.md`, `/.ai/architecture.md`,
+`/.ai/coding-standards.md`, `/.ai/validation.md` ou `docs/*` quando a mudanca
+alterar fluxo, contrato, fronteira, invariante, comportamento operacional ou
+validacao. Se nao houver impacto documental, declare isso no fechamento da
+tarefa ou no PR.
 
 ## Papel de cada documento
 
 - `README.md`: visao geral do projeto, arquitetura resumida e instrucoes principais
 - `AGENTS.md` e `CLAUDE.md`: ponte obrigatoria para as regras em `/.ai`
 - `/.ai/*`: regras detalhadas e canonicas para agentes e colaboradores
+- `/.ai/flows/*`: mapas curtos de fluxos implementados, conectando comportamento,
+  codigo principal, invariantes e testes
 
 ## Regra pratica
 

--- a/.ai/flows/README.md
+++ b/.ai/flows/README.md
@@ -1,0 +1,51 @@
+# Flow Maps
+
+Esta pasta descreve como os fluxos ja implementados funcionam no codigo.
+Ela preenche o espaco entre a documentacao de processo/arquitetura e as classes
+concretas que executam cada comportamento.
+
+Use estes arquivos quando a tarefa envolver feature, bug, review ou refactor em
+um fluxo existente. Eles nao substituem o codigo nem os testes; funcionam como
+mapas de entrada para uma nova sessao entender rapidamente:
+
+- qual problema o fluxo resolve;
+- quais classes participam;
+- quais invariantes nao podem ser quebradas;
+- quais testes validam o comportamento;
+- onde olhar primeiro no codigo.
+
+## Como Usar
+
+1. Leia `/.ai/README.md` e siga a matriz de contexto minimo.
+2. Abra o mapa do fluxo mais proximo da tarefa.
+3. Confirme o comportamento no codigo antes de alterar.
+4. Atualize o mapa quando a mudanca alterar uma decisao, transicao, contrato,
+   regra de idempotencia ou validacao importante.
+
+## Fluxos Mapeados
+
+| Fluxo | Quando consultar |
+| --- | --- |
+| `runner-signal-processing.md` | Processamento de sinais, montagem de contexto de estrategia, criacao de transacoes BUY/SELL e envio de ordens. |
+| `order-conciliation.md` | Atualizacoes de ordens vindas da exchange, fills, finalizacao, idempotencia e conciliacao via boot. |
+| `portfolio-capital.md` | Portfolio, GlobalBalance, reserva de capital, confirmacao financeira, liberacao de margem e DLQ de capital. |
+| `boot-recovery.md` | Sequencia de boot, readiness, sanity check, deteccao de zombies, TTL de reserva e recuperacao de runners. |
+
+## Regras de Manutencao
+
+- Mantenha cada mapa conciso. A intencao e orientar a leitura, nao copiar o
+  codigo.
+- Prefira caminhos de arquivos, nomes de classes e invariantes verificaveis.
+- Inclua testes relevantes sempre que existirem.
+- Nao duplique regras detalhadas de `docs/BLUEPRINT.md` ou
+  `docs/IMPLEMENTATION_GUIDE.md`; referencie o fluxo implementado.
+- Se um comportamento ainda nao existe, deixe isso claro em vez de documentar
+  como se estivesse pronto.
+
+## Proximos Mapas Candidatos
+
+- Integracao Binance e user data stream.
+- Adapter mock e feed simulado.
+- WebSocket inbound e roteamento de eventos.
+- Dead letter operacional e replay.
+- Persistencia/JPA dos agregados principais.

--- a/.ai/flows/_template.md
+++ b/.ai/flows/_template.md
@@ -1,0 +1,46 @@
+# Nome Do Fluxo
+
+## Objetivo
+
+Explique em poucas linhas qual problema este fluxo resolve.
+
+## Quando Consultar
+
+- Liste os tipos de tarefa que devem abrir este mapa.
+
+## Entradas E Saidas
+
+- Entrada principal:
+- Saida principal:
+- Efeitos colaterais:
+
+## Fluxo Principal
+
+1. Passo essencial.
+2. Passo essencial.
+3. Passo essencial.
+
+## Variacoes E Falhas
+
+- Caso alternativo relevante.
+- Falha esperada e como o fluxo responde.
+
+## Componentes Principais
+
+| Componente | Papel |
+| --- | --- |
+| `path/Class.java` | Responsabilidade no fluxo. |
+
+## Invariantes
+
+- Regra que nao pode ser quebrada.
+
+## Validacao
+
+- `path/Test.java`: comportamento coberto.
+- Comando recomendado:
+
+## Fontes
+
+- `docs/path-to-source.md`
+- `module/src/main/java/package/Class.java`

--- a/.ai/flows/boot-recovery.md
+++ b/.ai/flows/boot-recovery.md
@@ -1,0 +1,135 @@
+# Boot Recovery
+
+## Objetivo
+
+Executar a sequencia de boot operacional, validar dependencias externas,
+identificar inconsistencias entre estado local e exchange, aplicar recuperacoes
+seguras e expor observabilidade do processo.
+
+## Quando Consultar
+
+- Mudancas na inicializacao da aplicacao.
+- Bugs em readiness de exchange.
+- Divergencias de saldo, ordens abertas, zombies ou transacoes antigas.
+- Alteracoes em `FAIL_FAST` ou `WARN_ONLY`.
+- Recuperacao de runners, TTL de reserva e DLQ operacional.
+
+## Entradas E Saidas
+
+- Entrada principal: execucao de `RunBootSequenceUseCase`.
+- Escopo: portfolios e runners elegiveis.
+- Saida principal: boot concluido ou falha observada.
+- Efeitos colaterais: conciliacoes sinteticas, amostras de zombie em DLQ,
+  eventos de observabilidade e recuperacao de transacoes.
+
+## Fluxo Principal
+
+1. Cria `runId` de boot.
+2. Carrega portfolios.
+3. Carrega runners elegiveis, excluindo estados como `ARCHIVED` e
+   `TERMINATING`.
+4. Executa Phase 1 de readiness por exchange.
+5. Executa Phase 2 de sanity check por portfolio.
+6. Executa Phase 2 de zombie detection.
+7. Executa Phase 2 de reservation TTL.
+8. Executa Phase 3 de runner recovery.
+9. Notifica conclusao ou falha pelo observer.
+
+## Phase 1: Readiness
+
+`ExchangeBootReadinessPort.checkBootReadiness` verifica se as exchanges
+necessarias estao prontas para operacao.
+
+Exchange nao pronta bloqueia o boot em modo fail-fast.
+
+## Phase 2: Portfolio Sanity
+
+`PortfolioBootSanityUseCase` compara o estado local do `GlobalBalance` com a
+conta externa quando o adapter oferece consulta de conta.
+
+Resultados possiveis incluem:
+
+- `PASS`
+- `WARN_SURPLUS`
+- `FAIL_DEFICIT`
+- `SKIPPED`
+- `FAILED`
+
+Resultados criticos falham o boot em `FAIL_FAST`.
+
+## Phase 2: Zombie Detection
+
+`PortfolioZombieDetectionUseCase` lista ordens abertas na exchange e tenta
+correlacionar com runners/transacoes locais.
+
+Classificacoes relevantes:
+
+- `clientOrderId` invalido.
+- runner desconhecido.
+- ordem sem transacao local.
+- ordem antes do cutoff.
+- simbolo fora do escopo.
+
+Em `FAIL_FAST`, zombies detectados podem bloquear boot e persistir amostras em
+DLQ operacional. Em `WARN_ONLY`, deteccoes sao observadas sem bloquear.
+
+## Phase 2: Reservation TTL
+
+`PortfolioReservationTtlUseCase` procura transacoes `PENDING` antigas sem
+`exchangeOrderId`.
+
+Quando uma transacao passa do cutoff, o fluxo cria um `OrderDataDto` sintetico
+com status `EXPIRED` e reaproveita `ConciliationOrderUpdateExecutor`. Assim, a
+transicao segue a mesma regra transacional da conciliacao normal.
+
+## Phase 3: Runner Recovery
+
+`RunnerBootRecoveryUseCase` recupera cada runner elegivel. O fluxo observa
+transacoes em voo, zombies, limbo e outros sinais operacionais, sempre usando os
+contratos centrais de conciliacao quando precisa alterar estado local.
+
+## Observabilidade
+
+`BootExecutionObserverPort` recebe eventos de fase, resultados, falhas fail-fast
+e conclusao do run. Mudancas no boot devem preservar esses pontos de observacao,
+porque eles sao usados para diagnostico operacional e testes.
+
+## Componentes Principais
+
+| Componente | Papel |
+| --- | --- |
+| `core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java` | Orquestra as fases de boot. |
+| `core/src/main/java/com/marmitt/core/application/usecase/boot/phase2/PortfolioBootSanityUseCase.java` | Compara saldos locais e externos. |
+| `core/src/main/java/com/marmitt/core/application/usecase/boot/phase2/PortfolioZombieDetectionUseCase.java` | Detecta ordens abertas nao conciliadas. |
+| `core/src/main/java/com/marmitt/core/application/usecase/boot/phase2/PortfolioReservationTtlUseCase.java` | Expira reservas antigas sem ordem externa. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/RunnerBootRecoveryUseCase.java` | Recupera runners individualmente. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateExecutor.java` | Aplica recuperacoes pela mesma regra da conciliacao normal. |
+| `spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java` | Wires do boot, executores e propriedades. |
+
+## Invariantes
+
+- `WARN_ONLY` nao deve bloquear boot apenas por zombie detectado.
+- `FAIL_FAST` deve registrar a fase real que falhou.
+- Recuperacoes que mudam transacao devem usar o executor central de conciliacao.
+- Transacao `PENDING` antiga sem `exchangeOrderId` pode expirar por TTL; se ja
+  tem `exchangeOrderId`, nao deve ser expirada por esse caminho.
+- Runners arquivados ou em terminacao nao entram no escopo operacional normal.
+
+## Validacao
+
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerBootRecoveryIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/RunnerTransactionRecoveryWatchdogIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/config/exchange/BinanceBootReadinessIntegrationTest.java`
+- Comando recomendado:
+  `./scripts/gradle-run.ps1 -q :core:test :spring-application:test`
+
+## Fontes
+
+- `docs/IMPLEMENTATION_GUIDE.md`, secao 10.
+- `docs/PHASE0_INVARIANTS.md`.
+- `core/src/main/java/com/marmitt/core/application/usecase/boot/`.
+- `core/src/main/java/com/marmitt/core/application/usecase/runner/RunnerBootRecoveryUseCase.java`.
+- `spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java`.

--- a/.ai/flows/order-conciliation.md
+++ b/.ai/flows/order-conciliation.md
@@ -1,0 +1,121 @@
+# Order Conciliation
+
+## Objetivo
+
+Aplicar atualizacoes de ordens vindas da exchange ao estado local de
+transacoes, posicoes, matches e eventos financeiros, preservando idempotencia e
+transicoes validas.
+
+O mesmo executor atende o fluxo normal de eventos e os fluxos de boot/recovery.
+
+## Quando Consultar
+
+- Bugs em `NEW`, `PARTIALLY_FILLED`, `FILLED`, `CANCELED`, `EXPIRED` ou
+  `REJECTED`.
+- Mudancas em idempotencia de fills.
+- Alteracoes em abertura/reducao de posicao.
+- Recuperacao de transacoes durante boot.
+- Liberacao de margem em encerramentos sem fill final.
+
+## Entradas E Saidas
+
+- Entrada principal: `OrderDataDto`.
+- Identificador: `clientOrderId`.
+- Saida principal: `Transaction` atualizada.
+- Efeitos colaterais: alteracao de `Position`, criacao de `TransactionMatch`,
+  publicacao de `ExecutionConfirmedEvent` ou `MarginReleaseEvent`.
+
+## Fluxo Principal
+
+1. `OrderConciliationUseCase` recebe `OrderDataDto`.
+2. `ConciliationOrderUpdateExecutor` abre a fronteira transacional apropriada.
+3. `ConciliationOrderUpdate` valida `clientOrderId`.
+4. Carrega a transacao local correspondente.
+5. Roteia pelo status recebido da exchange.
+6. Aplica transicao de estado, fill incremental ou encerramento.
+7. Salva os agregados e publica eventos quando necessario.
+
+## Roteamento De Status
+
+- `NEW`: submete transacao `PENDING` para `SUBMITTED`; duplicatas sao
+  ignoradas quando a transacao ja saiu de `PENDING`.
+- `PARTIALLY_FILLED`: aplica apenas o delta ainda nao processado.
+- `FILLED`: aplica o delta final e finaliza a transacao.
+- `CANCELED`, `EXPIRED`, `REJECTED`: aplica transicao terminal e libera margem.
+
+Fills podem submeter uma transacao ainda `PENDING` quando a exchange envia fill
+antes do evento `NEW`.
+
+## BUY Fill
+
+`BuyFillHandler` aplica quantidade executada na posicao:
+
+1. Procura posicao por `openedByTransactionId`.
+2. Se nao existir, procura posicao aberta do mesmo runner/simbolo.
+3. Se ainda nao existir, cria nova `Position`.
+4. Associa a transacao de abertura quando necessario.
+5. Salva posicao e transacao na mesma unidade transacional.
+
+Conflito concorrente ao criar posicao e tratado recarregando a posicao aberta e
+aplicando o incremento.
+
+## SELL Fill
+
+`SellFillHandler` reduz a posicao alvo:
+
+1. Resolve posicao por `targetLotId` ou posicao aberta do runner/simbolo.
+2. Aplica reducao incremental.
+3. Destrava a posicao no fill final.
+4. Cria `TransactionMatch`.
+5. Publica `ExecutionConfirmedEvent`.
+
+Posicoes ativas precisam ter `openedByTransactionId`; ausencia dessa origem e
+erro de consistencia.
+
+## Idempotencia
+
+- `FILLED` duplicado e ignorado se a quantidade recebida nao aumentar a
+  quantidade ja registrada ou se a transacao ja for terminal.
+- `PARTIALLY_FILLED` duplicado e ignorado se a quantidade recebida for nula ou
+  menor/igual ao executado atual.
+- O efeito economico e calculado pelo incremento, nao pelo total recebido.
+- Eventos financeiros derivados devem ser idempotentes no fluxo de capital.
+
+## Componentes Principais
+
+| Componente | Papel |
+| --- | --- |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/OrderConciliationUseCase.java` | Entrada do caso de uso. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateExecutor.java` | Contrato compartilhado entre eventos normais e boot. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdate.java` | Roteia status e aplica transicoes. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/orderconciliation/BuyFillHandler.java` | Aplica fills BUY em posicao. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/orderconciliation/SellFillHandler.java` | Aplica fills SELL, matches e evento financeiro. |
+| `core/src/main/java/com/marmitt/core/domain/runner/Transaction.java` | Maquina de estados da transacao. |
+| `spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java` | Implementa executor com `TransactionTemplate`. |
+
+## Invariantes
+
+- Transicoes de `Transaction` sao monotonicas; estados terminais nao devem ser
+  reabertos.
+- Eventos duplicados nao podem duplicar quantidade, PnL, match ou efeito
+  financeiro.
+- A soma economica dos fills aplicados nao pode exceder a execucao informada
+  pela exchange.
+- SELL nao pode vender quantidade indisponivel.
+- Posicao travada por SELL deve ser destravada no encerramento final.
+
+## Validacao
+
+- `core/src/test/java/com/marmitt/core/application/usecase/runner/orderconciliation/ConciliationOrderUpdateIdempotencyTest.java`
+- `core/src/test/java/com/marmitt/core/domain/runner/TransactionInvariantsTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/userdata/UserDataStreamConciliationIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderTerminationConciliationIntegrationTest.java`
+- Comando recomendado:
+  `./scripts/gradle-run.ps1 -q :core:test :spring-application:test`
+
+## Fontes
+
+- `docs/IMPLEMENTATION_GUIDE.md`, secoes 5, 6, 10 e 15.
+- `docs/PHASE0_INVARIANTS.md`.
+- `core/src/main/java/com/marmitt/core/application/usecase/runner/orderconciliation/`.
+- `core/src/main/java/com/marmitt/core/domain/runner/Transaction.java`.

--- a/.ai/flows/portfolio-capital.md
+++ b/.ai/flows/portfolio-capital.md
@@ -1,0 +1,135 @@
+# Portfolio Capital
+
+## Objetivo
+
+Controlar capital por portfolio, incluindo saldo disponivel, saldo reservado,
+resultado realizado, reserva para BUY, confirmacao financeira de execucoes e
+liberacao de margem em encerramentos.
+
+## Quando Consultar
+
+- Mudancas em `GlobalBalance`.
+- Bugs de reserva, liberacao, PnL ou taxa.
+- Alteracoes em Safe Mode, limite de exposicao por runner ou capital pooling.
+- Eventos financeiros disparados pela conciliacao de ordens.
+- DLQ e replay de eventos de capital.
+
+## Entradas E Saidas
+
+- Entrada para reserva: runner, portfolio, valor solicitado e exposicao atual.
+- Entrada para confirmacao: `ExecutionConfirmedEvent`.
+- Entrada para liberacao: `MarginReleaseEvent`.
+- Saida principal: `GlobalBalance` atualizado.
+- Efeitos colaterais: registro idempotente de evento de capital e, em falha
+  persistente, dead letter.
+
+## Modelo Principal
+
+`GlobalBalance` mantem:
+
+- `availableBalance`
+- `reservedBalance`
+- `realizedBalance`
+- `initialCapital`
+- `baseCurrency`
+- `totalFeesPaid`
+- `lastExecutionTime`
+
+`getTotalBalance` considera `availableBalance + reservedBalance`.
+
+## Criacao De Portfolio
+
+1. `CreatePortfolioUseCase` valida unicidade de nome.
+2. Cria `Portfolio`.
+3. Registra o portfolio.
+4. Cria `GlobalBalance` inicial com capital e moeda base.
+
+## Reserva Para BUY
+
+`CapitalReservationPolicy` decide se um sinal BUY pode seguir:
+
+1. Runner precisa estar associado a portfolio conhecido.
+2. Safe Mode do portfolio nao pode bloquear operacao.
+3. `GlobalBalance` precisa existir.
+4. Exposicao atual + valor solicitado precisa respeitar
+   `maxAllocationPercent` do runner.
+5. Reserva atomica precisa mover capital de disponivel para reservado.
+
+Falha em qualquer passo levanta `CapitalReservationRejectedException`. O
+`BuySignalHandler` descarta o sinal e nao envia ordem externa.
+
+## Confirmacao Financeira
+
+`ExecutionConfirmedReaction` processa `ExecutionConfirmedEvent` apos match de
+SELL:
+
+1. Registra idempotencia por `matchId`.
+2. Resolve runner e portfolio.
+3. Carrega `GlobalBalance`.
+4. Chama `confirmExecution(totalCost, pnlRealized, feeConverted)`.
+5. Salva o saldo.
+
+Esse metodo reduz reserva, aplica PnL realizado, devolve custo ao disponivel e
+acumula taxa convertida.
+
+## Liberacao De Margem
+
+`MarginReleasedReaction` processa `MarginReleaseEvent`:
+
+1. Registra idempotencia por `transactionId`.
+2. Resolve runner e portfolio.
+3. Carrega `GlobalBalance`.
+4. Faz guarda defensiva contra liberacao maior que reservado.
+5. Chama `release(amount)`.
+6. Salva o saldo.
+
+## DLQ De Capital
+
+`CapitalEventListener` consome eventos apos commit em uma transacao nova. Quando
+as tentativas se esgotam, o payload e persistido em dead letter para investigacao
+ou replay.
+
+`ManageDeadLetterUseCase` lista pendencias, marca resolvidas e reprocessa via
+`DeadLetterReprocessingPort`.
+
+## Componentes Principais
+
+| Componente | Papel |
+| --- | --- |
+| `core/src/main/java/com/marmitt/core/domain/portfolio/GlobalBalance.java` | Regras de saldo disponivel, reservado e realizado. |
+| `core/src/main/java/com/marmitt/core/domain/portfolio/Portfolio.java` | Estado do portfolio e Safe Mode. |
+| `core/src/main/java/com/marmitt/core/application/usecase/portfolio/CreatePortfolioUseCase.java` | Cria portfolio e saldo inicial. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/CapitalReservationPolicy.java` | Reserva capital para BUY. |
+| `core/src/main/java/com/marmitt/core/application/reaction/ExecutionConfirmedReaction.java` | Aplica efeito financeiro de execucao confirmada. |
+| `core/src/main/java/com/marmitt/core/application/reaction/MarginReleasedReaction.java` | Libera margem de transacao encerrada. |
+| `spring-application/src/main/java/com/marmitt/application/spring/handler/CapitalEventListener.java` | Consome eventos financeiros com retry e DLQ. |
+| `core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java` | Operacao de DLQ. |
+
+## Invariantes
+
+- Saldos nao podem ficar negativos.
+- BUY nao pode reservar o mesmo capital mais de uma vez.
+- Liberacao de margem terminal nao pode duplicar efeito financeiro.
+- Eventos de capital precisam ser idempotentes.
+- Safe Mode deve impedir novas reservas quando ativo.
+- Limite de exposicao do runner deve considerar exposicao atual mais reserva
+  solicitada.
+
+## Validacao
+
+- `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/handler/CapitalEventListenerTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/CapitalDeadLetterReplayIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapterTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java`
+- `core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java`
+- Comando recomendado:
+  `./scripts/gradle-run.ps1 -q :core:test :spring-application:test`
+
+## Fontes
+
+- `docs/IMPLEMENTATION_GUIDE.md`, secoes 7 e 10.
+- `docs/PHASE0_INVARIANTS.md`.
+- `core/src/main/java/com/marmitt/core/domain/portfolio/`.
+- `core/src/main/java/com/marmitt/core/application/usecase/portfolio/`.
+- `spring-application/src/main/java/com/marmitt/application/spring/handler/CapitalEventListener.java`.

--- a/.ai/flows/runner-signal-processing.md
+++ b/.ai/flows/runner-signal-processing.md
@@ -1,0 +1,95 @@
+# Runner Signal Processing
+
+## Objetivo
+
+Transformar ticks de mercado em decisoes de estrategia e, quando aplicavel,
+persistir uma transacao BUY ou SELL antes de enviar a ordem para a exchange.
+
+Este fluxo fica no core. O Spring apenas fornece fronteiras transacionais e
+adaptadores externos.
+
+## Quando Consultar
+
+- Mudancas em processamento de sinais de trade.
+- Bugs em ordens que nao sao enviadas ou sao enviadas indevidamente.
+- Alteracoes no contexto entregue a estrategias.
+- Regras de reserva de capital, exposicao ou lock de posicao antes do dispatch.
+
+## Entradas E Saidas
+
+- Entrada principal: `MarketDataDto`.
+- Entrada derivada: runners operacionais por simbolo/exchange.
+- Saida principal: transacao `PENDING` persistida e ordem enviada via
+  `OrderDispatchPort`.
+- Efeitos colaterais: reserva atomica de capital para BUY; lock de posicao para
+  SELL.
+
+## Fluxo Principal
+
+1. `ProcessTradeSignalUseCase` recebe um tick de mercado.
+2. Busca runners operacionais por `symbol` e `exchange`.
+3. `RunnerSignalPolicy` filtra runners que podem avaliar o sinal.
+4. `RunnerContextAssembler` monta `StrategyContextDto` com portfolio,
+   posicoes, ordens pendentes, limites e PnL.
+5. `StrategySignalEvaluator` avalia a estrategia.
+6. Sinal `HOLD` encerra o fluxo sem efeito.
+7. Sinal `BUY` passa por `BuySignalHandler`.
+8. Sinal `SELL` passa por `SellSignalHandler`.
+9. A transacao e persistida antes do envio externo da ordem.
+
+## BUY
+
+1. `TradeIntentFactory` cria a intencao da transacao.
+2. `BuySignalHandler` salva a transacao como `PENDING`.
+3. `CapitalReservationPolicy` tenta reservar capital no `GlobalBalance`.
+4. Se a reserva for aceita, a ordem e enviada por `OrderDispatchPort`.
+5. A transacao continua `PENDING` ate a exchange confirmar via conciliacao.
+
+Se a reserva for rejeitada, o sinal e descartado sem dispatch.
+
+## SELL
+
+1. `SellSignalHandler` resolve a posicao alvo por `targetLotId` ou por posicao
+   aberta do runner/simbolo.
+2. A transacao SELL e persistida como `PENDING`.
+3. A posicao e travada com `tryLockPositionForSell`.
+4. A ordem e enviada por `OrderDispatchPort`.
+
+Se nao houver posicao aberta, o sinal e descartado. Se outra venda travou a
+mesma posicao, o fluxo falha com `ConcurrentPositionLockException`.
+
+## Componentes Principais
+
+| Componente | Papel |
+| --- | --- |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java` | Orquestra ticks, runners, contexto, decisao e handlers BUY/SELL. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/RunnerContextAssembler.java` | Monta `StrategyContextDto`. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/BuySignalHandler.java` | Persiste BUY, reserva capital e faz dispatch. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/SellSignalHandler.java` | Persiste SELL, trava posicao e faz dispatch. |
+| `core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/CapitalReservationPolicy.java` | Valida Safe Mode, fundos e limite de exposicao por runner. |
+| `spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java` | Injeta fronteiras transacionais com `TransactionTemplate`. |
+
+## Invariantes
+
+- Nenhuma ordem externa deve ser enviada antes da transacao local existir.
+- BUY so pode seguir para dispatch depois de reserva de capital aceita.
+- SELL so pode seguir para dispatch depois de posicao travada.
+- Falha em um runner nao deve impedir a avaliacao dos demais runners do tick.
+- `RunnerContextAssembler` exige `GlobalBalance`; sem ele a avaliacao nao deve
+  seguir.
+- O core nao deve depender de detalhes do adapter da exchange.
+
+## Validacao
+
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ProcessTradeSignalMockIntegrationTest.java`
+- `core/src/test/java/com/marmitt/core/domain/runner/StrategyRunnerInvariantsTest.java`
+- `core/src/test/java/com/marmitt/core/domain/portfolio/GlobalBalanceInvariantsTest.java`
+- Comando recomendado para mudancas neste fluxo:
+  `./scripts/gradle-run.ps1 -q :core:test :spring-application:test`
+
+## Fontes
+
+- `docs/IMPLEMENTATION_GUIDE.md`, secoes 12, 13 e 14.
+- `docs/PHASE0_INVARIANTS.md`.
+- `core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/`.
+- `spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java`.

--- a/.ai/project-context.md
+++ b/.ai/project-context.md
@@ -71,6 +71,7 @@ Invariantes de alto nivel:
 - Padroes de implementacao: `/.ai/coding-standards.md`.
 - Validacao minima: `/.ai/validation.md`.
 - Git workflow: `/.ai/git-workflow.md`.
+- Flow maps: `/.ai/flows/README.md`.
 - Seguranca de refactor/mudanca de responsabilidade: `/.ai/change-safety.md`.
 - Heuristicas de review: `/.ai/review.md` e `/.ai/agents/code-review-agent.md`.
 - Resolver comentarios de PR: `/.ai/skills/pr-comment-resolver/SKILL.md`.
@@ -100,7 +101,8 @@ Invariantes de alto nivel:
 ## Como Comecar uma Tarefa
 
 - Implementacao: leia `/.ai/README.md`, este arquivo, `architecture.md`,
-  `coding-standards.md`, `validation.md` e depois o doc profundo do fluxo afetado.
+  `coding-standards.md`, `validation.md`, o flow map aplicavel em `flows/` e
+  depois o doc profundo do fluxo afetado.
 - Review: leia `review.md`, `agents/code-review-agent.md`, o diff e os docs do
   fluxo tocado; publique achados priorizando bug, regressao e fronteira
   arquitetural.

--- a/.ai/skills/pr-creator/SKILL.md
+++ b/.ai/skills/pr-creator/SKILL.md
@@ -54,6 +54,9 @@ For refactors or responsibility moves, also read `/.ai/change-safety.md`.
    - If scope is ambiguous, ask before staging.
    - Use `git diff` and targeted file reads to understand related changes before
      writing the commit message or PR body.
+   - For code changes, evaluate documentation impact using `/.ai/docs.md`.
+     Update the applicable base documentation, or record that there is no
+     documentation impact.
 3. Validate.
    - Use the narrowest meaningful `./scripts/gradle-run.ps1` command from
      `/.ai/validation.md`.
@@ -83,6 +86,7 @@ For refactors or responsibility moves, also read `/.ai/change-safety.md`.
    - Include branch, base, commit hash if available.
    - Include files staged/committed.
    - Include validation command and result.
+   - Include documentation impact: updated docs, or "no documentation impact".
    - Include unrelated changes left out.
 
 ## PR Body Requirements
@@ -91,6 +95,7 @@ The PR body should include:
 
 - Summary: 2-4 bullets describing what changed.
 - Validation: exact commands run and outcome, or docs-only inspection.
+- Documentation: files updated, or explicit "no documentation impact".
 - Scope notes: related files included and unrelated files intentionally left out
   when relevant.
 - Risk notes: only if there is residual risk, skipped validation, or a known

--- a/.ai/skills/pr-creator/references/pr-body-template.md
+++ b/.ai/skills/pr-creator/references/pr-body-template.md
@@ -27,6 +27,9 @@ Add Binance symbol filter validation
 ## Validation
 - `<command>`: passed
 
+## Documentation
+- <updated docs, or no documentation impact>
+
 ## Notes
 - <optional: unrelated files left out, residual risk, skipped validation, or follow-up>
 ```
@@ -36,6 +39,9 @@ Add Binance symbol filter validation
 ```md
 ## Validation
 - Docs-only change; inspected the updated Markdown files.
+
+## Documentation
+- Updated base documentation.
 ```
 
 ## Failed or Skipped Validation


### PR DESCRIPTION
## Summary
- Add `/.ai/flows/` with an index, template, and initial maps for runner signal processing, order conciliation, portfolio capital, and boot recovery.
- Update the canonical `/.ai` onboarding docs so agents consult flow maps for implementation, review, refactor, and architecture work on existing flows.
- Add explicit documentation-impact handling to the PR creation workflow and PR body template.

## Validation
- Docs-only change; inspected the updated Markdown files.
- `rg -n TODO|FIXME|\\.\\.\\. .ai/flows .ai/README.md .ai/docs.md .ai/project-context.md .ai/skills/pr-creator/SKILL.md .ai/skills/pr-creator/references/pr-body-template.md`: no matches.

## Documentation
- Updated base documentation in `/.ai/README.md`, `/.ai/docs.md`, `/.ai/project-context.md`, `/.ai/flows/*`, and `/.ai/skills/pr-creator/*`.

## Notes
- No code changes; no Gradle validation was required.