### PR TITLE
feat(kill-switch): T8 — Kill Switch via admin API

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/HaltRunnerUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/HaltRunnerUseCase.java
@@ -1,0 +1,58 @@
+package com.marmitt.core.application.usecase.runner;
+
+import com.marmitt.core.dto.runner.response.RunnerHaltResult;
+import com.marmitt.core.enums.RunnerStatus;
+import com.marmitt.core.exceptions.RunnerNotFoundException;
+import com.marmitt.core.ports.inbound.runner.HaltRunnerPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+public class HaltRunnerUseCase implements HaltRunnerPort {
+
+    private final StrategyRunnerRepositoryPort runnerRepository;
+
+    public HaltRunnerUseCase(StrategyRunnerRepositoryPort runnerRepository) {
+        this.runnerRepository = runnerRepository;
+    }
+
+    @Override
+    public List<RunnerHaltResult> haltAll() {
+        List<RunnerHaltResult> affected = runnerRepository.findAllByStatus(RunnerStatus.ACTIVE).stream()
+                .map(runner -> {
+                    runner.halt();
+                    runnerRepository.save(runner);
+                    log.info("kill-switch: runner halted - id={} strategy={} symbol={}",
+                            runner.getId(), runner.getStrategyName(), runner.getSymbol());
+                    return new RunnerHaltResult(
+                            runner.getId(),
+                            runner.getStrategyName(),
+                            runner.getSymbol(),
+                            RunnerStatus.ACTIVE,
+                            RunnerStatus.HALTED);
+                })
+                .toList();
+        log.info("kill-switch: halt-all complete - {} runner(s) halted", affected.size());
+        return affected;
+    }
+
+    @Override
+    public RunnerHaltResult haltById(UUID id) {
+        var runner = runnerRepository.findById(id)
+                .orElseThrow(() -> new RunnerNotFoundException(id));
+
+        RunnerStatus previous = runner.getStatus();
+        if (previous == RunnerStatus.ACTIVE) {
+            runner.halt();
+            runnerRepository.save(runner);
+            log.info("kill-switch: runner halted - id={} strategy={} symbol={}",
+                    runner.getId(), runner.getStrategyName(), runner.getSymbol());
+        }
+
+        return new RunnerHaltResult(runner.getId(), runner.getStrategyName(),
+                runner.getSymbol(), previous, runner.getStatus());
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/HaltRunnerUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/HaltRunnerUseCase.java
@@ -21,7 +21,10 @@ public class HaltRunnerUseCase implements HaltRunnerPort {
 
     @Override
     public List<RunnerHaltResult> haltAll() {
+        // Use canAcceptSignals() as eligibility: excludes isReconciling=true runners so that
+        // boot recovery in progress is not interrupted by a concurrent halt-all.
         List<RunnerHaltResult> affected = runnerRepository.findAllByStatus(RunnerStatus.ACTIVE).stream()
+                .filter(runner -> runner.canAcceptSignals())
                 .map(runner -> {
                     runner.halt();
                     runnerRepository.save(runner);

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/QueryRunnerUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/QueryRunnerUseCase.java
@@ -31,6 +31,13 @@ public class QueryRunnerUseCase implements QueryRunnerPort {
     }
 
     @Override
+    public List<RunnerDto> findAll() {
+        return strategyRunnerRepository.findAll().stream()
+                .map(RunnerDto::fromDomain)
+                .toList();
+    }
+
+    @Override
     public List<RunnerDto> findByPortfolioId(UUID portfolioId) {
         log.debug("Querying runners by portfolioId: {}", portfolioId);
         return strategyRunnerRepository.findByPortfolioId(portfolioId).stream()

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/orderconciliation/TerminationHandler.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/orderconciliation/TerminationHandler.java
@@ -92,7 +92,10 @@ class TerminationHandler {
     private Optional<Position> resolvePosition(Transaction transaction) {
         return Optional.ofNullable(transaction.getTargetLotId())
                 .flatMap(strategyRunnerRepository::findPositionById)
-                .or(() -> strategyRunnerRepository.findOpenPositionByRunnerIdAndSymbol(
+                // Fallback uses findActive (OPEN or CLOSING) so that positions already
+                // locked to CLOSING by this SELL — but not yet dispatched or confirmed —
+                // can still be found and unlocked when the transaction is terminated.
+                .or(() -> strategyRunnerRepository.findActivePositionByRunnerIdAndSymbol(
                         transaction.getRunnerId(), transaction.getSymbol()));
     }
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/BuySignalHandler.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/BuySignalHandler.java
@@ -2,6 +2,7 @@ package com.marmitt.core.application.usecase.runner.processsignal;
 
 import com.marmitt.core.application.exception.CapitalReservationRejectedException;
 import com.marmitt.core.dto.capital.BuyExecutionContext;
+import com.marmitt.core.exceptions.RunnerHaltedException;
 import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,7 +41,7 @@ class BuySignalHandler {
      * descartado sem propagacao de excecao para o chamador.
      */
     public void handle(BuyExecutionContext context, BuyPersistenceAction persistenceAction,
-                       PreDispatchGuard preDispatchGuard) {
+                       PreDispatchGuard preDispatchGuard, OnHaltAction onHaltAction) {
         try {
             persistenceAction.persist(context);
         } catch (CapitalReservationRejectedException ex) {
@@ -51,7 +52,16 @@ class BuySignalHandler {
 
         // Re-check runner status after the persist transaction commits to close the
         // race window between persist-commit and dispatch.
-        preDispatchGuard.check(context.runner().getId());
+        try {
+            preDispatchGuard.check(context.runner().getId());
+        } catch (RunnerHaltedException ex) {
+            // Persist already committed — expire the dangling PENDING transaction so
+            // capital reservation is released immediately rather than waiting for TTL cleanup.
+            log.warn("processBuySignal: runner halted after persist - expiring transaction clientOrderId={}",
+                    context.transaction().getClientOrderId());
+            onHaltAction.expire(context);
+            throw ex;
+        }
 
         orderDispatch.dispatch(intentFactory.buildDispatchCommand(context.runner(), context.transaction()));
         log.debug("dispatch: order sent - clientOrderId={} stays PENDING until exchange confirms",
@@ -66,5 +76,10 @@ class BuySignalHandler {
     @FunctionalInterface
     public interface PreDispatchGuard {
         void check(UUID runnerId);
+    }
+
+    @FunctionalInterface
+    public interface OnHaltAction {
+        void expire(BuyExecutionContext context);
     }
 }

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/BuySignalHandler.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/BuySignalHandler.java
@@ -5,6 +5,8 @@ import com.marmitt.core.dto.capital.BuyExecutionContext;
 import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.UUID;
+
 /**
  * Executa o ramo BUY do pipeline de sinais: persistencia transacional seguida de dispatch.
  *
@@ -37,7 +39,8 @@ class BuySignalHandler {
      * Se a reserva de capital for rejeitada, o metodo retorna sem dispatch — o sinal e
      * descartado sem propagacao de excecao para o chamador.
      */
-    public void handle(BuyExecutionContext context, BuyPersistenceAction persistenceAction) {
+    public void handle(BuyExecutionContext context, BuyPersistenceAction persistenceAction,
+                       PreDispatchGuard preDispatchGuard) {
         try {
             persistenceAction.persist(context);
         } catch (CapitalReservationRejectedException ex) {
@@ -46,18 +49,22 @@ class BuySignalHandler {
             return;
         }
 
+        // Re-check runner status after the persist transaction commits to close the
+        // race window between persist-commit and dispatch.
+        preDispatchGuard.check(context.runner().getId());
+
         orderDispatch.dispatch(intentFactory.buildDispatchCommand(context.runner(), context.transaction()));
         log.debug("dispatch: order sent - clientOrderId={} stays PENDING until exchange confirms",
                 context.transaction().getClientOrderId());
     }
 
-    /**
-     * Seam de persistencia transacional do ramo BUY.
-     * Implementado pela camada de composicao (Spring) para executar
-     * {@link ProcessTradeSignalUseCase#persistBuyAndReserve} dentro de uma transacao.
-     */
     @FunctionalInterface
     public interface BuyPersistenceAction {
         void persist(BuyExecutionContext context);
+    }
+
+    @FunctionalInterface
+    public interface PreDispatchGuard {
+        void check(UUID runnerId);
     }
 }

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
@@ -16,6 +16,7 @@ import com.marmitt.core.ports.outbound.repository.PortfolioRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import com.marmitt.core.exceptions.ConcurrentPositionLockException;
+import com.marmitt.core.exceptions.RunnerHaltedException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigDecimal;
@@ -116,6 +117,14 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
      * mas antes do ACK da exchange, o sistema pode recuperar o estado pelo clientOrderId.
      */
     protected void persistBuyAndReserve(BuyExecutionContext context) {
+        // Re-read runner inside the transaction to close the race with the kill switch.
+        // PostgreSQL READ COMMITTED ensures this sees any HALTED status committed since the signal was loaded.
+        StrategyRunner current = strategyRunnerRepository.findById(context.runner().getId())
+                .orElseThrow(() -> new IllegalStateException("Runner disappeared mid-signal: " + context.runner().getId()));
+        if (!current.canAcceptSignals()) {
+            throw new RunnerHaltedException(context.runner().getId());
+        }
+
         strategyRunnerRepository.saveTransaction(context.transaction());
         capitalReservationPolicy.validateAndReserve(
                 context.capitalRequest(), context.runner(), context.precomputedExposure());
@@ -128,6 +137,12 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
     }
 
     protected void persistSellAndLockPosition(Transaction transaction, Position targetPosition) {
+        StrategyRunner current = strategyRunnerRepository.findById(transaction.getRunnerId())
+                .orElseThrow(() -> new IllegalStateException("Runner disappeared mid-signal: " + transaction.getRunnerId()));
+        if (!current.canAcceptSignals()) {
+            throw new RunnerHaltedException(transaction.getRunnerId());
+        }
+
         strategyRunnerRepository.saveTransaction(transaction);
         boolean locked = strategyRunnerRepository.tryLockPositionForSell(
                 targetPosition.getId(),
@@ -163,6 +178,9 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
 
             try {
                 processRunner(runner, strategyInput, marketData.price());
+            } catch (RunnerHaltedException e) {
+                log.warn("priceUpdate: signal discarded - runner halted mid-flight runnerId={} symbol={}",
+                        runner.getId(), symbol);
             } catch (ConcurrentPositionLockException e) {
                 log.warn("priceUpdate: concurrent SELL conflict for runner={} symbol={} - tick discarded (position already locked by another thread)",
                         runner.getId(), symbol);

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
@@ -144,6 +144,25 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
                 context.runner().getPortfolioId());
     }
 
+    private void expirePendingSell(Transaction tx) {
+        OrderDataDto rejected = new OrderDataDto(
+                null,
+                tx.getClientOrderId(),
+                Symbol.of(tx.getSymbol()),
+                OrderDataDto.OrderSide.SELL,
+                OrderDataDto.OrderType.LIMIT,
+                tx.getQuantity(),
+                BigDecimal.ZERO,
+                tx.getPrice(),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                OrderDataDto.OrderStatus.REJECTED,
+                "Runner halted mid-flight — signal expired before dispatch",
+                Instant.now()
+        );
+        orderConciliation.execute(rejected);
+    }
+
     private void expirePendingBuy(BuyExecutionContext context) {
         Transaction tx = context.transaction();
         OrderDataDto rejected = new OrderDataDto(
@@ -268,7 +287,8 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
                     this::checkRunnerNotHalted, this::expirePendingBuy);
         } else {
             sellSignalHandler.handle(runner, signal, transaction,
-                    this::transactionalPersistSellAndLockPosition, this::checkRunnerNotHalted);
+                    this::transactionalPersistSellAndLockPosition, this::checkRunnerNotHalted,
+                    this::expirePendingSell);
         }
     }
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
@@ -8,6 +8,9 @@ import com.marmitt.core.dto.strategy.StrategyContextDto;
 import com.marmitt.core.dto.strategy.StrategyInputDto;
 import com.marmitt.core.dto.strategy.StrategyOutputDto;
 import com.marmitt.core.dto.websocket.data.MarketDataDto;
+import com.marmitt.core.domain.Symbol;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.ports.inbound.runner.OrderConciliationPort;
 import com.marmitt.core.ports.inbound.runner.ProcessTradeSignalPort;
 import com.marmitt.core.ports.outbound.strategy.TradingStrategy;
 import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
@@ -20,6 +23,7 @@ import com.marmitt.core.exceptions.RunnerHaltedException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -62,6 +66,7 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
     private static final BigDecimal MINIMUM_OPERATION_AMOUNT = BigDecimal.valueOf(10);
 
     private final StrategyRunnerRepositoryPort strategyRunnerRepository;
+    private final OrderConciliationPort orderConciliation;
 
     private final RunnerSignalPolicy signalPolicy;
     private final StrategySignalEvaluator signalEvaluator;
@@ -76,8 +81,10 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
                                         StrategyRepositoryPort strategyRepository,
                                         GlobalBalanceRepositoryPort globalBalanceRepository,
                                         PortfolioRepositoryPort portfolioRepository,
-                                        OrderDispatchPort orderDispatch) {
+                                        OrderDispatchPort orderDispatch,
+                                        OrderConciliationPort orderConciliation) {
         this.strategyRunnerRepository = strategyRunnerRepository;
+        this.orderConciliation = orderConciliation;
 
         this.signalPolicy = new RunnerSignalPolicy();
         this.signalEvaluator = new StrategySignalEvaluator(strategyRepository);
@@ -135,6 +142,26 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
                 context.runner().getId(),
                 context.capitalRequest().amount(),
                 context.runner().getPortfolioId());
+    }
+
+    private void expirePendingBuy(BuyExecutionContext context) {
+        Transaction tx = context.transaction();
+        OrderDataDto rejected = new OrderDataDto(
+                null,
+                tx.getClientOrderId(),
+                Symbol.of(tx.getSymbol()),
+                OrderDataDto.OrderSide.BUY,
+                OrderDataDto.OrderType.LIMIT,
+                tx.getQuantity(),
+                BigDecimal.ZERO,
+                tx.getPrice(),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                OrderDataDto.OrderStatus.REJECTED,
+                "Runner halted mid-flight — signal expired before dispatch",
+                Instant.now()
+        );
+        orderConciliation.execute(rejected);
     }
 
     private void checkRunnerNotHalted(UUID runnerId) {
@@ -238,7 +265,7 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
             BuyExecutionContext buyContext = tradeIntentFactory
                     .buildBuyExecutionContext(runner, transaction, precomputedExposure);
             buySignalHandler.handle(buyContext, this::transactionalPersistBuyAndReserve,
-                    this::checkRunnerNotHalted);
+                    this::checkRunnerNotHalted, this::expirePendingBuy);
         } else {
             sellSignalHandler.handle(runner, signal, transaction,
                     this::transactionalPersistSellAndLockPosition, this::checkRunnerNotHalted);

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Orquestrador principal do fluxo market data → decisao de trade → ordem na exchange.
@@ -136,6 +137,14 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
                 context.runner().getPortfolioId());
     }
 
+    private void checkRunnerNotHalted(UUID runnerId) {
+        StrategyRunner current = strategyRunnerRepository.findById(runnerId)
+                .orElseThrow(() -> new IllegalStateException("Runner disappeared mid-signal: " + runnerId));
+        if (!current.canAcceptSignals()) {
+            throw new RunnerHaltedException(runnerId);
+        }
+    }
+
     protected void persistSellAndLockPosition(Transaction transaction, Position targetPosition) {
         StrategyRunner current = strategyRunnerRepository.findById(transaction.getRunnerId())
                 .orElseThrow(() -> new IllegalStateException("Runner disappeared mid-signal: " + transaction.getRunnerId()));
@@ -228,9 +237,11 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
                     : null;
             BuyExecutionContext buyContext = tradeIntentFactory
                     .buildBuyExecutionContext(runner, transaction, precomputedExposure);
-            buySignalHandler.handle(buyContext, this::transactionalPersistBuyAndReserve);
+            buySignalHandler.handle(buyContext, this::transactionalPersistBuyAndReserve,
+                    this::checkRunnerNotHalted);
         } else {
-            sellSignalHandler.handle(runner, signal, transaction, this::transactionalPersistSellAndLockPosition);
+            sellSignalHandler.handle(runner, signal, transaction,
+                    this::transactionalPersistSellAndLockPosition, this::checkRunnerNotHalted);
         }
     }
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/SellSignalHandler.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/SellSignalHandler.java
@@ -4,13 +4,13 @@ import com.marmitt.core.domain.runner.Position;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
 import com.marmitt.core.dto.strategy.StrategyOutputDto;
+import com.marmitt.core.exceptions.RunnerHaltedException;
 import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.UUID;
-
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Executa o ramo SELL do pipeline de sinais: resolucao do lote alvo, lock transacional
@@ -52,7 +52,8 @@ class SellSignalHandler {
                        StrategyOutputDto signal,
                        Transaction transaction,
                        SellPersistenceAction persistenceAction,
-                       BuySignalHandler.PreDispatchGuard preDispatchGuard) {
+                       BuySignalHandler.PreDispatchGuard preDispatchGuard,
+                       OnHaltAction onHaltAction) {
         Optional<Position> targetPosition = findTargetPosition(runner, signal);
         if (targetPosition.isEmpty()) {
             log.warn("processSellSignal: SELL signal discarded - no open position for runner={} symbol={}",
@@ -62,7 +63,16 @@ class SellSignalHandler {
 
         persistenceAction.persist(transaction, targetPosition.get());
 
-        preDispatchGuard.check(runner.getId());
+        try {
+            preDispatchGuard.check(runner.getId());
+        } catch (RunnerHaltedException ex) {
+            // Persist already committed — expire the SELL transaction so the position
+            // lock is released immediately via TerminationHandler.findAndUnlockPosition().
+            log.warn("processSellSignal: runner halted after persist - expiring transaction clientOrderId={}",
+                    transaction.getClientOrderId());
+            onHaltAction.expire(transaction);
+            throw ex;
+        }
 
         orderDispatch.dispatch(intentFactory.buildDispatchCommand(runner, transaction));
         log.debug("dispatch: order sent - clientOrderId={} stays PENDING until exchange confirms",
@@ -84,5 +94,10 @@ class SellSignalHandler {
     @FunctionalInterface
     public interface SellPersistenceAction {
         void persist(Transaction transaction, Position targetPosition);
+    }
+
+    @FunctionalInterface
+    public interface OnHaltAction {
+        void expire(Transaction transaction);
     }
 }

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/SellSignalHandler.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/SellSignalHandler.java
@@ -8,6 +8,8 @@ import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.UUID;
+
 import java.util.Optional;
 
 /**
@@ -49,7 +51,8 @@ class SellSignalHandler {
     public void handle(StrategyRunner runner,
                        StrategyOutputDto signal,
                        Transaction transaction,
-                       SellPersistenceAction persistenceAction) {
+                       SellPersistenceAction persistenceAction,
+                       BuySignalHandler.PreDispatchGuard preDispatchGuard) {
         Optional<Position> targetPosition = findTargetPosition(runner, signal);
         if (targetPosition.isEmpty()) {
             log.warn("processSellSignal: SELL signal discarded - no open position for runner={} symbol={}",
@@ -58,6 +61,8 @@ class SellSignalHandler {
         }
 
         persistenceAction.persist(transaction, targetPosition.get());
+
+        preDispatchGuard.check(runner.getId());
 
         orderDispatch.dispatch(intentFactory.buildDispatchCommand(runner, transaction));
         log.debug("dispatch: order sent - clientOrderId={} stays PENDING until exchange confirms",

--- a/core/src/main/java/com/marmitt/core/domain/runner/StrategyRunner.java
+++ b/core/src/main/java/com/marmitt/core/domain/runner/StrategyRunner.java
@@ -70,6 +70,7 @@ public class StrategyRunner {
     private boolean isReconciling;
 
     private final Instant createdAt;
+    private Instant statusChangedAt;
     private Instant lastReconciliationAt;
 
     /**
@@ -119,6 +120,7 @@ public class StrategyRunner {
         this.status = RunnerStatus.CREATED;
         this.isReconciling = false;
         this.createdAt = Instant.now();
+        this.statusChangedAt = this.createdAt;
         this.lastReconciliationAt = null;
         this.archivedAt = null;
         this.version = null;
@@ -145,6 +147,7 @@ public class StrategyRunner {
             BigDecimal dedicatedBudget,
             boolean isReconciling,
             Instant createdAt,
+            Instant statusChangedAt,
             Instant lastReconciliationAt,
             Instant archivedAt,
             Long version
@@ -168,6 +171,7 @@ public class StrategyRunner {
         this.dedicatedBudget = dedicatedBudget;
         this.isReconciling = isReconciling;
         this.createdAt = Objects.requireNonNull(createdAt, "createdAt cannot be null");
+        this.statusChangedAt = statusChangedAt != null ? statusChangedAt : createdAt;
         this.lastReconciliationAt = lastReconciliationAt;
         this.archivedAt = archivedAt;
         this.version = version;
@@ -184,6 +188,7 @@ public class StrategyRunner {
     public void startInitializing() {
         requireStatus(RunnerStatus.CREATED);
         this.status = RunnerStatus.INITIALIZING;
+        this.statusChangedAt = Instant.now();
         this.isReconciling = true;
     }
 
@@ -194,6 +199,7 @@ public class StrategyRunner {
     public void activate() {
         requireStatus(RunnerStatus.INITIALIZING);
         this.status = RunnerStatus.ACTIVE;
+        this.statusChangedAt = Instant.now();
         this.isReconciling = false;
         this.lastReconciliationAt = Instant.now();
     }
@@ -205,6 +211,7 @@ public class StrategyRunner {
     public void halt() {
         requireStatus(RunnerStatus.ACTIVE);
         this.status = RunnerStatus.HALTED;
+        this.statusChangedAt = Instant.now();
     }
 
     /**
@@ -214,6 +221,7 @@ public class StrategyRunner {
     public void resume() {
         requireStatus(RunnerStatus.HALTED);
         this.status = RunnerStatus.ACTIVE;
+        this.statusChangedAt = Instant.now();
     }
 
     /**
@@ -226,6 +234,7 @@ public class StrategyRunner {
                     "Cannot start terminating from status: " + this.status);
         }
         this.status = RunnerStatus.TERMINATING;
+        this.statusChangedAt = Instant.now();
     }
 
     /**
@@ -235,6 +244,7 @@ public class StrategyRunner {
     public void archive() {
         requireStatus(RunnerStatus.TERMINATING);
         this.status = RunnerStatus.ARCHIVED;
+        this.statusChangedAt = Instant.now();
         this.archivedAt = Instant.now();
     }
 

--- a/core/src/main/java/com/marmitt/core/dto/runner/response/RunnerDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/runner/response/RunnerDto.java
@@ -18,6 +18,7 @@ public record RunnerDto(
         String exchangeId,
         Set<String> allowedMarketDataSources,
         RunnerStatus status,
+        Instant statusChangedAt,
         Instant createdAt
 ) {
     public static RunnerDto fromDomain(StrategyRunner runner) {
@@ -30,6 +31,7 @@ public record RunnerDto(
                 .exchangeId(runner.getExchangeId())
                 .allowedMarketDataSources(runner.getAllowedMarketDataSources())
                 .status(runner.getStatus())
+                .statusChangedAt(runner.getStatusChangedAt())
                 .createdAt(runner.getCreatedAt())
                 .build();
     }

--- a/core/src/main/java/com/marmitt/core/dto/runner/response/RunnerHaltResult.java
+++ b/core/src/main/java/com/marmitt/core/dto/runner/response/RunnerHaltResult.java
@@ -1,0 +1,13 @@
+package com.marmitt.core.dto.runner.response;
+
+import com.marmitt.core.enums.RunnerStatus;
+
+import java.util.UUID;
+
+public record RunnerHaltResult(
+        UUID id,
+        String strategyName,
+        String symbol,
+        RunnerStatus previousStatus,
+        RunnerStatus newStatus
+) {}

--- a/core/src/main/java/com/marmitt/core/exceptions/RunnerHaltedException.java
+++ b/core/src/main/java/com/marmitt/core/exceptions/RunnerHaltedException.java
@@ -1,0 +1,10 @@
+package com.marmitt.core.exceptions;
+
+import java.util.UUID;
+
+public class RunnerHaltedException extends RuntimeException {
+
+    public RunnerHaltedException(UUID runnerId) {
+        super("Signal discarded — runner is halted: " + runnerId);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/exceptions/RunnerNotFoundException.java
+++ b/core/src/main/java/com/marmitt/core/exceptions/RunnerNotFoundException.java
@@ -1,0 +1,10 @@
+package com.marmitt.core.exceptions;
+
+import java.util.UUID;
+
+public class RunnerNotFoundException extends RuntimeException {
+
+    public RunnerNotFoundException(UUID runnerId) {
+        super("Runner not found: " + runnerId);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/ports/inbound/runner/HaltRunnerPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/runner/HaltRunnerPort.java
@@ -1,0 +1,13 @@
+package com.marmitt.core.ports.inbound.runner;
+
+import com.marmitt.core.dto.runner.response.RunnerHaltResult;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface HaltRunnerPort {
+
+    List<RunnerHaltResult> haltAll();
+
+    RunnerHaltResult haltById(UUID id);
+}

--- a/core/src/main/java/com/marmitt/core/ports/inbound/runner/QueryRunnerPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/runner/QueryRunnerPort.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 
 public interface QueryRunnerPort {
 
+    List<RunnerDto> findAll();
+
     List<RunnerDto> findByPortfolioId(UUID portfolioId);
 
     List<TransactionDto> findTransactionsByRunnerId(UUID runnerId);

--- a/core/src/main/java/com/marmitt/core/ports/outbound/repository/StrategyRunnerRepositoryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/repository/StrategyRunnerRepositoryPort.java
@@ -4,6 +4,7 @@ import com.marmitt.core.domain.runner.Position;
 import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
 import com.marmitt.core.domain.runner.TransactionMatch;
+import com.marmitt.core.enums.RunnerStatus;
 import com.marmitt.core.enums.TransactionStatus;
 
 import java.util.Collection;
@@ -34,6 +35,12 @@ public interface StrategyRunnerRepositoryPort {
      * Usa optimistic locking via campo {@code version}.
      */
     void save(StrategyRunner runner);
+
+    /** Busca todos os Runners (independente de status). */
+    List<StrategyRunner> findAll();
+
+    /** Busca todos os Runners com o status especificado. */
+    List<StrategyRunner> findAllByStatus(RunnerStatus status);
 
     /** Busca Runner por PK. */
     Optional<StrategyRunner> findById(UUID runnerId);

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCaseTest.java
@@ -425,6 +425,7 @@ class RecoverTransactionStatusUseCaseTest {
                 null,
                 false,
                 Instant.now(),
+                Instant.now(),
                 null,
                 null,
                 0L

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -13,7 +13,7 @@ Trilha de tarefas para habilitar operação com a API da Binance (testnet), pré
 | T5  | REST API Binance                | Alta         | Claude      | Concluído     |
 | T6  | Exchange Symbol Filters         | Média        | Codex       | Concluído     |
 | T7  | Boot Readiness real             | Média        | Codex       | Concluído     |
-| T8  | Kill Switch                     | Média        | Codex       | Pendente      |
+| T8  | Kill Switch                     | Média        | Codex       | Concluído     |
 | T9  | Observabilidade Docker Compose  | Média        | Codex       | Concluído     |
 | T10 | Otimização da suíte de integração | Média      | Codex       | Pendente      |
 | T11 | Order Quantity Normalization Before Persist | Média | Codex  | Pendente      |

--- a/docs/tasks/T8-kill-switch.md
+++ b/docs/tasks/T8-kill-switch.md
@@ -3,7 +3,7 @@
 **Complexidade:** Média  
 **Responsável:** Codex  
 **Dependências:** nenhuma  
-**Status:** Pendente
+**Status:** Concluído
 
 ---
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/AdminApiKeyInterceptor.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/AdminApiKeyInterceptor.java
@@ -1,0 +1,26 @@
+package com.marmitt.application.spring.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AdminApiKeyInterceptor implements HandlerInterceptor {
+
+    private final String adminApiKey;
+
+    public AdminApiKeyInterceptor(@Value("${admin.api.key:}") String adminApiKey) {
+        this.adminApiKey = adminApiKey;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (!adminApiKey.isBlank() && adminApiKey.equals(request.getHeader("X-Admin-Key"))) {
+            return true;
+        }
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return false;
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/AdminWebMvcConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/AdminWebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.marmitt.application.spring.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AdminWebMvcConfig implements WebMvcConfigurer {
+
+    private final AdminApiKeyInterceptor adminApiKeyInterceptor;
+
+    public AdminWebMvcConfig(AdminApiKeyInterceptor adminApiKeyInterceptor) {
+        this.adminApiKeyInterceptor = adminApiKeyInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(adminApiKeyInterceptor).addPathPatterns("/api/admin/**");
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
@@ -18,6 +18,7 @@ import com.marmitt.core.dto.capital.BuyExecutionContext;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.ports.inbound.runner.CreateRunnerPort;
 import com.marmitt.core.ports.inbound.runner.HaltRunnerPort;
+import com.marmitt.core.ports.inbound.runner.OrderConciliationPort;
 import com.marmitt.core.ports.inbound.runner.RecoverStaleTransactionsPort;
 import com.marmitt.core.ports.inbound.runner.QueryRunnerPort;
 import com.marmitt.core.ports.inbound.runner.ProcessTradeSignalPort;
@@ -116,14 +117,16 @@ public class RunnerConfig {
             StrategyRepositoryPort strategyRepository,
             GlobalBalanceRepositoryPort globalBalanceRepository,
             PortfolioRepositoryPort portfolioRepository,
-            OrderDispatchPort orderDispatch) {
+            OrderDispatchPort orderDispatch,
+            OrderConciliationPort orderConciliation) {
 
         return new ProcessTradeSignalUseCase(
                 strategyRunnerRepository,
                 strategyRepository,
                 globalBalanceRepository,
                 portfolioRepository,
-                orderDispatch) {
+                orderDispatch,
+                orderConciliation) {
 
             @Override
             public void transactionalPersistBuyAndReserve(BuyExecutionContext context) {

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/RunnerConfig.java
@@ -3,6 +3,7 @@ package com.marmitt.application.spring.config.core;
 import com.marmitt.application.spring.bootstrap.PortfolioReservationTtlProperties;
 import com.marmitt.application.spring.bootstrap.RunnerBootPhase3Properties;
 import com.marmitt.core.application.usecase.runner.CreateRunnerUseCase;
+import com.marmitt.core.application.usecase.runner.HaltRunnerUseCase;
 import com.marmitt.core.application.usecase.runner.RecoverStaleTransactionsUseCase;
 import com.marmitt.core.application.usecase.runner.RecoverTransactionStatusUseCase;
 import com.marmitt.core.application.usecase.runner.RunnerBootRecoveryUseCase;
@@ -16,6 +17,7 @@ import com.marmitt.core.domain.runner.Transaction;
 import com.marmitt.core.dto.capital.BuyExecutionContext;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.ports.inbound.runner.CreateRunnerPort;
+import com.marmitt.core.ports.inbound.runner.HaltRunnerPort;
 import com.marmitt.core.ports.inbound.runner.RecoverStaleTransactionsPort;
 import com.marmitt.core.ports.inbound.runner.QueryRunnerPort;
 import com.marmitt.core.ports.inbound.runner.ProcessTradeSignalPort;
@@ -155,6 +157,13 @@ public class RunnerConfig {
             StrategyRunnerRepositoryPort strategyRunnerRepository
     ) {
         return new QueryRunnerUseCase(strategyRunnerRepository);
+    }
+
+    @Bean
+    public HaltRunnerPort haltRunner(
+            StrategyRunnerRepositoryPort strategyRunnerRepository
+    ) {
+        return new HaltRunnerUseCase(strategyRunnerRepository);
     }
 
     @Bean

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/AdminController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/AdminController.java
@@ -1,26 +1,59 @@
 package com.marmitt.application.spring.controller;
 
 import com.marmitt.binance.filters.SymbolFilterCache;
+import com.marmitt.core.dto.runner.response.RunnerDto;
+import com.marmitt.core.dto.runner.response.RunnerHaltResult;
+import com.marmitt.core.exceptions.RunnerNotFoundException;
+import com.marmitt.core.ports.inbound.runner.HaltRunnerPort;
+import com.marmitt.core.ports.inbound.runner.QueryRunnerPort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/admin")
 public class AdminController {
 
     private final List<SymbolFilterCache> filterCaches;
+    private final HaltRunnerPort haltRunner;
+    private final QueryRunnerPort queryRunner;
 
-    public AdminController(List<SymbolFilterCache> filterCaches) {
+    public AdminController(List<SymbolFilterCache> filterCaches,
+                           HaltRunnerPort haltRunner,
+                           QueryRunnerPort queryRunner) {
         this.filterCaches = filterCaches;
+        this.haltRunner = haltRunner;
+        this.queryRunner = queryRunner;
     }
 
     @PostMapping("/filters/refresh")
     public ResponseEntity<Void> refreshFilters() {
         filterCaches.forEach(SymbolFilterCache::invalidateAll);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/runners/halt")
+    public ResponseEntity<List<RunnerHaltResult>> haltAll() {
+        return ResponseEntity.ok(haltRunner.haltAll());
+    }
+
+    @PostMapping("/runners/{id}/halt")
+    public ResponseEntity<RunnerHaltResult> haltById(@PathVariable UUID id) {
+        try {
+            return ResponseEntity.ok(haltRunner.haltById(id));
+        } catch (RunnerNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @GetMapping("/runners/status")
+    public ResponseEntity<List<RunnerDto>> runnersStatus() {
+        return ResponseEntity.ok(queryRunner.findAll());
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
@@ -10,6 +10,7 @@ import com.marmitt.core.domain.runner.StrategyRunner;
 import com.marmitt.core.domain.runner.Transaction;
 import com.marmitt.core.domain.runner.TransactionMatch;
 import com.marmitt.core.enums.PositionStatus;
+import com.marmitt.core.enums.RunnerStatus;
 import com.marmitt.core.enums.TransactionStatus;
 import com.marmitt.core.exceptions.ConcurrentPositionLockException;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
@@ -25,6 +26,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.StreamSupport;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
@@ -93,6 +95,26 @@ public class JdbcStrategyRunnerRepositoryAdapter implements StrategyRunnerReposi
         Optional<StrategyRunner> result = runnerRepo.findByShortCodeAndPortfolioId(shortCode, portfolioId)
                 .map(StrategyRunnerEntityMapper::toDomain);
         log.trace("[REPO] runner.findByShortCode({}, {}) - {}ms", shortCode, portfolioId, RepoTiming.elapsedMs(start));
+        return result;
+    }
+
+    @Override
+    public List<StrategyRunner> findAll() {
+        long start = System.nanoTime();
+        List<StrategyRunner> result = StreamSupport.stream(runnerRepo.findAll().spliterator(), false)
+                .map(StrategyRunnerEntityMapper::toDomain)
+                .toList();
+        log.trace("[REPO] runner.findAll() - {}ms - {} results", RepoTiming.elapsedMs(start), result.size());
+        return result;
+    }
+
+    @Override
+    public List<StrategyRunner> findAllByStatus(RunnerStatus status) {
+        long start = System.nanoTime();
+        List<StrategyRunner> result = runnerRepo.findAllByStatus(status.name()).stream()
+                .map(StrategyRunnerEntityMapper::toDomain)
+                .toList();
+        log.trace("[REPO] runner.findAllByStatus({}) - {}ms - {} results", status, RepoTiming.elapsedMs(start), result.size());
         return result;
     }
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/entity/StrategyRunnerEntity.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/entity/StrategyRunnerEntity.java
@@ -66,6 +66,7 @@ public class StrategyRunnerEntity {
     private boolean isReconciling;
 
     private Instant createdAt;
+    private Instant statusChangedAt;
     private Instant lastReconciliationAt;
     private Instant archivedAt;
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/mapper/StrategyRunnerEntityMapper.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/mapper/StrategyRunnerEntityMapper.java
@@ -39,6 +39,7 @@ public class StrategyRunnerEntityMapper {
                 .dedicatedBudget(domain.getDedicatedBudget())
                 .isReconciling(domain.isReconciling())
                 .createdAt(domain.getCreatedAt())
+                .statusChangedAt(domain.getStatusChangedAt())
                 .lastReconciliationAt(domain.getLastReconciliationAt())
                 .archivedAt(domain.getArchivedAt())
                 .version(domain.getVersion())
@@ -64,6 +65,7 @@ public class StrategyRunnerEntityMapper {
                 entity.getDedicatedBudget(),
                 entity.isReconciling(),
                 entity.getCreatedAt(),
+                entity.getStatusChangedAt(),
                 entity.getLastReconciliationAt(),
                 entity.getArchivedAt(),
                 entity.getVersion()

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/StrategyRunnerJdbcRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/StrategyRunnerJdbcRepository.java
@@ -57,4 +57,7 @@ public interface StrategyRunnerJdbcRepository extends CrudRepository<StrategyRun
             @Param("shortCode") String shortCode,
             @Param("portfolioId") UUID portfolioId
     );
+
+    @Query("SELECT * FROM strategy_runners WHERE status = :status")
+    List<StrategyRunnerEntity> findAllByStatus(@Param("status") String status);
 }

--- a/spring-application/src/main/resources/application.yml
+++ b/spring-application/src/main/resources/application.yml
@@ -100,3 +100,7 @@ runner:
       interval-ms: 60000
       stale-threshold-ms: 30000
       max-per-run: 50
+
+admin:
+  api:
+    key: ${ADMIN_API_KEY:}

--- a/spring-application/src/main/resources/db/migration/V10__add_status_changed_at_to_strategy_runners.sql
+++ b/spring-application/src/main/resources/db/migration/V10__add_status_changed_at_to_strategy_runners.sql
@@ -1,0 +1,9 @@
+ALTER TABLE strategy_runners
+    ADD COLUMN IF NOT EXISTS status_changed_at TIMESTAMPTZ;
+
+UPDATE strategy_runners
+   SET status_changed_at = created_at
+ WHERE status_changed_at IS NULL;
+
+ALTER TABLE strategy_runners
+    ALTER COLUMN status_changed_at SET NOT NULL;

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorBootMinimumTest.java
@@ -230,6 +230,7 @@ class BootOrchestratorBootMinimumTest {
                 null,
                 false,
                 Instant.now(),
+                Instant.now(),
                 null,
                 null,
                 0L

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorDlqOperationalTest.java
@@ -236,6 +236,7 @@ class BootOrchestratorDlqOperationalTest {
                 null,
                 false,
                 Instant.now(),
+                Instant.now(),
                 null,
                 null,
                 0L

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/BootOrchestratorObservabilityTest.java
@@ -245,6 +245,7 @@ class BootOrchestratorObservabilityTest {
                 null,
                 false,
                 Instant.now(),
+                Instant.now(),
                 null,
                 null,
                 0L

--- a/spring-application/src/test/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapterTest.java
@@ -250,6 +250,7 @@ class CapitalDeadLetterReprocessingAdapterTest {
                 null,
                 false,
                 Instant.now(),
+                Instant.now(),
                 null,
                 null,
                 0L

--- a/spring-application/src/test/java/com/marmitt/application/spring/handler/CapitalEventListenerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/handler/CapitalEventListenerTest.java
@@ -240,6 +240,7 @@ class CapitalEventListenerTest {
                 null,
                 false,
                 Instant.now(),
+                Instant.now(),
                 null,
                 null,
                 0L


### PR DESCRIPTION
## Summary

- `POST /api/admin/runners/halt` — coloca todos os runners `ACTIVE` em `HALTED`; retorna lista com id, strategyName, symbol, previousStatus, newStatus
- `POST /api/admin/runners/{id}/halt` — coloca runner específico em `HALTED`; 404 se não existir; idempotente se já `HALTED`
- `GET /api/admin/runners/status` — lista todos os runners e status atual
- Todos os endpoints `/api/admin/**` exigem `X-Admin-Key` header; ausente ou incorreto → 401

## Arquivos novos

| Arquivo | Responsabilidade |
|---|---|
| `core/.../HaltRunnerPort.java` | Port inbound para halt de runners |
| `core/.../HaltRunnerUseCase.java` | Lógica de halt usando `StrategyRunner.halt()` + persist |
| `core/.../RunnerHaltResult.java` | DTO de resposta (id, strategyName, symbol, previousStatus, newStatus) |
| `core/.../RunnerNotFoundException.java` | Exceção para runner inexistente (→ 404) |
| `AdminApiKeyInterceptor.java` | Verifica `X-Admin-Key` em todas as rotas `/api/admin/**` |
| `AdminWebMvcConfig.java` | Registra o interceptor via `WebMvcConfigurer` |

## Comportamento após halt

- Runners `HALTED` não processam sinais (`canAcceptSignals()` retorna false para status não-`ACTIVE`)
- Status persiste no banco — restart não reverte para `ACTIVE`
- Ordens em voo continuam sendo conciliadas normalmente pelo User Data Stream
- Reativação manual via endpoint futuro (não incluído nesta tarefa)

## Validation

- `:core:compileJava :spring-application:compileJava` — BUILD SUCCESSFUL
- Suite completa `spring-application` — BUILD SUCCESSFUL, zero regressões

🤖 Generated with [Claude Code](https://claude.com/claude-code)