### PR TITLE
feat(observability): T9 — Prometheus + Grafana via Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     volumes:
       - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,40 @@ services:
       timeout: 5s
       retries: 5
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: ctrade-prometheus
+    restart: unless-stopped
+    profiles: [observability]
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.enable-lifecycle"
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: ctrade-grafana
+    restart: unless-stopped
+    profiles: [observability]
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ctrade123
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+
 volumes:
   postgres_data:
+  prometheus_data:
+  grafana_data:

--- a/docker/grafana/provisioning/dashboards/ctrade.json
+++ b/docker/grafana/provisioning/dashboards/ctrade.json
@@ -1,0 +1,180 @@
+{
+  "uid": "ctrade-staging",
+  "title": "CTrade — Staging",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["ctrade"],
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Boot runs — total por status",
+      "description": "Contagem acumulada de execuções de boot por status (SUCCESS / FAIL_FAST / WARN_ONLY).",
+      "gridPos": { "x": 0, "y": 0, "w": 8, "h": 4 },
+      "datasource": { "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (status) (boot_run_total)",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Boot fail-fast — total por fase",
+      "description": "Contador de eventos fail-fast por fase de boot.",
+      "gridPos": { "x": 8, "y": 0, "w": 8, "h": 4 },
+      "datasource": { "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (phase, code) (boot_failfast_total)",
+          "legendFormat": "{{phase}} / {{code}}"
+        }
+      ],
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "JVM — heap usado",
+      "gridPos": { "x": 16, "y": 0, "w": 8, "h": 4 },
+      "datasource": { "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{area=\"heap\"}",
+          "legendFormat": "heap"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 314572800 },
+              { "color": "red", "value": 524288000 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Boot phase duration — p95 (segundos)",
+      "description": "Percentil 95 da duração de cada fase de boot. Picos indicam lentidão em conciliação ou queries de exchange.",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (phase, le) (rate(boot_phase_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 — {{phase}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Boot phases — taxa de execução",
+      "description": "Fases de boot executadas por minuto, por status.",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (phase, status) (rate(boot_phase_total[1m]))",
+          "legendFormat": "{{phase}} / {{status}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "HTTP — taxa de requests por endpoint",
+      "description": "Requests por segundo por URI e status HTTP.",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "datasource": { "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (uri, status) (rate(http_server_requests_seconds_count[1m]))",
+          "legendFormat": "{{uri}} {{status}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "HTTP — latência p95 por endpoint",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "datasource": { "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (uri, le) (rate(http_server_requests_seconds_bucket[5m])))",
+          "legendFormat": "p95 — {{uri}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "JVM — threads ativas",
+      "gridPos": { "x": 0, "y": 20, "w": 8, "h": 6 },
+      "datasource": { "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "jvm_threads_live_threads",
+          "legendFormat": "live"
+        },
+        {
+          "expr": "jvm_threads_daemon_threads",
+          "legendFormat": "daemon"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "JVM — GC pause (p95)",
+      "gridPos": { "x": 8, "y": 20, "w": 8, "h": 6 },
+      "datasource": { "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (gc, le) (rate(jvm_gc_pause_seconds_bucket[5m])))",
+          "legendFormat": "p95 — {{gc}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 10,
+      "type": "text",
+      "title": "Métricas a implementar (placeholders)",
+      "gridPos": { "x": 16, "y": 20, "w": 8, "h": 6 },
+      "options": {
+        "mode": "markdown",
+        "content": "**Painéis pendentes (métricas ainda não emitidas):**\n\n- `transactions_by_status{status=\"PENDING\"}` — volume acumulado de PENDING\n- `dead_letter_entries` — DLQ aberto por runner\n- `conciliation.duration` — latência de conciliação order update\n- `runners_by_status` — runners ACTIVE / HALTED / INITIALIZING\n\nQuando as métricas forem adicionadas ao `BootMetricsRecorder` ou em novos recorders, substituir este painel pelos respectivos time series."
+      }
+    }
+  ]
+}

--- a/docker/grafana/provisioning/dashboards/provider.yml
+++ b/docker/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: CTrade
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'ctrade'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      # host.docker.internal reaches the Spring app running on the host (Docker Desktop on Mac/Windows).
+      # On Linux, add --add-host=host.docker.internal:host-gateway to the prometheus service.
+      - targets: ['host.docker.internal:8080']
+    relabel_configs:
+      - target_label: application
+        replacement: ctrade

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -14,7 +14,7 @@ Trilha de tarefas para habilitar operação com a API da Binance (testnet), pré
 | T6  | Exchange Symbol Filters         | Média        | Codex       | Concluído     |
 | T7  | Boot Readiness real             | Média        | Codex       | Concluído     |
 | T8  | Kill Switch                     | Média        | Codex       | Pendente      |
-| T9  | Observabilidade Docker Compose  | Média        | Codex       | Pendente      |
+| T9  | Observabilidade Docker Compose  | Média        | Codex       | Concluído     |
 | T10 | Otimização da suíte de integração | Média      | Codex       | Pendente      |
 | T11 | Order Quantity Normalization Before Persist | Média | Codex  | Pendente      |
 

--- a/docs/tasks/T9-observabilidade.md
+++ b/docs/tasks/T9-observabilidade.md
@@ -3,7 +3,7 @@
 **Complexidade:** Média  
 **Responsável:** Codex  
 **Dependências:** nenhuma  
-**Status:** Pendente
+**Status:** Concluído
 
 ---
 

--- a/spring-application/build.gradle
+++ b/spring-application/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
     runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/spring-application/src/main/resources/application.yml
+++ b/spring-application/src/main/resources/application.yml
@@ -61,6 +61,11 @@ management:
     export:
       prometheus:
         enabled: true
+    distribution:
+      percentiles-histogram:
+        boot.phase.duration: true
+        http.server.requests: true
+        jvm.gc.pause: true
 
 runner:
   boot:

--- a/spring-application/src/main/resources/application.yml
+++ b/spring-application/src/main/resources/application.yml
@@ -49,6 +49,19 @@ margin:
     multiplier: 2.0
 
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  endpoint:
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+
 runner:
   boot:
     orchestrator-enabled: true


### PR DESCRIPTION
## Summary

- `micrometer-registry-prometheus` adicionado ao `build.gradle` — habilita o endpoint `/actuator/prometheus`
- `management.endpoints.web.exposure.include` expõe `health,info,prometheus,metrics`
- `docker-compose.yml` ganha `prometheus` e `grafana` sob `profiles: [observability]` — não afeta o ambiente local sem a flag
- `docker/prometheus/prometheus.yml` — scrape de `:8080/actuator/prometheus` a cada 15s via `host.docker.internal`
- Grafana com datasource Prometheus provisionado automaticamente (sem configuração manual)
- Dashboard **CTrade — Staging** provisionado com 10 painéis

## Dashboard CTrade — Staging

| Painel | Métrica | Status |
|---|---|---|
| Boot runs por status | `boot_run_total` by status | Dados reais |
| Boot fail-fast | `boot_failfast_total` by phase/code | Dados reais |
| JVM heap usado | `jvm_memory_used_bytes{area="heap"}` | Dados reais |
| Boot phase duration p95 | `boot_phase_duration_seconds_bucket` | Dados reais |
| Boot phases — taxa | `boot_phase_total` | Dados reais |
| HTTP requests por endpoint | `http_server_requests_seconds_count` | Dados reais |
| HTTP latência p95 | `http_server_requests_seconds_bucket` | Dados reais |
| JVM threads | `jvm_threads_live_threads` | Dados reais |
| JVM GC pause p95 | `jvm_gc_pause_seconds_bucket` | Dados reais |
| Placeholders | DLQ, conciliação, runners por status | A implementar |

## Como usar

```bash
# Só Postgres (desenvolvimento local)
docker compose up -d

# Stack completa com observabilidade
docker compose --profile observability up -d
```

Prometheus: http://localhost:9090  
Grafana: http://localhost:3000 (admin / ctrade123)

## Validation

- `:spring-application:compileJava` — BUILD SUCCESSFUL
- YAML de provisioning validado estruturalmente
- Nenhuma mudança em código Java de domínio

🤖 Generated with [Claude Code](https://claude.com/claude-code)