### PR TITLE
refactor(t14): move HttpClientPort from core to adapter-binance

### DIFF
--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceMarketStreamAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceMarketStreamAdapter.java
@@ -28,7 +28,7 @@ import com.marmitt.core.ports.outbound.exchange.rest.ExchangeBootReadinessPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
-import com.marmitt.core.ports.outbound.http.HttpClientPort;
+import com.marmitt.binance.rest.HttpClientPort;
 
 import java.io.IOException;
 import java.util.List;

--- a/adapter-binance/src/main/java/com/marmitt/binance/boot/BinanceBootReadinessChecker.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/boot/BinanceBootReadinessChecker.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marmitt.binance.rest.BinanceRestRequestBuilder;
 import com.marmitt.binance.rest.RestRequest;
 import com.marmitt.core.dto.exchange.boot.ExchangeBootReadiness;
-import com.marmitt.core.ports.outbound.http.HttpClientPort;
+import com.marmitt.binance.rest.HttpClientPort;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;

--- a/adapter-binance/src/main/java/com/marmitt/binance/filters/SymbolFilterCache.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/filters/SymbolFilterCache.java
@@ -2,7 +2,7 @@ package com.marmitt.binance.filters;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marmitt.core.ports.outbound.http.HttpClientPort;
+import com.marmitt.binance.rest.HttpClientPort;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;

--- a/adapter-binance/src/main/java/com/marmitt/binance/rest/HttpClientPort.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/rest/HttpClientPort.java
@@ -1,4 +1,4 @@
-package com.marmitt.core.ports.outbound.http;
+package com.marmitt.binance.rest;
 
 import java.io.IOException;
 import java.util.Map;

--- a/spring-application/src/main/java/com/marmitt/application/spring/adapter/binance/OkHttpClientAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/adapter/binance/OkHttpClientAdapter.java
@@ -1,6 +1,6 @@
 package com.marmitt.application.spring.adapter.binance;
 
-import com.marmitt.core.ports.outbound.http.HttpClientPort;
+import com.marmitt.binance.rest.HttpClientPort;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;


### PR DESCRIPTION
## Summary

- `HttpClientPort` removido de `core/ports/outbound/http/` e movido para `adapter-binance/rest/HttpClientPort` (`com.marmitt.binance.rest`)
- `core/` não tem mais nenhum port de transporte HTTP
- `OkHttpClientAdapter` em spring-application continua implementando o mesmo contrato — apenas o import muda
- Nenhuma dependência nova adicionada: spring-application já dependia de adapter-binance

**Por que adapter-binance e não spring-application?**
Mover para spring-application criaria dependência circular (`spring-application → adapter-binance → spring-application`). O port deve viver onde é consumido (adapter-binance), e a implementação (OkHttp) fica em spring-application que já tem essa dependência.

## Test plan

- [ ] Compilação limpa nos três módulos (core, adapter-binance, spring-application)
- [ ] Nenhuma referência a `com.marmitt.core.ports.outbound.http.HttpClientPort` no codebase
- [ ] Todos os testes existentes passam sem alteração de comportamento

🤖 Generated with [Claude Code](https://claude.com/claude-code)