### PR TITLE
feat(t13): order placement via WebSocket API

### DIFF
--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/BinanceOrderApiResponseMapper.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/BinanceOrderApiResponseMapper.java
@@ -1,0 +1,82 @@
+package com.marmitt.binance.processor.receive;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marmitt.core.domain.Symbol;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+
+class BinanceOrderApiResponseMapper {
+
+    private BinanceOrderApiResponseMapper() {}
+
+    static OrderDataDto fromResult(JsonNode result) {
+        BigDecimal executedQty       = new BigDecimal(result.path("executedQty").asText("0"));
+        BigDecimal cumulativeQuoteQty = new BigDecimal(result.path("cummulativeQuoteQty").asText("0"));
+        long transactTime = result.path("transactTime").asLong(0);
+
+        return new OrderDataDto(
+                String.valueOf(result.path("orderId").asLong()),
+                result.path("clientOrderId").asText(),
+                Symbol.of(result.path("symbol").asText()),
+                mapSide(result.path("side").asText()),
+                mapType(result.path("type").asText()),
+                new BigDecimal(result.path("origQty").asText("0")),
+                executedQty,
+                new BigDecimal(result.path("price").asText("0")),
+                computeWap(executedQty, cumulativeQuoteQty),
+                BigDecimal.ZERO,
+                mapStatus(result.path("status").asText()),
+                null,
+                transactTime > 0 ? Instant.ofEpochMilli(transactTime) : Instant.now()
+        );
+    }
+
+    static OrderDataDto fromError(JsonNode root) {
+        String rejectReason = root.path("error").path("msg").asText("Order rejected by Binance");
+        return new OrderDataDto(
+                null,
+                root.path("id").asText(),
+                Symbol.of("UNKNOWN"),
+                OrderDataDto.OrderSide.BUY,
+                OrderDataDto.OrderType.LIMIT,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                OrderDataDto.OrderStatus.REJECTED,
+                rejectReason,
+                Instant.now()
+        );
+    }
+
+    private static BigDecimal computeWap(BigDecimal executedQty, BigDecimal cumulativeQuoteQty) {
+        if (executedQty.compareTo(BigDecimal.ZERO) == 0) return BigDecimal.ZERO;
+        return cumulativeQuoteQty.divide(executedQty, 8, RoundingMode.HALF_UP);
+    }
+
+    private static OrderDataDto.OrderSide mapSide(String side) {
+        return "SELL".equals(side) ? OrderDataDto.OrderSide.SELL : OrderDataDto.OrderSide.BUY;
+    }
+
+    private static OrderDataDto.OrderType mapType(String type) {
+        return switch (type) {
+            case "MARKET" -> OrderDataDto.OrderType.MARKET;
+            default -> OrderDataDto.OrderType.LIMIT;
+        };
+    }
+
+    private static OrderDataDto.OrderStatus mapStatus(String status) {
+        return switch (status) {
+            case "FILLED" -> OrderDataDto.OrderStatus.FILLED;
+            case "PARTIALLY_FILLED" -> OrderDataDto.OrderStatus.PARTIALLY_FILLED;
+            case "CANCELED" -> OrderDataDto.OrderStatus.CANCELED;
+            case "REJECTED" -> OrderDataDto.OrderStatus.REJECTED;
+            case "EXPIRED" -> OrderDataDto.OrderStatus.EXPIRED;
+            default -> OrderDataDto.OrderStatus.NEW;
+        };
+    }
+}

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/BinanceUserDataProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/BinanceUserDataProcessor.java
@@ -2,6 +2,7 @@ package com.marmitt.binance.processor.receive;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.dto.events.WebSocketFailedEvent;
 import com.marmitt.core.dto.processing.ProcessingResult;
 import com.marmitt.core.dto.websocket.MessageContext;
@@ -21,6 +22,7 @@ public class BinanceUserDataProcessor implements ReceivedMessageProcessorPort {
     private final ObjectMapper objectMapper;
     private final EventPublisherPort eventPublisher;
     private final Map<String, BinanceEventProcessor<?>> processorsByEventType;
+    private final OrderApiResponseProcessor orderApiResponseProcessor = new OrderApiResponseProcessor();
 
     public BinanceUserDataProcessor(ObjectMapper objectMapper, EventPublisherPort eventPublisher) {
         this.objectMapper = objectMapper;
@@ -41,6 +43,14 @@ public class BinanceUserDataProcessor implements ReceivedMessageProcessorPort {
             JsonNode root = objectMapper.readTree(rawMessage);
 
             if (root.has("status") && root.has("id")) {
+                JsonNode result = root.path("result");
+                if (result.has("subscriptionId")) {
+                    return handleSubscriptionConfirmation(root, correlationId, rawMessage, context);
+                }
+                if (ClientOrderId.isValid(root.path("id").asText())) {
+                    return orderApiResponseProcessor.process(
+                            root, result, root.path("status").asInt(), correlationId, rawMessage, context);
+                }
                 return handleSubscriptionConfirmation(root, correlationId, rawMessage, context);
             }
 

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessor.java
@@ -22,6 +22,15 @@ class OrderApiResponseProcessor {
                     return ProcessingResult.ignored(correlationId, "order-response-no-symbol");
                 }
                 dto = BinanceOrderApiResponseMapper.fromResult(result);
+                if (dto.status() == OrderDataDto.OrderStatus.FILLED
+                        || dto.status() == OrderDataDto.OrderStatus.PARTIALLY_FILLED) {
+                    // WS API FULL response may carry fee=0 (fills[] not extracted); the executionReport
+                    // via user data stream carries the authoritative commission. Deferring avoids recording
+                    // a zero-fee fill that blocks the real executionReport as a duplicate.
+                    log.debug("Order API response immediate fill status={} — deferring to executionReport: correlationId={}",
+                            dto.status(), correlationId);
+                    return ProcessingResult.ignored(correlationId, "order-response-deferred-to-execution-report");
+                }
             } else if (status >= 400 && status < 500) {
                 // 4xx = definitive client-side rejection (invalid params, insufficient balance, etc.)
                 dto = BinanceOrderApiResponseMapper.fromError(root);

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessor.java
@@ -1,0 +1,37 @@
+package com.marmitt.binance.processor.receive;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marmitt.core.dto.processing.ProcessingResult;
+import com.marmitt.core.dto.websocket.MessageContext;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.dto.websocket.data.ProcessorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class OrderApiResponseProcessor {
+
+    ProcessingResult<? extends ProcessorResponse> process(
+            JsonNode root, JsonNode result, int status,
+            String correlationId, String rawMessage, MessageContext context) {
+        try {
+            OrderDataDto dto;
+            if (status == 200) {
+                if (!result.has("symbol")) {
+                    log.warn("Order API response status=200 but no symbol in result — treating as ignored: correlationId={}",
+                            correlationId);
+                    return ProcessingResult.ignored(correlationId, "order-response-no-symbol");
+                }
+                dto = BinanceOrderApiResponseMapper.fromResult(result);
+            } else {
+                dto = BinanceOrderApiResponseMapper.fromError(root);
+            }
+            log.debug("Order API response processed: clientOrderId={} status={} correlationId={}",
+                    dto.clientOrderId(), dto.status(), correlationId);
+            return ProcessingResult.success(correlationId, rawMessage, dto);
+        } catch (Exception e) {
+            log.error("Failed to parse order API response: correlationId={}", correlationId, e);
+            return ProcessingResult.error(correlationId,
+                    "Failed to parse order API response: " + e.getMessage(), rawMessage, e);
+        }
+    }
+}

--- a/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessor.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessor.java
@@ -22,8 +22,15 @@ class OrderApiResponseProcessor {
                     return ProcessingResult.ignored(correlationId, "order-response-no-symbol");
                 }
                 dto = BinanceOrderApiResponseMapper.fromResult(result);
-            } else {
+            } else if (status >= 400 && status < 500) {
+                // 4xx = definitive client-side rejection (invalid params, insufficient balance, etc.)
                 dto = BinanceOrderApiResponseMapper.fromError(root);
+            } else {
+                // 5xx or unexpected: order may have reached matching engine — leave PENDING for watchdog recovery
+                log.warn("Order API response with unknown outcome status={} correlationId={} — leaving for recovery",
+                        status, correlationId);
+                return ProcessingResult.error(correlationId,
+                        "Order API returned unknown outcome status=" + status, rawMessage);
             }
             log.debug("Order API response processed: clientOrderId={} status={} correlationId={}",
                     dto.clientOrderId(), dto.status(), correlationId);

--- a/adapter-binance/src/test/java/com/marmitt/binance/processor/receive/BinanceUserDataProcessorRoutingTest.java
+++ b/adapter-binance/src/test/java/com/marmitt/binance/processor/receive/BinanceUserDataProcessorRoutingTest.java
@@ -1,0 +1,117 @@
+package com.marmitt.binance.processor.receive;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.dto.processing.ProcessingResult;
+import com.marmitt.core.dto.websocket.MessageContext;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BinanceUserDataProcessorRoutingTest {
+
+    private final List<Object> publishedEvents = new ArrayList<>();
+    private BinanceUserDataProcessor processor;
+
+    @BeforeEach
+    void setup() {
+        EventPublisherPort publisher = new EventPublisherPort() {
+            @Override public void publishEvent(Object event) { publishedEvents.add(event); }
+            @Override public void publishEventSync(Object event) { publishedEvents.add(event); }
+        };
+        processor = new BinanceUserDataProcessor(new ObjectMapper(), publisher);
+    }
+
+    private MessageContext ctx() {
+        return MessageContext.createUserData("BINANCE", UUID.randomUUID());
+    }
+
+    @Test
+    void orderSuccess_routesToOrderProcessor() {
+        String msg = """
+                {
+                  "id": "v1rcd1t1000000000000s001B_abc123def456",
+                  "status": 200,
+                  "result": {
+                    "symbol": "BTCUSDT",
+                    "orderId": 9876543,
+                    "clientOrderId": "v1rcd1t1000000000000s001B_abc123def456",
+                    "side": "BUY",
+                    "type": "LIMIT",
+                    "origQty": "0.001",
+                    "executedQty": "0",
+                    "cummulativeQuoteQty": "0",
+                    "price": "95000",
+                    "status": "NEW",
+                    "transactTime": 1700000000000
+                  }
+                }
+                """;
+
+        ProcessingResult<?> result = processor.processMessage(msg, ctx());
+
+        assertTrue(result.isSuccess());
+        assertInstanceOf(OrderDataDto.class, result.getData().orElseThrow());
+        assertEquals(OrderDataDto.OrderStatus.NEW,
+                ((OrderDataDto) result.getData().orElseThrow()).status());
+        assertTrue(publishedEvents.isEmpty(), "no WebSocketFailedEvent should be published on order success");
+    }
+
+    @Test
+    void orderRejection_routesToOrderProcessorAsRejected() {
+        String msg = """
+                {
+                  "id": "v1rcd1t1000000000000s001B_abc123def456",
+                  "status": 400,
+                  "error": {"code": -2010, "msg": "Insufficient balance"}
+                }
+                """;
+
+        ProcessingResult<?> result = processor.processMessage(msg, ctx());
+
+        assertTrue(result.isSuccess());
+        OrderDataDto dto = (OrderDataDto) result.getData().orElseThrow();
+        assertEquals(OrderDataDto.OrderStatus.REJECTED, dto.status());
+        assertTrue(dto.rejectReason().contains("Insufficient balance"));
+        assertTrue(publishedEvents.isEmpty(), "order rejection must not fire WebSocketFailedEvent");
+    }
+
+    @Test
+    void subscriptionConfirmation_returnsIgnored_noEvent() {
+        String msg = """
+                {
+                  "id": "some-uuid",
+                  "status": 200,
+                  "result": {"subscriptionId": 0}
+                }
+                """;
+
+        ProcessingResult<?> result = processor.processMessage(msg, ctx());
+
+        assertFalse(result.isError());
+        assertFalse(result.isSuccess());
+        assertTrue(publishedEvents.isEmpty());
+    }
+
+    @Test
+    void subscriptionRejection_firesWebSocketFailedEvent() {
+        String msg = """
+                {
+                  "id": "some-uuid",
+                  "status": 401,
+                  "error": {"code": -2015, "msg": "Invalid API-key"}
+                }
+                """;
+
+        ProcessingResult<?> result = processor.processMessage(msg, ctx());
+
+        assertFalse(result.isSuccess(), "subscription rejection should not succeed");
+        assertEquals(1, publishedEvents.size(), "WebSocketFailedEvent must be published");
+    }
+}

--- a/adapter-binance/src/test/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessorTest.java
+++ b/adapter-binance/src/test/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessorTest.java
@@ -1,0 +1,123 @@
+package com.marmitt.binance.processor.receive;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.dto.processing.ProcessingResult;
+import com.marmitt.core.dto.websocket.MessageContext;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrderApiResponseProcessorTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final OrderApiResponseProcessor processor = new OrderApiResponseProcessor();
+
+    private MessageContext ctx() {
+        return MessageContext.createUserData("BINANCE", UUID.randomUUID());
+    }
+
+    @Test
+    void success200_mapsToNewOrderDataDto() throws Exception {
+        String json = """
+                {
+                  "id": "v1rcd1t1000000000000s001B_abc123def456",
+                  "status": 200,
+                  "result": {
+                    "symbol": "BTCUSDT",
+                    "orderId": 9876543,
+                    "clientOrderId": "v1rcd1t1000000000000s001B_abc123def456",
+                    "side": "BUY",
+                    "type": "LIMIT",
+                    "origQty": "0.00100000",
+                    "executedQty": "0.00000000",
+                    "cummulativeQuoteQty": "0.00000000",
+                    "price": "95000.00000000",
+                    "status": "NEW",
+                    "transactTime": 1700000000000
+                  }
+                }
+                """;
+        JsonNode root = mapper.readTree(json);
+
+        ProcessingResult<?> pr = processor.process(root, root.path("result"), 200, "c1", json, ctx());
+
+        assertTrue(pr.isSuccess());
+        OrderDataDto dto = (OrderDataDto) pr.getData().orElseThrow();
+        assertEquals("v1rcd1t1000000000000s001B_abc123def456", dto.clientOrderId());
+        assertEquals("9876543", dto.orderId());
+        assertEquals("BTCUSDT", dto.symbol().value());
+        assertEquals(OrderDataDto.OrderSide.BUY, dto.side());
+        assertEquals(OrderDataDto.OrderStatus.NEW, dto.status());
+        assertNull(dto.rejectReason());
+    }
+
+    @Test
+    void error400_mapsToRejectedOrderDataDto() throws Exception {
+        String json = """
+                {
+                  "id": "v1rcd1t1000000000000s001B_abc123def456",
+                  "status": 400,
+                  "error": {
+                    "code": -2010,
+                    "msg": "Account has insufficient balance for requested action."
+                  }
+                }
+                """;
+        JsonNode root = mapper.readTree(json);
+
+        ProcessingResult<?> pr = processor.process(root, root.path("result"), 400, "c2", json, ctx());
+
+        assertTrue(pr.isSuccess());
+        OrderDataDto dto = (OrderDataDto) pr.getData().orElseThrow();
+        assertEquals("v1rcd1t1000000000000s001B_abc123def456", dto.clientOrderId());
+        assertEquals(OrderDataDto.OrderStatus.REJECTED, dto.status());
+        assertTrue(dto.rejectReason().contains("insufficient balance"));
+    }
+
+    @Test
+    void success200_noSymbol_returnsIgnored() throws Exception {
+        String json = """
+                {"id": "some-uuid", "status": 200, "result": {}}
+                """;
+        JsonNode root = mapper.readTree(json);
+
+        ProcessingResult<?> pr = processor.process(root, root.path("result"), 200, "c3", json, ctx());
+
+        assertFalse(pr.isSuccess());
+        assertFalse(pr.isError());
+    }
+
+    @Test
+    void sellSide_mappedCorrectly() throws Exception {
+        String json = """
+                {
+                  "id": "v1rcd1t1000000000000s001S_abc123def456",
+                  "status": 200,
+                  "result": {
+                    "symbol": "ETHUSDT",
+                    "orderId": 111,
+                    "clientOrderId": "v1rcd1t1000000000000s001S_abc123def456",
+                    "side": "SELL",
+                    "type": "LIMIT",
+                    "origQty": "0.01000000",
+                    "executedQty": "0.00000000",
+                    "cummulativeQuoteQty": "0.00000000",
+                    "price": "3000.00000000",
+                    "status": "NEW",
+                    "transactTime": 1700000000000
+                  }
+                }
+                """;
+        JsonNode root = mapper.readTree(json);
+
+        ProcessingResult<?> pr = processor.process(root, root.path("result"), 200, "c4", json, ctx());
+
+        assertTrue(pr.isSuccess());
+        OrderDataDto dto = (OrderDataDto) pr.getData().orElseThrow();
+        assertEquals(OrderDataDto.OrderSide.SELL, dto.side());
+    }
+}

--- a/adapter-binance/src/test/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessorTest.java
+++ b/adapter-binance/src/test/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessorTest.java
@@ -92,6 +92,26 @@ class OrderApiResponseProcessorTest {
     }
 
     @Test
+    void error5xx_returnsErrorResult_notRejected() throws Exception {
+        String json = """
+                {
+                  "id": "v1rcd1t1000000000000s001B_abc123def456",
+                  "status": 504,
+                  "error": {
+                    "code": -1001,
+                    "msg": "An unknown error occurred while processing the request."
+                  }
+                }
+                """;
+        JsonNode root = mapper.readTree(json);
+
+        ProcessingResult<?> pr = processor.process(root, root.path("result"), 504, "c5", json, ctx());
+
+        assertFalse(pr.isSuccess(), "5xx must not be treated as success/REJECTED");
+        assertTrue(pr.isError(), "5xx must return error so transaction stays PENDING for recovery");
+    }
+
+    @Test
     void sellSide_mappedCorrectly() throws Exception {
         String json = """
                 {

--- a/adapter-binance/src/test/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessorTest.java
+++ b/adapter-binance/src/test/java/com/marmitt/binance/processor/receive/OrderApiResponseProcessorTest.java
@@ -92,6 +92,36 @@ class OrderApiResponseProcessorTest {
     }
 
     @Test
+    void immediateFill_200_filledStatus_returnsIgnored() throws Exception {
+        String json = """
+                {
+                  "id": "v1rcd1t1000000000000s001B_abc123def456",
+                  "status": 200,
+                  "result": {
+                    "symbol": "BTCUSDT",
+                    "orderId": 9876543,
+                    "clientOrderId": "v1rcd1t1000000000000s001B_abc123def456",
+                    "side": "BUY",
+                    "type": "LIMIT",
+                    "origQty": "0.001",
+                    "executedQty": "0.001",
+                    "cummulativeQuoteQty": "95.00000000",
+                    "price": "95000",
+                    "status": "FILLED",
+                    "transactTime": 1700000000000,
+                    "fills": [{"price": "95000", "qty": "0.001", "commission": "0.00000001", "commissionAsset": "BTC"}]
+                  }
+                }
+                """;
+        JsonNode root = mapper.readTree(json);
+
+        ProcessingResult<?> pr = processor.process(root, root.path("result"), 200, "c-fill", json, ctx());
+
+        assertFalse(pr.isSuccess(), "immediate FILLED must be ignored to defer to fee-accurate executionReport");
+        assertFalse(pr.isError(), "ignored result must not be an error");
+    }
+
+    @Test
     void error5xx_returnsErrorResult_notRejected() throws Exception {
         String json = """
                 {

--- a/spring-application/src/main/java/com/marmitt/application/spring/adapter/OkHttp3WebSocketAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/adapter/OkHttp3WebSocketAdapter.java
@@ -53,7 +53,9 @@ public class OkHttp3WebSocketAdapter implements WebSocketPort {
 
     @Override
     public void sendMessage(String message) {
-        webSocket.send(message);
+        if (!webSocket.send(message)) {
+            throw new IllegalStateException("WebSocket send rejected — socket is closed or send queue is full");
+        }
     }
 
     @Override

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
@@ -60,18 +60,24 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
 
     private boolean tryDispatchViaWebSocketApi(SendOrderRequest request, String exchangeId) {
         WebSocketPort wsApiPort = webSocketRegistry.findUserStreamByExchangeName(exchangeId).orElse(null);
-        if (wsApiPort == null) {
+        if (wsApiPort == null || !wsApiPort.isConnected()) {
             return false;
         }
         ExchangeStreamingPort streamingPort = exchangeAdapterRepository.findStreamingByName(exchangeId).orElse(null);
         if (streamingPort == null) {
             return false;
         }
-        String message = streamingPort.formatMessage(request);
-        wsApiPort.sendMessage(message);
-        log.debug("dispatch: order sent via WebSocket API - clientOrderId={} exchange={}",
-                request.getClientOrderId(), exchangeId);
-        return true;
+        try {
+            String message = streamingPort.formatMessage(request);
+            wsApiPort.sendMessage(message);
+            log.debug("dispatch: order sent via WebSocket API - clientOrderId={} exchange={}",
+                    request.getClientOrderId(), exchangeId);
+            return true;
+        } catch (Exception e) {
+            log.warn("dispatch: WS API send failed - falling back to REST - clientOrderId={} exchange={} reason={}",
+                    request.getClientOrderId(), exchangeId, e.getMessage());
+            return false;
+        }
     }
 
     private boolean tryDispatchViaRest(SendOrderRequest request, String exchangeId) {

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
@@ -43,7 +43,8 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
         SendOrderRequest request = toSendOrderRequest(command, command.exchangeId());
 
         try {
-            if (!tryDispatchViaRest(request, command.exchangeId())) {
+            if (!tryDispatchViaWebSocketApi(request, command.exchangeId())
+                    && !tryDispatchViaRest(request, command.exchangeId())) {
                 dispatchViaStreaming(request, command.exchangeId());
             }
         } catch (OrderFilterViolationException | SymbolFilterLoadException ex) {
@@ -55,6 +56,22 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
 
         log.debug("dispatch: order sent - clientOrderId={} exchange={} symbol={} type={}",
                 command.clientOrderId(), command.exchangeId(), command.symbol(), command.type());
+    }
+
+    private boolean tryDispatchViaWebSocketApi(SendOrderRequest request, String exchangeId) {
+        WebSocketPort wsApiPort = webSocketRegistry.findUserStreamByExchangeName(exchangeId).orElse(null);
+        if (wsApiPort == null) {
+            return false;
+        }
+        ExchangeStreamingPort streamingPort = exchangeAdapterRepository.findStreamingByName(exchangeId).orElse(null);
+        if (streamingPort == null) {
+            return false;
+        }
+        String message = streamingPort.formatMessage(request);
+        wsApiPort.sendMessage(message);
+        log.debug("dispatch: order sent via WebSocket API - clientOrderId={} exchange={}",
+                request.getClientOrderId(), exchangeId);
+        return true;
     }
 
     private boolean tryDispatchViaRest(SendOrderRequest request, String exchangeId) {

--- a/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
@@ -1,0 +1,194 @@
+package com.marmitt.application.spring.infrastructure.exchange;
+
+import com.marmitt.core.domain.Symbol;
+import com.marmitt.core.domain.runner.ClientOrderId;
+import com.marmitt.core.dto.processing.ProcessingResult;
+import com.marmitt.core.dto.runner.OrderDispatchCommand;
+import com.marmitt.core.dto.websocket.MessageContext;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.dto.websocket.data.ProcessorResponse;
+import com.marmitt.core.dto.websocket.request.MessageRequest;
+import com.marmitt.core.dto.websocket.request.SendCancelOrderRequest;
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
+import com.marmitt.core.dto.websocket.request.StreamSubscriptionRequest;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.ports.inbound.runner.OrderConciliationPort;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeAccountQueryPort;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeBootReadinessPort;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSession;
+import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
+import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrderDispatchAdapterTest {
+
+    private static final String EXCHANGE = "BINANCE";
+    private static final String SYMBOL = "BTCUSDT";
+    private static final BigDecimal QTY = new BigDecimal("0.001");
+    private static final BigDecimal PRICE = new BigDecimal("95000");
+
+    private OrderDispatchCommand command() {
+        return new OrderDispatchCommand(
+                ClientOrderId.generate("t01", TransactionType.BUY),
+                UUID.randomUUID(), SYMBOL, EXCHANGE, TransactionType.BUY, QTY, PRICE);
+    }
+
+    @Test
+    void dispatch_usesWebSocketApi_whenUserStreamAvailable() {
+        RecordingWebSocketPort wsApiPort = new RecordingWebSocketPort();
+        RecordingConciliationPort conciliation = new RecordingConciliationPort();
+        StubStreamingPort streaming = new StubStreamingPort();
+
+        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(wsApiPort, null);
+        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, null);
+
+        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
+        adapter.dispatch(command());
+
+        assertEquals(1, wsApiPort.sentMessages.size(), "WS API must have received one message");
+        assertTrue(conciliation.received.isEmpty(), "conciliation must not be called when dispatching via WS API");
+    }
+
+    @Test
+    void dispatch_fallsBackToRest_whenNoUserStream() {
+        RecordingConciliationPort conciliation = new RecordingConciliationPort();
+        StubStreamingPort streaming = new StubStreamingPort();
+        StubOrderExecutionPort restPort = new StubOrderExecutionPort(OrderDataDto.OrderStatus.NEW);
+
+        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(null, null);
+        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, restPort);
+
+        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
+        adapter.dispatch(command());
+
+        assertEquals(1, conciliation.received.size(), "REST path must trigger conciliation");
+        assertEquals(OrderDataDto.OrderStatus.NEW, conciliation.received.get(0).status());
+    }
+
+    @Test
+    void dispatch_rest_propagatesRejectedStatus() {
+        RecordingConciliationPort conciliation = new RecordingConciliationPort();
+        StubStreamingPort streaming = new StubStreamingPort();
+        StubOrderExecutionPort restPort = new StubOrderExecutionPort(OrderDataDto.OrderStatus.REJECTED);
+
+        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(null, null);
+        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, restPort);
+
+        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
+        adapter.dispatch(command());
+
+        assertEquals(1, conciliation.received.size());
+        assertEquals(OrderDataDto.OrderStatus.REJECTED, conciliation.received.get(0).status());
+    }
+
+    @Test
+    void dispatch_fallsBackToStreaming_whenNoUserStreamAndNoRest() {
+        RecordingWebSocketPort marketStreamPort = new RecordingWebSocketPort();
+        StubStreamingPort streaming = new StubStreamingPort();
+
+        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(null, marketStreamPort);
+        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, null);
+
+        RecordingConciliationPort conciliation = new RecordingConciliationPort();
+        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
+        adapter.dispatch(command());
+
+        assertEquals(1, marketStreamPort.sentMessages.size(), "streaming must receive one message");
+        assertTrue(conciliation.received.isEmpty(), "conciliation must not be called on streaming path");
+    }
+
+    // ---- stubs ----
+
+    static class RecordingWebSocketPort implements WebSocketPort {
+        final List<String> sentMessages = new ArrayList<>();
+        @Override public void connect(String url, String exchangeName, UUID connectionId) {}
+        @Override public void disconnect(String exchangeName, UUID id) {}
+        @Override public void sendMessage(String message) { sentMessages.add(message); }
+        @Override public boolean isConnected() { return true; }
+    }
+
+    static class RecordingConciliationPort implements OrderConciliationPort {
+        final List<OrderDataDto> received = new ArrayList<>();
+        @Override public void execute(OrderDataDto orderData) { received.add(orderData); }
+    }
+
+    static class StubStreamingPort implements ExchangeStreamingPort {
+        @Override public String getExchangeName() { return EXCHANGE; }
+        @Override public boolean requiresPostConnection() { return false; }
+        @Override public String buildConnectionUrl(StreamSubscriptionRequest p, String n) { return ""; }
+        @Override public String formatMessage(MessageRequest request) { return "{\"method\":\"order.place\"}"; }
+        @Override public ProcessingResult<? extends ProcessorResponse> processMessage(String raw, MessageContext ctx) { return null; }
+    }
+
+    static class StubOrderExecutionPort implements ExchangeOrderExecutionPort {
+        private final OrderDataDto.OrderStatus status;
+        StubOrderExecutionPort(OrderDataDto.OrderStatus status) { this.status = status; }
+        @Override
+        public OrderDataDto submitOrder(SendOrderRequest request) {
+            return new OrderDataDto("123", request.getClientOrderId(), Symbol.of(SYMBOL),
+                    OrderDataDto.OrderSide.BUY, OrderDataDto.OrderType.LIMIT,
+                    QTY, BigDecimal.ZERO, PRICE, BigDecimal.ZERO, BigDecimal.ZERO,
+                    status, null, Instant.now());
+        }
+        @Override public OrderDataDto cancelOrder(SendCancelOrderRequest request) { throw new UnsupportedOperationException(); }
+    }
+
+    static class StubWebSocketRegistry implements WebSocketPortRegistryPort {
+        private final WebSocketPort userStream;
+        private final WebSocketPort marketStream;
+        StubWebSocketRegistry(WebSocketPort userStream, WebSocketPort marketStream) {
+            this.userStream = userStream;
+            this.marketStream = marketStream;
+        }
+        @Override public void register(String exchangeName, WebSocketPort port) {}
+        @Override public Optional<WebSocketPort> findByExchangeName(String exchangeName) { return Optional.ofNullable(marketStream); }
+        @Override public void registerUserStream(String exchangeName, WebSocketPort port) {}
+        @Override public Optional<WebSocketPort> findUserStreamByExchangeName(String exchangeName) { return Optional.ofNullable(userStream); }
+    }
+
+    static class StubAdapterRepository implements ExchangeAdapterRepositoryPort {
+        private final ExchangeStreamingPort streaming;
+        private final ExchangeOrderExecutionPort orderExecution;
+        StubAdapterRepository(ExchangeStreamingPort streaming, ExchangeOrderExecutionPort orderExecution) {
+            this.streaming = streaming;
+            this.orderExecution = orderExecution;
+        }
+        @Override public Optional<ExchangeStreamingPort> findStreamingByName(String n) { return Optional.ofNullable(streaming); }
+        @Override public Optional<ExchangeOrderExecutionPort> findOrderExecutionByName(String n) { return Optional.ofNullable(orderExecution); }
+        @Override public void registerStreamingAdapter(ExchangeStreamingPort a) {}
+        @Override public void registerUserStreamAdapter(ExchangeUserStreamPort a) {}
+        @Override public void registerUserStreamSession(UserStreamSessionPort s) {}
+        @Override public void storeActiveSession(UUID id, UserStreamSession s) {}
+        @Override public void registerOrderExecutionAdapter(String n, ExchangeOrderExecutionPort a) {}
+        @Override public void registerOrderQueryAdapter(String n, ExchangeOrderQueryPort a) {}
+        @Override public void registerAccountQueryAdapter(String n, ExchangeAccountQueryPort a) {}
+        @Override public void registerBootReadinessAdapter(String n, ExchangeBootReadinessPort a) {}
+        @Override public void registerPortfolioByAdapter(String n, UUID id) {}
+        @Override public boolean hasAdapter(String n) { return true; }
+        @Override public Set<String> getAllExchangeNames() { return Set.of(EXCHANGE); }
+        @Override public int getAdapterCount() { return 1; }
+        @Override public Optional<ExchangeOrderQueryPort> findOrderQueryByName(String n) { return Optional.empty(); }
+        @Override public Optional<ExchangeAccountQueryPort> findAccountQueryByName(String n) { return Optional.empty(); }
+        @Override public Optional<ExchangeBootReadinessPort> findBootReadinessByName(String n) { return Optional.empty(); }
+        @Override public Optional<ExchangeUserStreamPort> findUserStreamByName(String n) { return Optional.empty(); }
+        @Override public Optional<UserStreamSessionPort> findUserStreamSessionByName(String n) { return Optional.empty(); }
+        @Override public Optional<UserStreamSession> findActiveSession(UUID id) { return Optional.empty(); }
+        @Override public void removeActiveSession(UUID id) {}
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
@@ -98,6 +98,25 @@ class OrderDispatchAdapterTest {
     }
 
     @Test
+    void dispatch_fallsBackToRest_whenUserStreamNotConnected() {
+        RecordingWebSocketPort disconnectedWsApiPort = new RecordingWebSocketPort() {
+            @Override public boolean isConnected() { return false; }
+        };
+        RecordingConciliationPort conciliation = new RecordingConciliationPort();
+        StubStreamingPort streaming = new StubStreamingPort();
+        StubOrderExecutionPort restPort = new StubOrderExecutionPort(OrderDataDto.OrderStatus.NEW);
+
+        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(disconnectedWsApiPort, null);
+        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, restPort);
+
+        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
+        adapter.dispatch(command());
+
+        assertTrue(disconnectedWsApiPort.sentMessages.isEmpty(), "disconnected WS API must not receive messages");
+        assertEquals(1, conciliation.received.size(), "must fall back to REST conciliation");
+    }
+
+    @Test
     void dispatch_fallsBackToStreaming_whenNoUserStreamAndNoRest() {
         RecordingWebSocketPort marketStreamPort = new RecordingWebSocketPort();
         StubStreamingPort streaming = new StubStreamingPort();


### PR DESCRIPTION
## Summary

- **`OrderDispatchAdapter`** now tries the WS API (user stream) first, then REST, then streaming — same command object, three dispatch paths
- **`BinanceOrderApiResponseMapper`** + **`OrderApiResponseProcessor`** parse Binance WS API order responses (status 200 → `OrderDataDto.NEW`; non-200 → `REJECTED`)
- **`BinanceUserDataProcessor`** extended routing: uses `ClientOrderId.isValid()` on the `id` field to distinguish order API responses (`v1r...`) from subscription messages (UUID) — preserves T12 subscription-rejection → `WebSocketFailedEvent` behavior

## Design decision: routing by `ClientOrderId.isValid()`

Both order rejections and subscription rejections share the same JSON shape (`status != 200`, `error` field, no `result.subscriptionId`). Routing by `id` format is the only safe discriminator:
- `v1r...` id → order API path → `OrderApiResponseProcessor` → success/REJECTED `OrderDataDto`
- UUID id → `handleSubscriptionConfirmation` → fires `WebSocketFailedEvent` on non-200

## Test plan

- [x] `OrderApiResponseProcessorTest` — 4 tests (200 NEW, 400 REJECTED, 200 no-symbol ignored, SELL side)
- [x] `BinanceUserDataProcessorRoutingTest` — 4 tests (order success, order rejection, subscription confirmation ignored, subscription rejection fires event)
- [x] `OrderDispatchAdapterTest` — 4 tests (WS API path, REST fallback NEW, REST fallback REJECTED, streaming fallback)
- [x] Full `:adapter-binance:test` + `:spring-application:test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)