### PR TITLE
docs: add feature delivery agent

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -33,6 +33,8 @@ Todo agente deve consultar este material antes de implementar, revisar, refatora
 ## Guias adicionais por tipo de tarefa
 
 - Uso de agentes e skills: consultar `agents/usage.md` para exemplos de comandos e efeitos esperados
+- Entrega de feature ou bug: usar `agents/feature-delivery-agent.md` como agente
+  orientador quando a tarefa pedir implementacao/correcao end-to-end
 - Flow maps: consultar `flows/README.md` para entender fluxos implementados antes de alterar feature ou bug
 - Impacto documental: toda alteracao de codigo deve avaliar se `/.ai`, `/.ai/flows` ou `docs/` precisam ser atualizados; quando nao houver impacto, declarar isso no fechamento da tarefa ou PR
 - Git workflow: consultar `git-workflow.md` para branch, commit e base de PR
@@ -45,6 +47,9 @@ Todo agente deve consultar este material antes de implementar, revisar, refatora
 ## Agentes compartilhados
 
 - Os prompts especializados compartilhados entre ferramentas devem ficar em `/.ai/agents/`
+- Entrega de feature ou bug deve usar `/.ai/agents/feature-delivery-agent.md`
+  quando a tarefa pedir conduzir implementacao, correcao ou investigacao com
+  mudanca de codigo
 - Review de codigo deve usar `/.ai/agents/code-review-agent.md` como complemento operacional de `review.md`
 - `AGENTS.md` e `CLAUDE.md` devem apenas apontar para esses arquivos, sem duplicar regra detalhada
 

--- a/.ai/agents/README.md
+++ b/.ai/agents/README.md
@@ -18,3 +18,8 @@ Este diretorio concentra prompts especializados reutilizaveis por mais de uma fe
 
 - `usage.md`: exemplos de comandos para acionar agentes e skills, incluindo o que
   cada comando deve fazer ou evitar.
+- `feature-delivery-agent.md`: agente para conduzir features, bugs e mudancas de
+  codigo do entendimento inicial ate validacao, usando flow maps e skills quando
+  necessario.
+- `code-review-agent.md`: agente para revisar PRs, diffs e mudancas com foco em
+  correcao, fronteiras arquiteturais, regressao e validacao.

--- a/.ai/agents/feature-delivery-agent.md
+++ b/.ai/agents/feature-delivery-agent.md
@@ -1,0 +1,141 @@
+# Agente Compartilhado de Entrega de Feature/Bug
+
+Este arquivo e a especificacao canonica do agente de entrega de feature/bug do
+projeto. Ele existe para conduzir uma demanda do entendimento inicial ate uma
+mudanca implementada, validada e pronta para publicacao quando o usuario pedir.
+
+## Quando usar
+
+Use este agente quando a tarefa principal for:
+
+- implementar feature nova ou evolucao funcional;
+- corrigir bug;
+- investigar comportamento e aplicar correcao;
+- conduzir uma mudanca de codigo do pedido ate validacao;
+- preparar uma entrega que pode terminar em commit, push ou PR, se o usuario
+  pedir explicitamente.
+
+Este agente nao substitui:
+
+- `/.ai/agents/code-review-agent.md` para reviews;
+- `/.ai/skills/pr-comment-resolver/SKILL.md` para resolver comentarios de PR;
+- `/.ai/skills/pr-creator/SKILL.md` para a mecanica de commit, push e PR;
+- `/.ai/skills/pr-review-publisher/SKILL.md` para publicar findings.
+
+## Papel Do Agente
+
+O agente orquestra decisao tecnica. Skills operacionalizam workflows fechados.
+
+Na pratica, este agente deve:
+
+- classificar a demanda;
+- escolher os documentos e flow maps relevantes;
+- identificar o modulo dono da responsabilidade;
+- confirmar comportamento no codigo antes de alterar;
+- implementar a menor mudanca coerente;
+- validar conforme risco e modulo tocado;
+- avaliar impacto documental;
+- acionar skills apenas quando a tarefa pedir a operacao correspondente.
+
+## Ordem Obrigatoria De Leitura
+
+1. `/.ai/README.md`
+2. `/.ai/project-context.md`
+3. `/.ai/architecture.md`
+4. `/.ai/coding-standards.md`
+5. `/.ai/validation.md`
+
+Leituras adicionais por contexto:
+
+- `/.ai/flows/README.md` e o flow map aplicavel quando a demanda tocar fluxo
+  existente;
+- `/.ai/change-safety.md` quando houver refactor, mudanca de responsabilidade,
+  contrato ou fronteira entre modulos;
+- `/.ai/docs.md` para avaliar ou atualizar documentacao base;
+- `/.ai/git-workflow.md` e `/.ai/skills/pr-creator/SKILL.md` quando o usuario
+  pedir commit, push ou PR.
+
+## Classificacao Inicial
+
+Antes de editar, classifique a tarefa como uma ou mais categorias:
+
+- `feature`: comportamento novo ou evolucao funcional;
+- `bugfix`: correcao de comportamento existente;
+- `refactor`: mudanca estrutural sem mudanca comportamental pretendida;
+- `test`: cobertura ou validacao;
+- `docs`: documentacao;
+- `investigation`: analise sem alteracao imediata.
+
+Se a classificacao mudar durante a execucao, ajuste o plano e os documentos
+consultados.
+
+## Fluxo De Execucao
+
+1. Confirmar estado do repositorio com `git status --short`.
+2. Se a tarefa envolver nova implementacao em branch nova, atualizar `develop` e
+   criar branch conforme `/.ai/git-workflow.md`.
+3. Ler o contexto minimo da tarefa e o flow map aplicavel.
+4. Localizar no codigo os contratos, use cases, adapters, mappers ou testes que
+   executam o comportamento.
+5. Declarar brevemente a abordagem antes de editar quando a mudanca for
+   substancial.
+6. Implementar no modulo dono da responsabilidade.
+7. Evitar refactors laterais que nao sejam necessarios para concluir a demanda.
+8. Rodar a validacao mais restrita que cubra o risco.
+9. Atualizar documentacao base quando contrato, fluxo, invariante, validacao ou
+   comportamento operacional mudar.
+10. Reportar arquivos alterados, validacao e impacto documental.
+11. Se o usuario pedir publicacao, usar `/.ai/skills/pr-creator/SKILL.md`.
+
+## Decisoes Que O Agente Deve Tomar
+
+O agente deve responder, de forma explicita ou implicita na implementacao:
+
+1. Qual fluxo ou modulo e dono da mudanca?
+2. Quais flow maps ajudam a entender o comportamento existente?
+3. A mudanca pertence ao `core`, `strategy`, `spring-application` ou
+   `adapter-*`?
+4. Alguma regra de negocio esta sendo empurrada para infraestrutura ou adapter?
+5. Qual e a menor validacao suficiente para o risco?
+6. A documentacao base precisa mudar?
+7. Ha trabalho de PR, review ou comentario que deve ser delegado a uma skill?
+
+## Regras De Fronteira
+
+- Regra de negocio deve permanecer no `core`.
+- Estrategia deve permanecer calculo deterministico e sem infraestrutura.
+- `spring-application` deve compor, adaptar e configurar.
+- `adapter-*` deve isolar payloads e schemas de provider.
+- DTOs ou formatos externos nao devem vazar para o dominio.
+- Persistencia, transporte e framework nao devem definir politica de dominio.
+
+## Uso De Skills
+
+Use skills apenas quando a operacao correspondente for parte explicita da tarefa:
+
+- `pr-creator`: quando o usuario pedir commit, push, publicar branch ou abrir PR;
+- `pr-comment-resolver`: quando o usuario pedir para resolver comentarios de PR;
+- `pr-review-publisher`: quando o usuario pedir para publicar findings;
+- skills de plugin GitHub: quando a tarefa envolver PR, issue, CI ou comentarios.
+
+Se a tarefa nao pedir write externo, mantenha respostas, rascunhos e conclusoes
+na conversa.
+
+## Contrato De Saida
+
+Ao concluir uma entrega, reporte:
+
+- resumo da mudanca;
+- arquivos principais alterados;
+- validacao executada e resultado;
+- documentacao atualizada ou justificativa de nao impacto;
+- branch/commit/PR apenas quando essas acoes foram pedidas e executadas;
+- riscos residuais ou proximos passos objetivos, se existirem.
+
+## Regra De Manutencao
+
+Se este agente precisar mudar:
+
+1. atualize primeiro este arquivo;
+2. atualize `/.ai/agents/usage.md` quando houver novo comando ou efeito esperado;
+3. ajuste documentos ponte apenas para apontar para `/.ai`, sem duplicar politica.

--- a/.ai/agents/usage.md
+++ b/.ai/agents/usage.md
@@ -113,6 +113,64 @@ Deve fazer:
 
 ## Comandos de implementacao
 
+### Implementar com agente de entrega
+
+Comando:
+
+```text
+Use o feature-delivery-agent para implementar suporte a validacao de symbol filters no adapter Binance.
+```
+
+Deve fazer:
+
+- ler `/.ai/agents/feature-delivery-agent.md` e os documentos exigidos por ele;
+- classificar a demanda como feature, bugfix, refactor, test, docs ou
+  investigation;
+- consultar o flow map aplicavel em `/.ai/flows` quando houver fluxo existente;
+- confirmar o comportamento no codigo antes de alterar;
+- implementar no modulo dono da responsabilidade;
+- validar com o comando mais restrito suficiente;
+- avaliar impacto documental;
+- nao fazer commit, push ou PR sem pedido explicito.
+
+### Corrigir bug com agente de entrega
+
+Comando:
+
+```text
+Use o feature-delivery-agent para corrigir o bug em que replay de DLQ de margem resolve entrada sem mudanca de estado.
+```
+
+Deve fazer:
+
+- usar `feature-delivery-agent.md`;
+- ler o flow map mais proximo do bug, por exemplo
+  `/.ai/flows/dead-letter-replay.md`;
+- localizar use case, adapter, teste ou controller responsavel;
+- implementar a correcao mantendo fronteiras de modulo;
+- adicionar ou ajustar teste quando o bug tiver comportamento verificavel;
+- reportar validacao e impacto documental.
+
+### Implementar e abrir PR com agente de entrega
+
+Comando:
+
+```text
+Use o feature-delivery-agent para implementar a mudanca, faca commit, suba a branch e abra um PR draft.
+```
+
+Deve fazer:
+
+- executar o fluxo de entrega normal do agente;
+- usar `/.ai/skills/pr-creator/SKILL.md` apenas na etapa de publicacao;
+- conferir escopo do commit;
+- criar ou usar branch conforme `/.ai/git-workflow.md`;
+- commitar apenas arquivos relacionados;
+- fazer rebase da branch sobre `develop`;
+- subir a branch;
+- abrir PR draft apontando para `develop`;
+- nao fazer merge.
+
 ### Implementar uma mudanca
 
 Comando:


### PR DESCRIPTION

## Summary
- Adds `feature-delivery-agent.md` as the canonical agent for feature and bug delivery.
- Documents how the agent classifies work, selects flow maps, preserves module boundaries, validates changes, evaluates documentation impact, and delegates publishing to skills.
- Updates `.ai/README.md`, `.ai/agents/README.md`, and `.ai/agents/usage.md` with references and example commands.

## Validation
- Docs-only change; inspected the updated Markdown files.
- `rg -n TODO|FIXME|<<<<<<<|=======|>>>>>>> .ai/README.md .ai/agents/README.md .ai/agents/usage.md .ai/agents/feature-delivery-agent.md`: no matches.
- `rg -n [^\\x00-\\x7F] .ai/README.md .ai/agents/README.md .ai/agents/usage.md .ai/agents/feature-delivery-agent.md`: no matches.

## Documentation
- Updated base documentation in `/.ai`.

## Notes
- Rebased on `origin/develop` before opening the PR.
- No application code changes.
