### PR TITLE
docs: add integration event flow maps

### DIFF
--- a/.ai/flows/README.md
+++ b/.ai/flows/README.md
@@ -32,6 +32,9 @@ O plano de expansao e status dos mapas fica em `ROADMAP.md`.
 | `order-conciliation.md` | Atualizacoes de ordens vindas da exchange, fills, finalizacao, idempotencia e conciliacao via boot. |
 | `portfolio-capital.md` | Portfolio, GlobalBalance, reserva de capital, confirmacao financeira, liberacao de margem e DLQ de capital. |
 | `boot-recovery.md` | Sequencia de boot, readiness, sanity check, deteccao de zombies, TTL de reserva e recuperacao de runners. |
+| `binance-user-data-stream.md` | Listen key, User Data Stream, `executionReport`, reconexao e entrada de updates Binance na conciliacao. |
+| `websocket-event-routing.md` | Entrada WebSocket, eventos raw, handlers de mensagem e notificacao de listeners de preco/ordem. |
+| `mock-exchange-runtime.md` | Runtime mock, feed simulado, ordem mock, slippage/fees, overrides e publicacao no pipeline raw. |
 
 ## Regras de Manutencao
 
@@ -46,8 +49,5 @@ O plano de expansao e status dos mapas fica em `ROADMAP.md`.
 
 ## Proximos Mapas Candidatos
 
-- Integracao Binance e user data stream.
-- Adapter mock e feed simulado.
-- WebSocket inbound e roteamento de eventos.
 - Dead letter operacional e replay.
 - Persistencia/JPA dos agregados principais.

--- a/.ai/flows/ROADMAP.md
+++ b/.ai/flows/ROADMAP.md
@@ -13,7 +13,7 @@ conectar comportamento implementado, codigo principal, invariantes e validacao.
 | Estrutura base de `/.ai/flows` | Completo | Indice, template e regra de manutencao dos flow maps. |
 | Mapas dos fluxos centrais | Completo | Cobertura dos fluxos mais criticos de sinal, ordem, capital e boot. |
 | Regra de impacto documental | Completo | Toda alteracao de codigo deve avaliar se a documentacao base precisa mudar. |
-| Mapas de integracao e eventos externos | Pendente | Cobertura de Binance, WebSocket e adapter mock. |
+| Mapas de integracao e eventos externos | Completo | Cobertura de Binance, WebSocket e adapter mock. |
 | Mapas operacionais e persistencia | Pendente | Cobertura de DLQ/replay e persistencia dos agregados principais. |
 
 ## Entrega 1: Base E Fluxos Centrais
@@ -35,7 +35,7 @@ Arquivos entregues:
 
 ## Entrega 2: Integracao E Eventos Externos
 
-Status: Pendente.
+Status: Completo.
 
 Ordem recomendada:
 
@@ -50,6 +50,15 @@ Ordem recomendada:
 3. `mock-exchange-runtime.md`
    - Feed simulado, execucao mock, slippage, fees e cenarios de desenvolvimento.
    - Deve explicar como o mock sustenta testes e desenvolvimento local.
+
+Arquivos entregues:
+
+- `binance-user-data-stream.md`: listen key, User Data Stream, `executionReport`,
+  reconexao e entrada na conciliacao.
+- `websocket-event-routing.md`: canais `MARKET`/`USER_DATA`, eventos raw,
+  handlers, listeners e estado de conexao.
+- `mock-exchange-runtime.md`: runtime mock, feed, ordens, slippage/fees,
+  overrides, snapshots e publicacao no pipeline raw.
 
 ## Entrega 3: Operacao E Persistencia
 

--- a/.ai/flows/binance-user-data-stream.md
+++ b/.ai/flows/binance-user-data-stream.md
@@ -1,0 +1,155 @@
+# Binance User Data Stream
+
+## Objetivo
+
+Conectar o User Data Stream da Binance, manter o `listenKey` ativo, transformar
+eventos privados de ordem em `OrderDataDto` e entregar esses updates ao fluxo de
+conciliacao de ordens.
+
+Este fluxo e a entrada real de callbacks de execucao da Binance. Ele nao deve
+decidir regra de dominio; o adapter traduz payload externo e o core aplica a
+conciliacao.
+
+## Quando Consultar
+
+- Bugs em callbacks de ordem Binance.
+- Mudancas em `listenKey`, keepalive, revoke ou reconexao de User Data Stream.
+- Alteracoes no parsing de `executionReport`.
+- Problemas em status `NEW`, `PARTIALLY_FILLED`, `FILLED`, `CANCELED`,
+  `EXPIRED` ou `REJECTED` vindos da Binance.
+- Review de mudancas que conectam Binance ao fluxo de conciliacao.
+
+## Entradas E Saidas
+
+- Entrada de conexao: `ConnectUserStreamUseCase.execute("BINANCE")`.
+- Entrada raw: mensagem WebSocket privada da Binance.
+- Payload processavel: evento `executionReport`.
+- Saida interna: `OrderDataDto`.
+- Efeito colateral: notificacao de `OrderUpdateListener`, que chama
+  `OrderConciliationPort`.
+
+## Fluxo Principal
+
+1. `BinanceUserStreamConfiguration` registra os beans de User Data Stream quando
+   `binance.api-key` e `binance.api-secret` nao estao em branco.
+2. `ConnectUserStreamUseCase` valida se ha `UserStreamSessionPort` e
+   `ExchangeUserStreamPort` para a exchange.
+3. O use case registra/recupera a conexao `ConnectionKey.userStream("BINANCE")`.
+4. `BinanceUserStreamSessionAdapter` cria uma `BinanceUserStreamSession`.
+5. `BinanceUserStreamSession.open()` pede o `listenKey` via REST.
+6. A sessao agenda keepalive a cada 30 minutos.
+7. O use case conecta o `WebSocketPort` de user stream no URL
+   `wsBaseUrl + "/ws/" + listenKey`.
+8. `OkHttp3ListenerConverter` publica `RawUserDataMessageReceivedEvent` para
+   mensagens recebidas no canal `USER_DATA`.
+9. `ProcessUserMessageEventListener` chama `HandlerProcessUserMessagePort`.
+10. `ProcessUserMessageHandler` usa `ExchangeUserStreamPort` para processar a
+    mensagem raw.
+11. `BinanceUserDataProcessor` roteia pelo campo `e`.
+12. `ExecutionReportProcessor` converte `executionReport` em `OrderDataDto`.
+13. O handler notifica listeners de ordem registrados.
+14. `PortfolioStrategyRunnerOrderUpdateListener` chama `OrderConciliationPort`.
+
+## Listen Key
+
+`ListenKeyManager` encapsula o ciclo REST do listen key:
+
+- `POST /api/v3/userDataStream`: obtem `listenKey`.
+- `PUT /api/v3/userDataStream?listenKey={listenKey}`: keepalive.
+- `DELETE /api/v3/userDataStream?listenKey={listenKey}`: revoke.
+
+Todas as chamadas usam header `X-MBX-APIKEY`.
+
+## Parsing De executionReport
+
+`ExecutionReportProcessor` le campos Binance e cria `OrderDataDto`:
+
+- `i` -> `orderId`
+- `c` -> `clientOrderId`
+- `s` -> `Symbol`
+- `S` -> side
+- `o` -> type
+- `X` -> status
+- `q` -> quantidade total
+- `z` -> quantidade executada acumulada
+- `Z` -> quote acumulado
+- `p` -> preco informado
+- `n` -> fee
+- `r` -> reject reason
+- `T` -> timestamp
+
+O preco executado e calculado como `Z / z` quando `z > 0`; caso contrario fica
+zero.
+
+## Reconexao
+
+Falhas WebSocket publicam `WebSocketFailedEvent`. `ConnectionFailedHandler`:
+
+1. marca a conexao como falha;
+2. agenda reconnect com backoff linear de 5 segundos por tentativa;
+3. para `USER_DATA`, fecha a sessao ativa anterior;
+4. remove a sessao antiga do repositorio;
+5. chama `ConnectUserStreamPort` novamente;
+6. a nova conexao obtem novo `listenKey`.
+
+Fechamento normal por `WebSocketClosedEvent` tambem fecha/revoga a sessao ativa
+quando a conexao nao estava em processo de disconnect manual.
+
+## Variacoes E Falhas
+
+- Sem credenciais Binance: `BinanceUserStreamConfiguration` nao cria os beans.
+- Sem adapters de user stream: `ConnectUserStreamUseCase` retorna vazio.
+- Falha ao obter listen key: a sessao e fechada e o manager recebe status de
+  falha.
+- Mensagem sem campo `e`: resultado de erro, sem notificacao de listener.
+- Evento `e` sem processor registrado: resultado de erro.
+- `executionReport` com side/type/status desconhecido: erro de parse.
+- `clientOrderId` desconhecido ainda passa pelo listener, mas a conciliacao deve
+  descartar sem efeito economico.
+
+## Componentes Principais
+
+| Componente | Papel |
+| --- | --- |
+| `spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceUserStreamConfiguration.java` | Configura WebSocket de user stream, session adapter e processor Binance. |
+| `core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java` | Orquestra abertura de conexao privada por exchange. |
+| `adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamSessionAdapter.java` | Cria sessoes Binance por conexao. |
+| `adapter-binance/src/main/java/com/marmitt/binance/userdata/BinanceUserStreamSession.java` | Abre URL privada e agenda keepalive. |
+| `adapter-binance/src/main/java/com/marmitt/binance/userdata/ListenKeyManager.java` | Obtem, renova e revoga listen key. |
+| `spring-application/src/main/java/com/marmitt/application/spring/adapter/OkHttp3ListenerConverter.java` | Publica eventos raw por canal WebSocket. |
+| `spring-application/src/main/java/com/marmitt/application/spring/handler/ProcessUserMessageEventListener.java` | Consome evento raw de user data de forma async. |
+| `core/src/main/java/com/marmitt/core/application/handler/ProcessUserMessageHandler.java` | Processa payload privado e notifica listeners de ordem. |
+| `adapter-binance/src/main/java/com/marmitt/binance/BinanceUserStreamAdapter.java` | Adapter de processamento do user stream Binance. |
+| `adapter-binance/src/main/java/com/marmitt/binance/processor/receive/BinanceUserDataProcessor.java` | Roteia eventos privados Binance por `e`. |
+| `adapter-binance/src/main/java/com/marmitt/binance/processor/receive/ExecutionReportProcessor.java` | Converte `executionReport` em `OrderDataDto`. |
+| `core/src/main/java/com/marmitt/core/application/handler/connection/ConnectionFailedHandler.java` | Agenda reconnect e renova sessao privada. |
+| `core/src/main/java/com/marmitt/core/application/listener/runner/PortfolioStrategyRunnerOrderUpdateListener.java` | Entrega updates de ordem ao fluxo de conciliacao. |
+
+## Invariantes
+
+- Payload Binance nao deve vazar para o dominio; a borda deve produzir
+  `OrderDataDto`.
+- User stream privado usa `ConnectionKey.userStream`, separado do market stream.
+- Keepalive pertence a sessao Binance, nao ao core.
+- Reconnect de user stream precisa fechar/revogar a sessao anterior antes de
+  abrir nova sessao.
+- Apenas `OrderDataDto` deve ser notificado aos `OrderUpdateListener` no user
+  stream.
+- O efeito economico final pertence a `order-conciliation.md`, nao ao adapter.
+
+## Validacao
+
+- `spring-application/src/test/java/com/marmitt/application/spring/userdata/UserDataStreamConciliationIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/userdata/BinanceListenKeyReconnectIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfigurationIntegrationTest.java`
+- Comando recomendado:
+  `./scripts/gradle-run.ps1 -q :adapter-binance:test :spring-application:test`
+
+## Fontes
+
+- `docs/IMPLEMENTATION_GUIDE.md`, secoes 10 e 15.
+- `/.ai/flows/order-conciliation.md`.
+- `adapter-binance/src/main/java/com/marmitt/binance/userdata/`.
+- `adapter-binance/src/main/java/com/marmitt/binance/processor/receive/`.
+- `core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java`.
+- `core/src/main/java/com/marmitt/core/application/handler/ProcessUserMessageHandler.java`.

--- a/.ai/flows/mock-exchange-runtime.md
+++ b/.ai/flows/mock-exchange-runtime.md
@@ -1,0 +1,188 @@
+# Mock Exchange Runtime
+
+## Objetivo
+
+Descrever como o adapter mock simula conexao local, market data, execucao de
+ordens, cenarios deterministas, consultas REST-like e eventos raw para usar o
+mesmo pipeline de uma exchange real.
+
+O mock existe para desenvolvimento local, testes de fluxo e cenarios
+controlados. Ele deve continuar usando os mesmos contratos internos que os
+adapters reais usam.
+
+## Quando Consultar
+
+- Bugs em testes ou desenvolvimento com exchange `MOCK`.
+- Mudancas em feed simulado, slippage, fees, partial fills ou eventos duplicados.
+- Alteracoes em overrides deterministas por `clientOrderId`.
+- Problemas em boot/recovery usando snapshots mock.
+- Review de mudancas em `MockExchangeAdapter` ou `MockExchangeRuntime`.
+
+## Entradas E Saidas
+
+- Entrada de stream: `StreamSubscriptionRequest`.
+- Entrada de ordem: `SendOrderRequest` ou `SendCancelOrderRequest`.
+- Entrada de consulta: `queryOrderByClientOrderId`, `queryOrderByExchangeOrderId`,
+  `listOpenOrders*`, `queryAccountSnapshot`.
+- Saida de ordem: `OrderDataDto`.
+- Saida de mercado: `MarketDataDto`.
+- Efeitos colaterais: publicacao de `RawMarketMessageReceivedEvent` para entrar
+  no mesmo roteamento WebSocket/eventos usado por exchanges reais.
+
+## Fluxo De Configuracao
+
+1. `MockAdapterConfiguration` cria `LocalEventWebSocketAdapter` e registra a
+   porta WebSocket `MOCK`.
+2. A mesma config cria `MockExchangeAdapter`.
+3. `InMemoryExchangeAdapterRepository` registra as capacidades implementadas:
+   streaming, execucao de ordem, consulta de ordem, consulta de conta e boot
+   readiness.
+4. `MockExchangeAdapter` cria `MockExchangeRuntime`, `MockReceivedMessageProcessor`
+   e `MockSenderMessageProcessor`.
+
+## Conexao Local
+
+`LocalEventWebSocketAdapter` nao abre socket real. Ele:
+
+- marca conexao como ativa;
+- publica `WebSocketConnectedEvent` com canal `MARKET`;
+- publica `WebSocketDisconnectedEvent` em disconnect manual;
+- ignora `sendMessage`, porque o runtime mock ja processa comandos localmente.
+
+Isso permite que o mesmo fluxo post-connection usado por exchanges reais seja
+executado para `MOCK`.
+
+## Feed De Market Data
+
+1. `ConnectMarketStreamUseCase` conecta `MOCK`.
+2. `LocalEventWebSocketAdapter` publica conexao estabelecida.
+3. `PostConnectionEstablishHandler` envia a subscription salva no historico.
+4. `MockSenderMessageProcessor` recebe `StreamSubscriptionRequest`.
+5. `MockExchangeRuntime.handleStream` chama `MockMarketDataFeedEngine`.
+6. O feed cria tarefas por simbolo e publica ticks periodicos.
+7. Cada tick vira `MarketDataDto`.
+8. `MockRawMessagePublisher` serializa o DTO e publica
+   `RawMarketMessageReceivedEvent`.
+9. O fluxo segue por `ProcessMessageHandler` e listeners de preco.
+
+## Execucao De Ordem
+
+1. Chamadas sincronas REST-like usam `MockExchangeAdapter.submitOrder`.
+2. O adapter delega para `MockExchangeRuntime.submitOrderRest`.
+3. O runtime gera `orderId` e salva o mapeamento por `clientOrderId`.
+4. `MockOrderExecutionSimulator.simulateAccepted` cria snapshot `NEW`.
+5. O runtime agenda simulacao assincrona de eventos.
+6. `MockOrderExecutionSimulator.buildScenarioSchedule` gera sequencia de updates.
+7. Cada `MockScheduledOrderEvent` e publicado via `MockRawMessagePublisher`.
+8. `MockReceivedMessageProcessor` desserializa o raw em `OrderDataDto`.
+9. `ProcessMessageHandler` notifica `OrderUpdateListener`.
+10. `PortfolioStrategyRunnerOrderUpdateListener` chama conciliacao.
+
+## Cenarios E Overrides
+
+`MockScenarioConfig.defaultConfig()` define comportamento aleatorio controlado:
+
+- seed fixa;
+- latencia entre 100ms e 400ms;
+- 2 partial fills;
+- chance de duplicatas;
+- chance de out-of-order;
+- chance de cancelamento/expiracao;
+- fee em mesma moeda;
+- slippage para market orders;
+- validacao basica de quantidade, step size e notional;
+- saldos iniciais.
+
+`MockOrderScenarioOverride` permite cenarios deterministas por `clientOrderId`:
+
+- lista ordenada de eventos planejados;
+- status, quantidade executada, preco, fee e reject reason por evento;
+- delay por evento;
+- duplicatas por evento;
+- ordem normal ou reversa.
+
+O override e consumido uma vez quando a ordem correspondente e submetida.
+
+## Consultas E Boot Recovery
+
+O runtime mantem:
+
+- `orderIdByClientOrderId`;
+- `latestEventByOrderId`;
+- planos de falha de consulta por `clientOrderId`;
+- snapshots sem publicacao de callbacks.
+
+Isso suporta:
+
+- `queryOrderByClientOrderId`;
+- `queryOrderByExchangeOrderId`;
+- `listOpenOrdersBySymbol`;
+- `listAllOpenOrders`;
+- `seedQueriedOrderSnapshot`;
+- `registerQueryFailurePlan`.
+
+Esses recursos sao usados por testes de boot/recovery e watchdog sem depender de
+exchange real.
+
+## Variacoes E Falhas
+
+- Runtime parado: submissao retorna snapshot `REJECTED` com
+  `MOCK_LIFECYCLE_STOPPED`; consultas lancam `ExchangeQueryException`.
+- Cancel de ordem desconhecida: retorna `REJECTED` com `ORDER_NOT_FOUND`.
+- Cancel de ordem terminal: retorna o snapshot terminal atual.
+- Ordem invalida por regra de quantidade/notional/saldo: simulador emite
+  `REJECTED`.
+- Eventos duplicados e fora de ordem sao intencionais e devem ser tratados pelo
+  fluxo de conciliacao.
+- Feed desabilitado ou sem pares: subscription nao gera ticks.
+
+## Componentes Principais
+
+| Componente | Papel |
+| --- | --- |
+| `spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockAdapterConfiguration.java` | Registra WebSocket local e adapter mock. |
+| `spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockExchangeAdapter.java` | Expoe capacidades mock para streaming, ordem, query, conta e readiness. |
+| `adapter-mock/src/main/java/com/marmitt/mock/adapter/LocalEventWebSocketAdapter.java` | Simula ciclo de conexao sem socket real. |
+| `adapter-mock/src/main/java/com/marmitt/mock/runtime/MockExchangeRuntime.java` | Orquestra feed, ordens, snapshots, query failures e lifecycle. |
+| `adapter-mock/src/main/java/com/marmitt/mock/processor/MockSenderMessageProcessor.java` | Processa comandos enviados ao mock. |
+| `adapter-mock/src/main/java/com/marmitt/mock/processor/MockReceivedMessageProcessor.java` | Converte payload raw mock em `MarketDataDto` ou `OrderDataDto`. |
+| `adapter-mock/src/main/java/com/marmitt/mock/processor/MockRawMessagePublisher.java` | Publica payloads mock no pipeline raw. |
+| `adapter-mock/src/main/java/com/marmitt/mock/simulator/MockMarketDataFeedEngine.java` | Gera ticks sinteticos de mercado. |
+| `adapter-mock/src/main/java/com/marmitt/mock/simulator/MockOrderExecutionSimulator.java` | Gera lifecycle de ordens, fills, falhas e duplicatas. |
+| `adapter-mock/src/main/java/com/marmitt/mock/config/MockScenarioConfig.java` | Configuracao aleatoria controlada do simulador. |
+| `adapter-mock/src/main/java/com/marmitt/mock/config/MockOrderScenarioOverride.java` | Cenarios deterministas por ordem. |
+| `adapter-mock/src/main/java/com/marmitt/mock/simulator/FeeModel.java` | Calcula fee por incremento executado. |
+| `adapter-mock/src/main/java/com/marmitt/mock/simulator/SlippageModel.java` | Calcula preco executado com slippage. |
+
+## Invariantes
+
+- O mock deve publicar eventos pelo mesmo pipeline raw usado por exchanges reais.
+- Eventos mock de ordem precisam carregar `clientOrderId` para conciliacao.
+- Duplicatas e out-of-order sao cenarios validos; o core deve preservar
+  idempotencia.
+- Overrides deterministas devem ser consumidos uma vez por `clientOrderId`.
+- Snapshots seedados para query nao devem publicar callbacks automaticamente.
+- `LocalEventWebSocketAdapter` nao deve abrir rede real.
+- O mock nao deve introduzir regra de dominio; ele simula exchange e traduz para
+  DTOs internos.
+
+## Validacao
+
+- `adapter-mock/src/test/java/com/marmitt/mock/simulator/MockOrderExecutionSimulatorDeterministicScenarioTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ProcessTradeSignalMockIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderLifecycleMockIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockBuyOrderOverrideIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockSellOrderOverrideIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTerminalOrderOverrideIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTerminalMonotonicityStabilityIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/MockTransientOrderFailureIntegrationTest.java`
+- Comando recomendado:
+  `./scripts/gradle-run.ps1 -q :adapter-mock:test :spring-application:test`
+
+## Fontes
+
+- `/.ai/flows/websocket-event-routing.md`.
+- `/.ai/flows/order-conciliation.md`.
+- `adapter-mock/src/main/java/com/marmitt/mock/`.
+- `spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockExchangeAdapter.java`.
+- `spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockAdapterConfiguration.java`.

--- a/.ai/flows/websocket-event-routing.md
+++ b/.ai/flows/websocket-event-routing.md
@@ -1,0 +1,159 @@
+# WebSocket Event Routing
+
+## Objetivo
+
+Descrever como mensagens WebSocket entram na aplicacao, viram eventos raw,
+sao processadas por adapters de exchange e chegam aos listeners de preco ou
+ordem.
+
+Este fluxo e a ponte entre transporte externo e casos de uso do core. Ele deve
+preservar a separacao entre payload externo, DTO interno e regra de negocio.
+
+## Quando Consultar
+
+- Bugs em mensagens WebSocket que nao chegam aos use cases.
+- Mudancas em `OkHttp3WebSocketAdapter` ou `OkHttp3ListenerConverter`.
+- Alteracoes em `ProcessMessageHandler` ou `ProcessUserMessageHandler`.
+- Problemas de roteamento entre market stream e user data stream.
+- Mudancas em listeners de preco ou ordem.
+- Review de novas exchanges/adapters WebSocket.
+
+## Entradas E Saidas
+
+- Entrada de conexao market: `ConnectMarketStreamUseCase`.
+- Entrada de conexao user data: `ConnectUserStreamUseCase`.
+- Entrada raw: mensagem WebSocket como `String`.
+- Saida de processamento: `MarketDataDto` ou `OrderDataDto`.
+- Efeitos colaterais: notificacao de `PriceUpdateListener` ou
+  `OrderUpdateListener`; atualizacao de estatisticas/estado da conexao.
+
+## Canais
+
+O roteamento separa dois canais:
+
+- `StreamChannel.MARKET`: market data e, em alguns adapters, mensagens de ordem
+  por canal publico/geral.
+- `StreamChannel.USER_DATA`: eventos privados de conta/ordem.
+
+`OkHttp3ListenerConverter` escolhe o evento raw pelo canal:
+
+- `MARKET` -> `RawMarketMessageReceivedEvent`.
+- `USER_DATA` -> `RawUserDataMessageReceivedEvent`.
+
+## Fluxo Market Stream
+
+1. `ConnectMarketStreamUseCase` recebe exchange e `StreamSubscriptionRequest`.
+2. Busca `ExchangeStreamingPort` no `ExchangeAdapterRepositoryPort`.
+3. Registra `ConnectionKey.market(exchangeName)`.
+4. Salva o request no historico da conexao.
+5. Pede ao adapter a URL com `buildConnectionUrl`.
+6. Busca `WebSocketPort` no `WebSocketPortRegistryPort`.
+7. Chama `webSocket.connect(url, exchangeName, connectionId)`.
+8. `OkHttp3ListenerConverter` publica `WebSocketConnectedEvent` no `onOpen`.
+9. `ConnectionStateEventListener` chama handlers de conexao.
+10. `PostConnectionEstablishHandler` envia mensagem de subscribe se o adapter
+    exigir post-connection.
+11. Mensagens recebidas publicam `RawMarketMessageReceivedEvent`.
+12. `ProcessMessageEventListener` chama `ProcessMessageHandler`.
+13. `ProcessMessageHandler` processa a mensagem via `ExchangeStreamingPort`.
+14. Resultado `MarketDataDto` notifica `PriceUpdateListener`.
+15. Resultado `OrderDataDto` notifica `OrderUpdateListener`.
+
+## Fluxo User Data
+
+1. `ConnectUserStreamUseCase` abre a conexao privada e cria a sessao de user
+   stream.
+2. O WebSocket usa listener convertido com canal `USER_DATA`.
+3. Mensagens recebidas publicam `RawUserDataMessageReceivedEvent`.
+4. `ProcessUserMessageEventListener` chama `ProcessUserMessageHandler`.
+5. O handler processa via `ExchangeUserStreamPort`.
+6. Resultado processavel precisa conter `OrderDataDto`.
+7. O handler notifica apenas `OrderUpdateListener`.
+
+## Listeners Registrados
+
+`InMemoryListenerRepository` registra listeners padrao no `@PostConstruct`:
+
+- `MarketDataPriceUpdateListener`: logging/cache simples de ultimo preco.
+- `PortfolioStrategyRunnerPriceUpdateListener`: chama `ProcessTradeSignalPort`.
+- `PortfolioStrategyRunnerOrderUpdateListener`: chama `OrderConciliationPort`.
+
+Isso conecta:
+
+- market data -> `runner-signal-processing.md`;
+- order update -> `order-conciliation.md`.
+
+## Estado Da Conexao
+
+Eventos de conexao sao publicados pelo listener convertido:
+
+- `WebSocketConnectedEvent`
+- `WebSocketClosingEvent`
+- `WebSocketClosedEvent`
+- `WebSocketFailedEvent`
+
+`ConnectionStateEventListener` delega para handlers do core. Falhas podem
+acionar reconnect por `ConnectionFailedHandler`, usando historico de request para
+market stream e nova sessao para user data stream.
+
+## Variacoes E Falhas
+
+- Adapter de streaming ausente: `ConnectMarketStreamUseCase` retorna falha.
+- WebSocket registrado ausente: erro de configuracao ao conectar/enviar.
+- Mensagem raw nula/vazia: handlers rejeitam com erro.
+- Adapter retorna erro/warning sem payload: estatistica de erro da conexao e
+  atualizada e listeners nao sao notificados.
+- Listener individual com exception: erro e logado, mas os demais listeners
+  continuam sendo chamados.
+- User data nao aceita payload diferente de `OrderDataDto`; tipos inesperados sao
+  descartados com warning.
+
+## Componentes Principais
+
+| Componente | Papel |
+| --- | --- |
+| `core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectMarketStreamUseCase.java` | Abre conexao de market stream e guarda historico de subscription. |
+| `core/src/main/java/com/marmitt/core/application/usecase/websocket/ConnectUserStreamUseCase.java` | Abre conexao privada de user data stream. |
+| `core/src/main/java/com/marmitt/core/application/usecase/websocket/SendMessageWebSocketUseCase.java` | Formata/envia mensagens usando adapter da exchange. |
+| `spring-application/src/main/java/com/marmitt/application/spring/adapter/OkHttp3WebSocketAdapter.java` | Implementa `WebSocketPort` com OkHttp. |
+| `spring-application/src/main/java/com/marmitt/application/spring/adapter/OkHttp3ListenerConverter.java` | Converte callbacks OkHttp em eventos internos. |
+| `spring-application/src/main/java/com/marmitt/application/spring/event/RawMarketMessageReceivedEvent.java` | Evento raw para market stream. |
+| `spring-application/src/main/java/com/marmitt/application/spring/event/RawUserDataMessageReceivedEvent.java` | Evento raw para user data stream. |
+| `spring-application/src/main/java/com/marmitt/application/spring/handler/ProcessMessageEventListener.java` | Listener Spring async para market messages. |
+| `spring-application/src/main/java/com/marmitt/application/spring/handler/ProcessUserMessageEventListener.java` | Listener Spring async para user data messages. |
+| `core/src/main/java/com/marmitt/core/application/handler/ProcessMessageHandler.java` | Processa market raw e notifica listeners de preco/ordem. |
+| `core/src/main/java/com/marmitt/core/application/handler/ProcessUserMessageHandler.java` | Processa user data raw e notifica listeners de ordem. |
+| `spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryListenerRepository.java` | Registra listeners padrao. |
+| `spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryWebSocketPortRegistry.java` | Separa portas WebSocket de market e user stream. |
+| `spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryExchangeAdapterRepository.java` | Registra capacidades dos adapters de exchange. |
+
+## Invariantes
+
+- Payload externo deve ser traduzido por adapter antes de tocar listeners de
+  dominio.
+- `MARKET` e `USER_DATA` usam chaves e portas WebSocket separadas.
+- Market stream pode notificar preco e ordem; user data deve notificar somente
+  ordem processavel.
+- Falha em um listener nao pode impedir notificacao dos demais.
+- Reconnect de market depende do historico de subscription; limpar esse historico
+  quebra recuperacao automatica.
+- O core conhece contratos (`ExchangeStreamingPort`, `ExchangeUserStreamPort`),
+  nao detalhes de OkHttp ou payload Binance.
+
+## Validacao
+
+- `spring-application/src/test/java/com/marmitt/application/spring/userdata/UserDataStreamConciliationIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/userdata/BinanceListenKeyReconnectIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/ProcessTradeSignalMockIntegrationTest.java`
+- `spring-application/src/test/java/com/marmitt/application/spring/bootstrap/OrderLifecycleMockIntegrationTest.java`
+- Comando recomendado:
+  `./scripts/gradle-run.ps1 -q :core:test :spring-application:test`
+
+## Fontes
+
+- `/.ai/flows/runner-signal-processing.md`.
+- `/.ai/flows/order-conciliation.md`.
+- `core/src/main/java/com/marmitt/core/application/usecase/websocket/`.
+- `core/src/main/java/com/marmitt/core/application/handler/`.
+- `spring-application/src/main/java/com/marmitt/application/spring/adapter/`.
+- `spring-application/src/main/java/com/marmitt/application/spring/handler/`.


### PR DESCRIPTION
## Summary
- Add Entrega 2 flow maps for Binance User Data Stream, WebSocket event routing, and the mock exchange runtime.
- Update `/.ai/flows/README.md` with the new maps and remove them from pending candidates.
- Mark Entrega 2 as complete in `/.ai/flows/ROADMAP.md` with the delivered files listed.

## Validation
- Docs-only change; inspected the updated Markdown files.
- `rg -n TODO|FIXME|\\.\\.\\. .ai/flows/binance-user-data-stream.md .ai/flows/websocket-event-routing.md .ai/flows/mock-exchange-runtime.md .ai/flows/README.md .ai/flows/ROADMAP.md`: no matches.
- `rg -n [^\\x00-\\x7F] .ai/flows/binance-user-data-stream.md .ai/flows/websocket-event-routing.md .ai/flows/mock-exchange-runtime.md .ai/flows/README.md .ai/flows/ROADMAP.md`: no matches.

## Documentation
- Updated base documentation in `/.ai/flows`.

## Notes
- No code changes; no Gradle validation was required.