### PR TITLE
docs: add operational persistence flow maps

### DIFF
--- a/.ai/flows/README.md
+++ b/.ai/flows/README.md
@@ -35,6 +35,8 @@ O plano de expansao e status dos mapas fica em `ROADMAP.md`.
 | `binance-user-data-stream.md` | Listen key, User Data Stream, `executionReport`, reconexao e entrada de updates Binance na conciliacao. |
 | `websocket-event-routing.md` | Entrada WebSocket, eventos raw, handlers de mensagem e notificacao de listeners de preco/ordem. |
 | `mock-exchange-runtime.md` | Runtime mock, feed simulado, ordem mock, slippage/fees, overrides e publicacao no pipeline raw. |
+| `dead-letter-replay.md` | DLQ operacional, DLQ de capital, replay automatico, resolucao manual e impacto no boot/recovery. |
+| `persistence-adapters.md` | Persistencia JDBC dos agregados principais, mappers, migrations, locks, operacoes atomicas e idempotencia. |
 
 ## Regras de Manutencao
 
@@ -49,5 +51,5 @@ O plano de expansao e status dos mapas fica em `ROADMAP.md`.
 
 ## Proximos Mapas Candidatos
 
-- Dead letter operacional e replay.
-- Persistencia/JPA dos agregados principais.
+Sem candidatos definidos no momento. Adicione novos candidatos aqui quando um
+fluxo implementado ainda nao tiver mapa em `/.ai/flows`.

--- a/.ai/flows/ROADMAP.md
+++ b/.ai/flows/ROADMAP.md
@@ -14,7 +14,7 @@ conectar comportamento implementado, codigo principal, invariantes e validacao.
 | Mapas dos fluxos centrais | Completo | Cobertura dos fluxos mais criticos de sinal, ordem, capital e boot. |
 | Regra de impacto documental | Completo | Toda alteracao de codigo deve avaliar se a documentacao base precisa mudar. |
 | Mapas de integracao e eventos externos | Completo | Cobertura de Binance, WebSocket e adapter mock. |
-| Mapas operacionais e persistencia | Pendente | Cobertura de DLQ/replay e persistencia dos agregados principais. |
+| Mapas operacionais e persistencia | Completo | Cobertura de DLQ/replay e persistencia dos agregados principais. |
 
 ## Entrega 1: Base E Fluxos Centrais
 
@@ -62,18 +62,15 @@ Arquivos entregues:
 
 ## Entrega 3: Operacao E Persistencia
 
-Status: Pendente.
+Status: Completo.
 
-Ordem recomendada:
+Arquivos entregues:
 
-1. `dead-letter-replay.md`
-   - DLQ operacional, payloads, replay, resolucao manual e falhas persistentes.
-   - Deve cobrir tanto o caminho de capital quanto o uso operacional em boot.
-2. `persistence-adapters.md`
-   - Repositorios, mapeamento de agregados principais, fronteiras de persistencia
-     e pontos de risco em migracoes/estado.
-   - Deve orientar bugs de estado sem transformar o mapa em referencia completa
-     de schema.
+- `dead-letter-replay.md`: DLQ operacional, payloads, replay, resolucao manual,
+  falhas persistentes, caminho de capital e uso operacional em boot/recovery.
+- `persistence-adapters.md`: repositorios, mapeamento de agregados principais,
+  fronteiras de persistencia, migrations, locks, idempotencia e pontos de risco
+  em estado duravel.
 
 ## Criterios Para Marcar Um Mapa Como Completo
 

--- a/.ai/flows/dead-letter-replay.md
+++ b/.ai/flows/dead-letter-replay.md
@@ -1,0 +1,162 @@
+# Dead Letter E Replay
+
+## Objetivo
+
+Mapear como o projeto registra entradas de DLQ, como elas bloqueiam fluxos
+operacionais e quando podem ser resolvidas ou reprocessadas automaticamente.
+
+Use este mapa para bugs ou features envolvendo:
+
+- callbacks ou ordens que nao podem ser reconciliados;
+- retries esgotados em eventos de capital;
+- boot/recovery que encontra ordens zumbis ou limbo irreconciliavel;
+- telas, endpoints ou jobs de resolucao/replay de DLQ.
+
+## Entradas E Saidas
+
+Entradas principais:
+
+- eventos de capital publicados apos commit do runner;
+- ordens abertas consultadas durante boot phase2 zombie detection;
+- transacoes em voo consultadas por boot recovery ou watchdog;
+- chamadas REST para listar, resolver ou reprocessar DLQ.
+
+Saidas e efeitos colaterais:
+
+- `DeadLetterEntry` persistida em `dead_letter_entries`;
+- entrada marcada como resolvida quando operador resolve manualmente;
+- entrada marcada como resolvida apos replay automatico aplicado;
+- runner pode ficar `HALTED` se ainda existir DLQ nao resolvida na finalizacao
+  do recovery.
+
+## Fluxo Principal
+
+1. O core cria `DeadLetterEntry` com `portfolioId`, `runnerId` opcional,
+   `clientOrderId`, `exchangeOrderId`, `rawPayload`, `DlqReason` e estado
+   `isResolved=false`.
+2. A persistencia passa por `DeadLetterEntryRepositoryPort`.
+3. A implementacao JDBC salva em `dead_letter_entries` e consulta pendencias por
+   portfolio, runner ou identidade.
+4. A operacao manual entra por `DeadLetterController`.
+5. `TransactionalManageDeadLetterPort` aplica transacao:
+   - listagem e read-only;
+   - resolve/reprocess em `REQUIRES_NEW`.
+6. `ManageDeadLetterUseCase` valida a entrada:
+   - nao encontrada retorna falha;
+   - ja resolvida retorna conflito;
+   - resolve manual marca `resolvedBy` e `resolvedAt`;
+   - replay automatico exige `DeadLetterReprocessingPort.supports(entry)`.
+7. Se o reprocessor retorna `applied=true`, a entrada e resolvida. Se retorna
+   `applied=false`, a DLQ permanece aberta para revisao manual.
+
+## Tipos De DLQ
+
+### Capital
+
+`CapitalEventListener` consome `ExecutionConfirmedEvent` e
+`MarginReleaseEvent` com `@TransactionalEventListener(AFTER_COMMIT)`,
+`REQUIRES_NEW` e retry Spring.
+
+Quando os retries acabam, os metodos `@Recover` serializam o evento com
+`CapitalDeadLetterPayloadCodec` e persistem uma DLQ com
+`DlqReason.RETRY_EXHAUSTED`.
+
+Replay automatico:
+
+- `CapitalDeadLetterReprocessingAdapter.supports` aceita apenas
+  `RETRY_EXHAUSTED`;
+- o payload precisa decodificar como `EXECUTION_CONFIRMED` ou
+  `MARGIN_RELEASE`;
+- `EXECUTION_CONFIRMED` chama `ExecutionConfirmedReaction`;
+- `MARGIN_RELEASE` chama `MarginReleasedReaction` somente se o
+  `GlobalBalance.reservedBalance` ainda cobre o valor a liberar;
+- se margem ja foi consumida/liberada e nao ha mudanca segura de estado, o replay
+  retorna `notApplied` e exige revisao manual.
+
+### Boot Zombie Detection
+
+`PortfolioZombieDetectionUseCase` classifica ordens abertas da exchange em:
+
+- `INVALID_FORMAT`;
+- `UNKNOWN_RUNNER`;
+- `RECONCILIATION_CONFLICT`;
+- `UNKNOWN_SYMBOL`.
+
+`RunBootSequenceUseCase` persiste amostras em DLQ apenas quando a phase2 zombie
+detection roda em `FAIL_FAST`. Em `WARN_ONLY`, o fluxo observa e loga, mas nao
+persiste a DLQ operacional.
+
+Antes de persistir, o boot consulta `existsUnresolvedByIdentity` para evitar
+duplicar entradas abertas com a mesma identidade.
+
+### Runtime Recovery
+
+`RecoverTransactionStatusUseCase` pode rotear uma transacao para DLQ quando a
+exchange nao encontra uma ordem e a policy escolhida e `REGISTER_DLQ`.
+
+O payload e textual e identifica:
+
+- `source=runner.recovery.transaction`;
+- exchange;
+- runner;
+- transaction;
+- client/exchange order ids;
+- status anterior;
+- outcome `ORDER_NOT_FOUND_ON_EXCHANGE`.
+
+Se ja existe DLQ aberta para a mesma identidade, o fluxo mantem a entrada
+existente.
+
+### Runner Boot Recovery
+
+`RunnerBootRecoveryUseCase` consulta DLQ nao resolvida na finalizacao:
+
+- `existsUnresolvedByRunnerId(runnerId)`;
+- `existsUnresolvedByPortfolioIdAndRunnerIsNull(portfolioId)`.
+
+Se houver pendencia, o recovery registra erro. Runner `ACTIVE` e movido para
+`HALTED`; caso contrario a reconciliacao nao e marcada como concluida.
+
+## Componentes Principais
+
+- `core/src/main/java/com/marmitt/core/domain/portfolio/DeadLetterEntry.java`
+- `core/src/main/java/com/marmitt/core/enums/DlqReason.java`
+- `core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java`
+- `core/src/main/java/com/marmitt/core/ports/outbound/repository/DeadLetterEntryRepositoryPort.java`
+- `core/src/main/java/com/marmitt/core/ports/outbound/repository/DeadLetterReprocessingPort.java`
+- `spring-application/src/main/java/com/marmitt/application/spring/controller/DeadLetterController.java`
+- `spring-application/src/main/java/com/marmitt/application/spring/service/TransactionalManageDeadLetterPort.java`
+- `spring-application/src/main/java/com/marmitt/application/spring/handler/CapitalEventListener.java`
+- `spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterPayloadCodec.java`
+- `spring-application/src/main/java/com/marmitt/application/spring/deadletter/CapitalDeadLetterReprocessingAdapter.java`
+- `spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcDeadLetterEntryRepositoryAdapter.java`
+- `core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java`
+- `core/src/main/java/com/marmitt/core/application/usecase/runner/RunnerBootRecoveryUseCase.java`
+- `core/src/main/java/com/marmitt/core/application/usecase/runner/RecoverTransactionStatusUseCase.java`
+
+## Invariantes
+
+- DLQ aberta nao deve ser duplicada quando a identidade ja existe aberta.
+- Replay automatico so resolve a entrada depois de efeito aplicado.
+- Payload de capital e detalhe de adapter Spring; o core conhece apenas
+  `DeadLetterEntry`, `DlqReason` e portas.
+- `runnerId` pode ser nulo para DLQ de portfolio sem escopo de runner.
+- Resolucao manual exige operador (`resolvedBy`/`requestedBy`) nao vazio.
+- Entrada ja resolvida nao pode ser resolvida nem reprocessada novamente.
+- DLQ operacional aberta impede finalizacao limpa do runner recovery.
+
+## Validacao Recomendada
+
+- `./scripts/gradle-run.ps1 -q :core:test --tests "*ManageDeadLetterUseCaseTest"`
+- `./scripts/gradle-run.ps1 -q :spring-application:test --tests "*DeadLetterControllerTest"`
+- `./scripts/gradle-run.ps1 -q :spring-application:test --tests "*CapitalDeadLetterReprocessingAdapterTest"`
+- `./scripts/gradle-run.ps1 -q :spring-application:test --tests "*CapitalDeadLetterReplayIntegrationTest"`
+- `./scripts/gradle-run.ps1 -q :spring-application:test --tests "*BootOrchestratorDlqOperationalTest"`
+- `./scripts/gradle-run.ps1 -q :spring-application:test --tests "*RunnerTransactionRecoveryWatchdogIntegrationTest"`
+
+## Fontes
+
+- Codigo listado em "Componentes Principais".
+- Migrations `V1__create_initial_schema.sql` e
+  `V8__add_runner_id_to_dead_letter_entries.sql`.
+- Testes de use case, controller, replay de capital, boot DLQ e watchdog.

--- a/.ai/flows/persistence-adapters.md
+++ b/.ai/flows/persistence-adapters.md
@@ -1,0 +1,221 @@
+# Persistencia E Adapters
+
+## Objetivo
+
+Mapear como o estado duravel dos agregados principais sai do core por portas e
+chega a infraestrutura Spring Data JDBC, mappers e migrations.
+
+Use este mapa para bugs ou features envolvendo:
+
+- estado de `Portfolio`, `GlobalBalance`, `StrategyRunner`, `Position`,
+  `Transaction`, `TransactionMatch` ou DLQ;
+- locks, operacoes atomicas, idempotencia e concorrencia;
+- alteracoes em schema, migrations, repositories ou mappers;
+- investigacao de divergencia entre dominio e banco.
+
+## Fronteira Arquitetural
+
+O core define contratos em `core/.../ports/outbound/repository`. A
+infraestrutura Spring implementa esses contratos em
+`spring-application/.../infrastructure/persistence`.
+
+O dominio nao deve depender de:
+
+- entidades JDBC;
+- annotations de persistencia;
+- queries SQL;
+- detalhes de migration.
+
+O limite entre dominio e banco e feito por adapters e mappers:
+
+- adapter implementa a porta;
+- mapper converte entidade JDBC <-> dominio;
+- repository JDBC executa `CrudRepository` e queries anotadas;
+- migration define a forma persistida.
+
+## Fluxo Principal
+
+1. Um use case do core chama uma porta outbound.
+2. O adapter Spring recebe dominio ou parametros de consulta.
+3. O adapter converte dominio para entidade via mapper quando grava.
+4. O repository JDBC executa save/query/update.
+5. O adapter converte entidade para dominio ao retornar.
+6. O caller do core continua operando apenas com tipos de dominio/DTOs do core.
+
+Transacoes ficam na camada Spring quando o limite operacional exige atomicidade,
+por exemplo adapters com `@Transactional`, listeners com `REQUIRES_NEW` ou
+servicos transacionais que encapsulam portas inbound.
+
+## Agregados Persistidos
+
+### Portfolio
+
+Contrato: `PortfolioRepositoryPort`.
+
+Implementacao:
+
+- `JdbcPortfolioRepositoryAdapter`;
+- `PortfolioJdbcRepository`;
+- `PortfolioEntityMapper`;
+- `PortfolioEntity`;
+- tabela `portfolios`.
+
+Responsabilidades principais:
+
+- buscar por id, nome, simbolo ou listar todos;
+- registrar portfolio evitando duplicidade por id ou nome;
+- manter o core isolado do schema.
+
+### GlobalBalance
+
+Contrato: `GlobalBalanceRepositoryPort`.
+
+Implementacao:
+
+- `JdbcGlobalBalanceRepositoryAdapter`;
+- `GlobalBalanceJdbcRepository`;
+- `GlobalBalanceEntityMapper`;
+- `GlobalBalanceEntity`;
+- tabela `global_balances`.
+
+Ponto critico:
+
+- `reserveAtomic(portfolioId, amount)` executa `UPDATE` condicional que move
+  saldo de `available_balance` para `reserved_balance` apenas quando existe saldo
+  suficiente.
+- Saldo insuficiente nao e excecao: o contrato retorna `false`.
+- Concorrencia financeira deve continuar passando por esse ponto de
+  serializacao.
+
+### StrategyRunner E Filhos
+
+Contrato: `StrategyRunnerRepositoryPort`.
+
+Implementacao:
+
+- `JdbcStrategyRunnerRepositoryAdapter`;
+- `StrategyRunnerJdbcRepository`;
+- `RunnerPositionJdbcRepository`;
+- `RunnerTransactionJdbcRepository`;
+- `RunnerTransactionMatchJdbcRepository`;
+- `StrategyRunnerEntityMapper`;
+- entidades `StrategyRunnerEntity`, `RunnerPositionEntity`,
+  `RunnerTransactionEntity`, `RunnerTransactionMatchEntity` e
+  `RunnerMarketDataSourceEntity`;
+- tabelas `strategy_runners`, `runner_market_data_sources`, `positions`,
+  `transactions` e `transaction_matches`.
+
+Responsabilidades principais:
+
+- salvar runner, position, transaction e match;
+- buscar runners por portfolio, simbolo, exchange e short code;
+- buscar transacoes por `clientOrderId` para roteamento e idempotencia;
+- buscar transacoes em voo para boot/recovery/watchdog;
+- aplicar lock pessimista em positions quando o fluxo precisa serializar fills
+  ou venda;
+- executar operacoes atomicas de transaction+position lock e transaction+match.
+
+Pontos criticos:
+
+- `tryLockPositionForSell` usa update condicional e aceita estado ja lockado pela
+  mesma transacao como sucesso idempotente.
+- positions `OPEN` ou `CLOSING` precisam de `openedByTransactionId`.
+- `saveAtomicTransactionAndMatch` mantem status de transaction e match no mesmo
+  limite transacional.
+- `transaction_matches` sao registros de execucao; nao trate como estado
+  mutavel de lifecycle.
+
+### DeadLetter
+
+Contrato: `DeadLetterEntryRepositoryPort`.
+
+Implementacao:
+
+- `JdbcDeadLetterEntryRepositoryAdapter`;
+- `DeadLetterEntryJdbcRepository`;
+- `DeadLetterEntryEntityMapper`;
+- `DeadLetterEntryEntity`;
+- tabela `dead_letter_entries`.
+
+Responsabilidades principais:
+
+- salvar entrada;
+- listar pendencias por portfolio/runner;
+- detectar DLQ aberta por portfolio, runner ou identidade;
+- suportar boot/recovery e operacao manual de DLQ.
+
+Detalhes operacionais ficam no mapa `dead-letter-replay.md`.
+
+### Capital Event Ledger
+
+Contrato: `CapitalEventIdempotencyPort`.
+
+Implementacao:
+
+- `JdbcCapitalEventIdempotencyRepositoryAdapter`;
+- tabela `capital_event_ledger`.
+
+Ponto critico:
+
+- o adapter faz `INSERT ... ON CONFLICT DO NOTHING`;
+- retorno `true` significa primeiro processamento;
+- retorno `false` significa evento duplicado e deve impedir novo efeito
+  financeiro.
+
+## Repositorios Em Memoria
+
+Nem todo `RepositoryPort` e persistencia duravel.
+
+Registries como exchange adapters, strategies, listeners e WebSocket connection
+repository podem ser implementados em memoria para runtime. Nao use esses
+repositorios como fonte historica de estado de dominio.
+
+Ao investigar estado persistido, priorize os adapters em
+`spring-application/.../infrastructure/persistence`.
+
+## Migrations
+
+Schema duravel fica em `spring-application/src/main/resources/db/migration`.
+
+Migrations relevantes:
+
+- `V1__create_initial_schema.sql`: schema inicial dos agregados principais,
+  DLQ, indices e FKs circulares resolvidas por `ALTER TABLE`;
+- `V2__add_opened_by_transaction_id.sql` a
+  `V6__enforce_opened_by_transaction_in_positions.sql`: ajustes de positions e
+  matches;
+- `V7__create_capital_event_ledger.sql`: ledger de idempotencia de capital;
+- `V8__add_runner_id_to_dead_letter_entries.sql`: escopo opcional de runner na
+  DLQ e indices para pendencias;
+- `V9__add_updated_at_to_transactions.sql`: suporte a consultas por
+  `updated_at` em recovery/watchdog.
+
+## Invariantes
+
+- O core depende de portas, nunca de entidades ou repositories JDBC.
+- Toda coluna nova que altera estado de dominio precisa refletir em migration,
+  entity, mapper e adapter/repository quando aplicavel.
+- Operacoes financeiras concorrentes devem preservar os pontos atomicos
+  existentes (`reserveAtomic`, locks de position, ledger de idempotencia).
+- Queries hot path devem respeitar os indices existentes ou adicionar migration
+  explicita.
+- Nao transforme repositorios em memoria em fonte duravel de estado.
+- Mudancas em mappers devem preservar reconstrucao completa de agregados.
+
+## Validacao Recomendada
+
+- `./scripts/gradle-run.ps1 -q :core:test`
+- `./scripts/gradle-run.ps1 -q :spring-application:test`
+- Para mudanca focada em persistencia de runner:
+  `./scripts/gradle-run.ps1 -q :spring-application:test --tests "*Runner*IntegrationTest"`
+- Para mudanca de capital:
+  `./scripts/gradle-run.ps1 -q :spring-application:test --tests "*Capital*"`
+- Para mudanca de DLQ:
+  `./scripts/gradle-run.ps1 -q :spring-application:test --tests "*DeadLetter*"`
+
+## Fontes
+
+- Ports em `core/src/main/java/com/marmitt/core/ports/outbound/repository`.
+- Adapters, repositories, entities e mappers em
+  `spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence`.
+- Migrations em `spring-application/src/main/resources/db/migration`.


### PR DESCRIPTION

## Summary
- Adds `dead-letter-replay.md` to map operational DLQ, capital replay, manual resolution, boot zombie detection, runtime recovery, and runner recovery impact.
- Adds `persistence-adapters.md` to map JDBC persistence adapters, mappers, migrations, locks, atomic operations, and idempotency boundaries.
- Updates the flow index and roadmap after rebasing on the latest `develop`, preserving the integration/event maps from the previous delivery.

## Validation
- Docs-only change; inspected the updated Markdown files.
- `rg -n <<<<<<<|=======|>>>>>>> .ai/flows`: no conflict markers found.
- `rg -n [^\\x00-\\x7F] .ai/flows/dead-letter-replay.md .ai/flows/persistence-adapters.md .ai/flows/README.md .ai/flows/ROADMAP.md`: no non-ASCII characters found.

## Documentation
- Updated base documentation in `/.ai/flows`.

## Notes
- Rebased on `origin/develop` before opening the PR.
- No application code changes.
