### PR TITLE
refactor(t15): ExchangeOrderPort — move transport selection to adapter-binance

### DIFF
--- a/adapter-binance/src/main/java/com/marmitt/binance/BinanceOrderAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/BinanceOrderAdapter.java
@@ -1,0 +1,113 @@
+package com.marmitt.binance;
+
+import com.marmitt.binance.filters.OrderFilterViolationException;
+import com.marmitt.binance.filters.SymbolFilterLoadException;
+import com.marmitt.core.dto.exchange.OrderSubmissionResult;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
+import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
+import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class BinanceOrderAdapter implements ExchangeOrderPort {
+
+    private final WebSocketPort userStreamWebSocket;
+    private final WebSocketPort marketStreamWebSocket;
+    private final ExchangeStreamingPort streamingAdapter;
+    private final ExchangeOrderExecutionPort restAdapter;
+
+    public BinanceOrderAdapter(WebSocketPort userStreamWebSocket,
+                               WebSocketPort marketStreamWebSocket,
+                               ExchangeStreamingPort streamingAdapter,
+                               ExchangeOrderExecutionPort restAdapter) {
+        this.userStreamWebSocket = userStreamWebSocket;
+        this.marketStreamWebSocket = marketStreamWebSocket;
+        this.streamingAdapter = streamingAdapter;
+        this.restAdapter = restAdapter;
+    }
+
+    @Override
+    public String getExchangeName() {
+        return "BINANCE";
+    }
+
+    @Override
+    public OrderSubmissionResult submitOrder(SendOrderRequest request) {
+        try {
+            if (userStreamWebSocket.isConnected()) {
+                OrderSubmissionResult wsResult = tryViaWebSocketApi(request);
+                if (wsResult != null) {
+                    return wsResult;
+                }
+            }
+            return tryViaRestThenStreaming(request);
+        } catch (OrderFilterViolationException | SymbolFilterLoadException ex) {
+            log.warn("submitOrder: order rejected by local filter — clientOrderId={} reason={}",
+                    request.getClientOrderId(), ex.getMessage());
+            return OrderSubmissionResult.failed(ex.getMessage());
+        }
+    }
+
+    private OrderSubmissionResult tryViaWebSocketApi(SendOrderRequest request) {
+        try {
+            String message = streamingAdapter.formatMessage(request);
+            userStreamWebSocket.sendMessage(message);
+            log.debug("submitOrder: sent via WebSocket API — clientOrderId={}", request.getClientOrderId());
+            return OrderSubmissionResult.dispatched();
+        } catch (Exception ex) {
+            log.warn("submitOrder: WS API send failed — falling back to REST — clientOrderId={} reason={}",
+                    request.getClientOrderId(), ex.getMessage());
+            return null;
+        }
+    }
+
+    private OrderSubmissionResult tryViaRestThenStreaming(SendOrderRequest request) {
+        try {
+            OrderDataDto response = restAdapter.submitOrder(request);
+            if (response == null || response.status() == null) {
+                log.warn("submitOrder: REST returned empty status — falling back to streaming — clientOrderId={}",
+                        request.getClientOrderId());
+                return tryViaStreaming(request);
+            }
+            OrderDataDto normalized = normalizeClientOrderId(response, request.getClientOrderId());
+            log.debug("submitOrder: REST submit reconciled — clientOrderId={} status={}",
+                    normalized.clientOrderId(), normalized.status());
+            return OrderSubmissionResult.completed(normalized);
+        } catch (UnsupportedOperationException ex) {
+            log.trace("submitOrder: REST unsupported — falling back to streaming — clientOrderId={}",
+                    request.getClientOrderId());
+            return tryViaStreaming(request);
+        }
+    }
+
+    private OrderSubmissionResult tryViaStreaming(SendOrderRequest request) {
+        String message = streamingAdapter.formatMessage(request);
+        marketStreamWebSocket.sendMessage(message);
+        log.debug("submitOrder: sent via market stream — clientOrderId={}", request.getClientOrderId());
+        return OrderSubmissionResult.dispatched();
+    }
+
+    private static OrderDataDto normalizeClientOrderId(OrderDataDto response, String fallback) {
+        if (response.clientOrderId() != null && !response.clientOrderId().isBlank()) {
+            return response;
+        }
+        return new OrderDataDto(
+                response.orderId(),
+                fallback,
+                response.symbol(),
+                response.side(),
+                response.type(),
+                response.quantity(),
+                response.executedQuantity(),
+                response.price(),
+                response.executedPrice(),
+                response.fee(),
+                response.status(),
+                response.rejectReason(),
+                response.timestamp()
+        );
+    }
+}

--- a/adapter-binance/src/test/java/com/marmitt/binance/BinanceOrderAdapterTest.java
+++ b/adapter-binance/src/test/java/com/marmitt/binance/BinanceOrderAdapterTest.java
@@ -1,0 +1,159 @@
+package com.marmitt.binance;
+
+import com.marmitt.binance.filters.OrderFilterViolationException;
+import com.marmitt.core.domain.Symbol;
+import com.marmitt.core.dto.exchange.OrderSubmissionResult;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.dto.websocket.request.MessageRequest;
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
+import com.marmitt.core.dto.websocket.request.StreamSubscriptionRequest;
+import com.marmitt.core.dto.websocket.MessageContext;
+import com.marmitt.core.dto.processing.ProcessingResult;
+import com.marmitt.core.dto.websocket.data.ProcessorResponse;
+import com.marmitt.core.dto.websocket.request.SendCancelOrderRequest;
+import com.marmitt.core.enums.OrderSide;
+import com.marmitt.core.enums.OrderType;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
+import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
+import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BinanceOrderAdapterTest {
+
+    private static final String EXCHANGE = "BINANCE";
+    private static final String SYMBOL = "BTCUSDT";
+    private static final BigDecimal QTY = new BigDecimal("0.001");
+    private static final BigDecimal PRICE = new BigDecimal("95000");
+
+    private SendOrderRequest request(String clientOrderId) {
+        return new SendOrderRequest(EXCHANGE, SYMBOL, QTY, PRICE, OrderType.LIMIT, OrderSide.BUY, clientOrderId);
+    }
+
+    private OrderDataDto orderDto(String clientOrderId, OrderDataDto.OrderStatus status) {
+        return new OrderDataDto("123", clientOrderId, Symbol.of(SYMBOL),
+                OrderDataDto.OrderSide.BUY, OrderDataDto.OrderType.LIMIT,
+                QTY, BigDecimal.ZERO, PRICE, BigDecimal.ZERO, BigDecimal.ZERO,
+                status, null, Instant.now());
+    }
+
+    @Test
+    void submitOrder_usesWebSocketApi_whenUserStreamConnected() {
+        RecordingWebSocketPort userStreamWs = new RecordingWebSocketPort(true);
+        RecordingWebSocketPort marketWs = new RecordingWebSocketPort(true);
+        StubStreamingPort streaming = new StubStreamingPort();
+        StubRestPort rest = new StubRestPort(null);
+
+        BinanceOrderAdapter adapter = new BinanceOrderAdapter(userStreamWs, marketWs, streaming, rest);
+        OrderSubmissionResult result = adapter.submitOrder(request("t01"));
+
+        assertTrue(result.asyncDispatched(), "should return Dispatched when sent via WS API");
+        assertEquals(1, userStreamWs.sentMessages.size(), "user stream must receive the message");
+        assertTrue(marketWs.sentMessages.isEmpty(), "market stream must not receive message");
+        assertFalse(rest.called, "REST must not be called");
+    }
+
+    @Test
+    void submitOrder_fallsBackToRest_whenUserStreamDisconnected() {
+        RecordingWebSocketPort userStreamWs = new RecordingWebSocketPort(false);
+        RecordingWebSocketPort marketWs = new RecordingWebSocketPort(true);
+        StubStreamingPort streaming = new StubStreamingPort();
+        StubRestPort rest = new StubRestPort(orderDto("t01", OrderDataDto.OrderStatus.NEW));
+
+        BinanceOrderAdapter adapter = new BinanceOrderAdapter(userStreamWs, marketWs, streaming, rest);
+        OrderSubmissionResult result = adapter.submitOrder(request("t01"));
+
+        assertTrue(result.isCompleted(), "should return Completed when REST succeeds");
+        assertEquals(OrderDataDto.OrderStatus.NEW, result.syncResult().status());
+        assertTrue(rest.called, "REST must be called on user stream unavailability");
+        assertTrue(userStreamWs.sentMessages.isEmpty());
+    }
+
+    @Test
+    void submitOrder_fallsBackToStreaming_whenRestUnsupported() {
+        RecordingWebSocketPort userStreamWs = new RecordingWebSocketPort(false);
+        RecordingWebSocketPort marketWs = new RecordingWebSocketPort(true);
+        StubStreamingPort streaming = new StubStreamingPort();
+        StubRestPort rest = new StubRestPort(null) {
+            @Override public OrderDataDto submitOrder(SendOrderRequest r) { throw new UnsupportedOperationException(); }
+        };
+
+        BinanceOrderAdapter adapter = new BinanceOrderAdapter(userStreamWs, marketWs, streaming, rest);
+        OrderSubmissionResult result = adapter.submitOrder(request("t01"));
+
+        assertTrue(result.asyncDispatched(), "should return Dispatched when sent via market stream");
+        assertEquals(1, marketWs.sentMessages.size(), "market stream must receive the message");
+    }
+
+    @Test
+    void submitOrder_returnsFailed_whenFilterViolationThrown() {
+        RecordingWebSocketPort userStreamWs = new RecordingWebSocketPort(true);
+        RecordingWebSocketPort marketWs = new RecordingWebSocketPort(true);
+        StubStreamingPort streaming = new StubStreamingPort() {
+            @Override public String formatMessage(MessageRequest r) {
+                throw new OrderFilterViolationException("stepSize violation");
+            }
+        };
+        StubRestPort rest = new StubRestPort(null);
+
+        BinanceOrderAdapter adapter = new BinanceOrderAdapter(userStreamWs, marketWs, streaming, rest);
+        OrderSubmissionResult result = adapter.submitOrder(request("t01"));
+
+        assertTrue(result.isFailed(), "should return Failed on filter violation");
+        assertEquals("stepSize violation", result.failureReason());
+    }
+
+    @Test
+    void submitOrder_normalizesMissingClientOrderId_whenRestReturnsBlanckId() {
+        RecordingWebSocketPort userStreamWs = new RecordingWebSocketPort(false);
+        RecordingWebSocketPort marketWs = new RecordingWebSocketPort(true);
+        StubStreamingPort streaming = new StubStreamingPort();
+        OrderDataDto responseWithBlankId = new OrderDataDto("123", "", Symbol.of(SYMBOL),
+                OrderDataDto.OrderSide.BUY, OrderDataDto.OrderType.LIMIT,
+                QTY, BigDecimal.ZERO, PRICE, BigDecimal.ZERO, BigDecimal.ZERO,
+                OrderDataDto.OrderStatus.NEW, null, Instant.now());
+        StubRestPort rest = new StubRestPort(responseWithBlankId);
+
+        BinanceOrderAdapter adapter = new BinanceOrderAdapter(userStreamWs, marketWs, streaming, rest);
+        OrderSubmissionResult result = adapter.submitOrder(request("my-client-id"));
+
+        assertTrue(result.isCompleted());
+        assertEquals("my-client-id", result.syncResult().clientOrderId(),
+                "missing clientOrderId from REST must be filled from the request");
+    }
+
+    // ---- stubs ----
+
+    static class RecordingWebSocketPort implements WebSocketPort {
+        final List<String> sentMessages = new ArrayList<>();
+        private final boolean connected;
+        RecordingWebSocketPort(boolean connected) { this.connected = connected; }
+        @Override public void connect(String url, String name, UUID id) {}
+        @Override public void disconnect(String name, UUID id) {}
+        @Override public void sendMessage(String message) { sentMessages.add(message); }
+        @Override public boolean isConnected() { return connected; }
+    }
+
+    static class StubStreamingPort implements ExchangeStreamingPort {
+        @Override public String getExchangeName() { return EXCHANGE; }
+        @Override public boolean requiresPostConnection() { return false; }
+        @Override public String buildConnectionUrl(StreamSubscriptionRequest p, String n) { return ""; }
+        @Override public String formatMessage(MessageRequest request) { return "{\"method\":\"order.place\"}"; }
+        @Override public ProcessingResult<? extends ProcessorResponse> processMessage(String raw, MessageContext ctx) { return null; }
+    }
+
+    static class StubRestPort implements ExchangeOrderExecutionPort {
+        private final OrderDataDto response;
+        boolean called = false;
+        StubRestPort(OrderDataDto response) { this.response = response; }
+        @Override public OrderDataDto submitOrder(SendOrderRequest request) { called = true; return response; }
+        @Override public OrderDataDto cancelOrder(SendCancelOrderRequest request) { throw new UnsupportedOperationException(); }
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/exchange/OrderSubmissionResult.java
+++ b/core/src/main/java/com/marmitt/core/dto/exchange/OrderSubmissionResult.java
@@ -1,0 +1,30 @@
+package com.marmitt.core.dto.exchange;
+
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+
+public record OrderSubmissionResult(
+        boolean asyncDispatched,
+        OrderDataDto syncResult,
+        String failureReason
+) {
+
+    public static OrderSubmissionResult dispatched() {
+        return new OrderSubmissionResult(true, null, null);
+    }
+
+    public static OrderSubmissionResult completed(OrderDataDto dto) {
+        return new OrderSubmissionResult(false, dto, null);
+    }
+
+    public static OrderSubmissionResult failed(String reason) {
+        return new OrderSubmissionResult(false, null, reason);
+    }
+
+    public boolean isCompleted() {
+        return syncResult != null;
+    }
+
+    public boolean isFailed() {
+        return failureReason != null;
+    }
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/ExchangeOrderPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/ExchangeOrderPort.java
@@ -1,0 +1,11 @@
+package com.marmitt.core.ports.outbound.exchange;
+
+import com.marmitt.core.dto.exchange.OrderSubmissionResult;
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
+
+public interface ExchangeOrderPort {
+
+    String getExchangeName();
+
+    OrderSubmissionResult submitOrder(SendOrderRequest request);
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/repository/ExchangeAdapterRepositoryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/repository/ExchangeAdapterRepositoryPort.java
@@ -1,5 +1,6 @@
 package com.marmitt.core.ports.outbound.repository;
 
+import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeAccountQueryPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeBootReadinessPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
@@ -56,6 +57,10 @@ public interface ExchangeAdapterRepositoryPort {
     Optional<UserStreamSession> findActiveSession(UUID connectionId);
 
     void removeActiveSession(UUID connectionId);
+
+    void registerOrderPort(ExchangeOrderPort port);
+
+    Optional<ExchangeOrderPort> findOrderPortByName(String exchangeName);
 
     void blockDispatch(String exchangeName);
 

--- a/core/src/test/java/com/marmitt/core/application/handler/connection/ConnectionLostOrderDispatchGuardTest.java
+++ b/core/src/test/java/com/marmitt/core/application/handler/connection/ConnectionLostOrderDispatchGuardTest.java
@@ -183,5 +183,7 @@ class ConnectionLostOrderDispatchGuardTest {
         @Override public Optional<UserStreamSessionPort> findUserStreamSessionByName(String n) { return Optional.empty(); }
         @Override public Optional<UserStreamSession> findActiveSession(UUID id) { return Optional.empty(); }
         @Override public void removeActiveSession(UUID id) {}
+        @Override public void registerOrderPort(com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort p) {}
+        @Override public Optional<com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort> findOrderPortByName(String n) { return Optional.empty(); }
     }
 }

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -20,6 +20,7 @@ Trilha de tarefas para habilitar operação com a API da Binance (testnet), pré
 | T12 | Migração User Data Stream → WebSocket API Binance | Alta | Claude | Concluído |
 | T13 | Order Placement via WebSocket API Binance | Alta | Claude | Concluído |
 | T14 | Refactor Fronteiras Arquiteturais: Transporte e Negócio | Alta | Claude | Concluído |
+| T15 | ExchangeOrderPort: Mover seleção de transporte para adapter-binance | Média | Claude | Pendente |
 
 ## Ordem de execução
 
@@ -55,6 +56,8 @@ T12  Migração User Data Stream → WS API  ← desbloqueio testnet
 T13  Order Placement via WS API          ← elimina REST para ordens
        ↓
 T14  Refactor fronteiras: transporte     ← reconexão, reações de negócio, HttpClientPort
+       ↓
+T15  ExchangeOrderPort                  ← seleção de transporte no adapter-binance
        ↓
    produção
 ```

--- a/docs/tasks/T15-exchange-order-port.md
+++ b/docs/tasks/T15-exchange-order-port.md
@@ -1,0 +1,120 @@
+# T15 — ExchangeOrderPort: Mover seleção de transporte de despacho para adapter-binance
+
+**Complexidade:** Média  
+**Responsável:** Claude  
+**Dependências:** T14 (refactor fronteiras arquiteturais: transporte e negócio)  
+**Status:** Pendente
+
+---
+
+## Contexto
+
+Após T14, `OrderDispatchAdapter` (spring-application) ainda contém a lógica de seleção de transporte para despacho de ordens: ela testa se o WebSocket de user data está conectado, decide usar o WS API da Binance, cai para REST, ou cai para streaming via market stream.
+
+Essa decisão é um detalhe de provider — o adapter-binance é quem sabe quais transportes existem e em que ordem de preferência usá-los. A camada spring-application não deveria coordenar essa lógica.
+
+O problema concreto: para cada despacho, `OrderDispatchAdapter` precisa de duas buscas em repositórios distintos:
+- `webSocketRegistry.findUserStreamByExchangeName(id)` — verifica conectividade
+- `adapterRepository.findStreamingByName(id)` — obtém o adapter para formatar a mensagem
+
+Isso acopla spring-application ao modelo interno do Binance (user data WS para API de ordens, market WS para streaming fallback).
+
+**Separação que guia o refactor:**
+
+| Responsabilidade | Onde deve viver |
+|---|---|
+| Verificar bloqueio de despacho por perda de conexão | spring-application (`OrderDispatchAdapter`) |
+| Selecionar transporte: WS API → REST → Streaming | adapter-binance (`BinanceOrderAdapter`) |
+| Resultado síncrono de REST → trigger de conciliação | spring-application (`OrderDispatchAdapter`) |
+
+---
+
+## Etapas
+
+### Etapa 1 — `ExchangeOrderPort` e `OrderSubmissionResult` no core
+
+**Novo port outbound** `core/.../ports/outbound/exchange/ExchangeOrderPort.java`:
+```java
+public interface ExchangeOrderPort {
+    String getExchangeName();
+    OrderSubmissionResult submitOrder(SendOrderRequest request);
+}
+```
+
+**Tipo de retorno** `core/.../dto/exchange/OrderSubmissionResult.java`:
+- `dispatched()` — enviado de forma assíncrona (WS ou streaming); fill chegará via user data stream
+- `completed(OrderDataDto dto)` — REST síncrono; conciliação imediata necessária
+- `failed(String reason)` — rejeitado por filtro local ou falha de envio
+
+### Etapa 2 — `BinanceOrderAdapter` em adapter-binance
+
+`adapter-binance/.../BinanceOrderAdapter.java` implementa `ExchangeOrderPort`.
+
+Recebe no construtor via injeção de spring-application:
+- `WebSocketPort userStreamWebSocket` — WS API de ordens (user data channel)
+- `WebSocketPort marketStreamWebSocket` — fallback de streaming
+- `ExchangeStreamingPort streamingAdapter` — formatação de mensagem
+- `ExchangeOrderExecutionPort restAdapter` — submissão REST
+
+Lógica de fallback encapsulada aqui:
+1. `userStreamWs.isConnected()` → formata + envia via user stream → `Dispatched`
+2. `restAdapter.submitOrder(request)` → normaliza clientOrderId → `Completed(dto)`
+3. `UnsupportedOperationException` → formata + envia via market stream → `Dispatched`
+4. `OrderFilterViolationException | SymbolFilterLoadException` → `Failed(reason)`
+
+### Etapa 3 — Extensão do repositório de adapters
+
+Adicionar em `ExchangeAdapterRepositoryPort`:
+```java
+void registerOrderPort(ExchangeOrderPort port);
+Optional<ExchangeOrderPort> findOrderPortByName(String exchangeName);
+```
+
+`InMemoryExchangeAdapterRepository` recebe `List<ExchangeOrderPort> orderPorts` no construtor — Spring injeta todos os beans que implementam o port.
+
+### Etapa 4 — Simplificação de `OrderDispatchAdapter`
+
+Remove: `WebSocketPortRegistryPort`, `tryDispatchViaWebSocketApi`, `tryDispatchViaRest`, `dispatchViaStreaming`, `normalizeClientOrderId`.
+
+Nova lógica:
+```java
+if (isDispatchBlocked) → rejeita via conciliação
+ExchangeOrderPort port = adapterRepository.findOrderPortByName(id).orElseThrow(...)
+OrderSubmissionResult result = port.submitOrder(toSendOrderRequest(command))
+if result.isCompleted() → orderConciliation.execute(result.syncResult())
+if result.isFailed()    → orderConciliation.execute(toRejectedOrder(command, reason))
+// dispatched = sem ação (fill chega async)
+```
+
+### Etapa 5 — Wiring em spring-application
+
+Em `BinanceMarketStreamConfiguration`:
+```java
+@Bean
+public BinanceOrderAdapter binanceOrderAdapter(
+    OkHttp3WebSocketAdapter binanceUserStreamWebSocketPort,   // user data WS
+    OkHttp3WebSocketAdapter binanceMarketWebSocketPort,       // market WS
+    BinanceMarketStreamAdapter binanceMarketStreamAdapter) {  // streaming + REST
+    return new BinanceOrderAdapter(...);
+}
+```
+
+---
+
+## Critérios de aceitação
+
+1. `OrderDispatchAdapter` não referencia `WebSocketPortRegistryPort`
+2. `BinanceOrderAdapter` contém toda a lógica de seleção de transporte
+3. Despacho via WS API → `Dispatched`; via REST → `Completed(dto)` com conciliação; via streaming → `Dispatched`
+4. Violações de filtro retornam `Failed(reason)` com conciliação REJECTED
+5. Compilação limpa em todos os módulos
+6. Todos os testes de `BinanceOrderAdapterTest` e `OrderDispatchAdapterTest` passam
+
+---
+
+## Invariantes preservados
+
+- `InMemoryWebSocketPortRegistry` não muda — ainda necessário para connection management
+- `WebSocketPortRegistryPort` permanece no core — usado por ConnectMarketStream, ConnectUserStream, LinearBackoffReconnectionStrategy
+- `BinanceMarketStreamAdapter` e `BinanceUserStreamAdapter` sem alteração
+- `OrderConciliationPort` permanece chamado somente de spring-application

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceMarketStreamConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceMarketStreamConfiguration.java
@@ -6,6 +6,7 @@ import com.marmitt.application.spring.adapter.OkHttp3WebSocketAdapter;
 import com.marmitt.application.spring.adapter.binance.OkHttpClientAdapter;
 import com.marmitt.binance.BinanceConnectionConfig;
 import com.marmitt.binance.BinanceMarketStreamAdapter;
+import com.marmitt.binance.BinanceOrderAdapter;
 import com.marmitt.binance.filters.SymbolFilterCache;
 import com.marmitt.core.enums.StreamChannel;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
@@ -80,5 +81,17 @@ public class BinanceMarketStreamConfiguration {
                 .build();
         return new BinanceMarketStreamAdapter(objectMapper, config,
                 new OkHttpClientAdapter(bootReadinessClient), binanceSymbolFilterCache);
+    }
+
+    @Bean
+    public BinanceOrderAdapter binanceOrderAdapter(OkHttp3WebSocketAdapter binanceUserStreamWebSocketPort,
+                                                   OkHttp3WebSocketAdapter binanceMarketWebSocketPort,
+                                                   BinanceMarketStreamAdapter binanceMarketStreamAdapter) {
+        return new BinanceOrderAdapter(
+                binanceUserStreamWebSocketPort,
+                binanceMarketWebSocketPort,
+                binanceMarketStreamAdapter,
+                binanceMarketStreamAdapter
+        );
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/CoinbaseAdapterConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/CoinbaseAdapterConfiguration.java
@@ -3,8 +3,11 @@ package com.marmitt.application.spring.config.exchange;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marmitt.application.spring.adapter.OkHttp3ListenerConverter;
 import com.marmitt.application.spring.adapter.OkHttp3WebSocketAdapter;
+import com.marmitt.core.dto.exchange.OrderSubmissionResult;
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.core.enums.StreamChannel;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
 import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,5 +27,21 @@ public class CoinbaseAdapterConfiguration {
     @Bean
     public CoinbaseExchangeAdapter coinbaseExchangeAdapter(ObjectMapper objectMapper) {
         return new CoinbaseExchangeAdapter(objectMapper);
+    }
+
+    // REST not implemented for Coinbase — orders are dispatched via streaming only
+    @Bean
+    public ExchangeOrderPort coinbaseOrderPort(CoinbaseExchangeAdapter coinbaseExchangeAdapter,
+                                               OkHttp3WebSocketAdapter coinbaseWebSocketPort) {
+        return new ExchangeOrderPort() {
+            @Override
+            public String getExchangeName() { return "COINBASE"; }
+
+            @Override
+            public OrderSubmissionResult submitOrder(SendOrderRequest request) {
+                coinbaseWebSocketPort.sendMessage(coinbaseExchangeAdapter.formatMessage(request));
+                return OrderSubmissionResult.dispatched();
+            }
+        };
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockAdapterConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/MockAdapterConfiguration.java
@@ -1,7 +1,11 @@
 package com.marmitt.application.spring.config.exchange;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.dto.exchange.OrderSubmissionResult;
+import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
+import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
 import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
 import com.marmitt.mock.adapter.LocalEventWebSocketAdapter;
 import org.springframework.context.annotation.Bean;
@@ -22,5 +26,29 @@ public class MockAdapterConfiguration {
     public MockExchangeAdapter mockExchangeAdapter(ObjectMapper objectMapper,
                                                    EventPublisherPort eventPublisher) {
         return new MockExchangeAdapter(objectMapper, eventPublisher);
+    }
+
+    @Bean
+    public ExchangeOrderPort mockOrderPort(MockExchangeAdapter mockExchangeAdapter,
+                                           LocalEventWebSocketAdapter mockWebSocketPort) {
+        return new ExchangeOrderPort() {
+            @Override
+            public String getExchangeName() { return "MOCK"; }
+
+            @Override
+            public OrderSubmissionResult submitOrder(SendOrderRequest request) {
+                try {
+                    OrderDataDto dto = mockExchangeAdapter.submitOrder(request);
+                    if (dto == null || dto.status() == null) {
+                        mockWebSocketPort.sendMessage(mockExchangeAdapter.formatMessage(request));
+                        return OrderSubmissionResult.dispatched();
+                    }
+                    return OrderSubmissionResult.completed(dto);
+                } catch (UnsupportedOperationException ex) {
+                    mockWebSocketPort.sendMessage(mockExchangeAdapter.formatMessage(request));
+                    return OrderSubmissionResult.dispatched();
+                }
+            }
+        };
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
@@ -1,8 +1,7 @@
 package com.marmitt.application.spring.infrastructure.exchange;
 
-import com.marmitt.binance.filters.OrderFilterViolationException;
-import com.marmitt.binance.filters.SymbolFilterLoadException;
 import com.marmitt.core.domain.Symbol;
+import com.marmitt.core.dto.exchange.OrderSubmissionResult;
 import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
 import com.marmitt.core.dto.websocket.request.SendOrderRequest;
@@ -10,12 +9,9 @@ import com.marmitt.core.enums.OrderSide;
 import com.marmitt.core.enums.OrderType;
 import com.marmitt.core.enums.TransactionType;
 import com.marmitt.core.ports.inbound.runner.OrderConciliationPort;
+import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
 import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
-import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
-import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
-import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
-import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -28,14 +24,11 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
 
     private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
     private final OrderConciliationPort orderConciliation;
-    private final WebSocketPortRegistryPort webSocketRegistry;
 
     public OrderDispatchAdapter(ExchangeAdapterRepositoryPort exchangeAdapterRepository,
-                                OrderConciliationPort orderConciliation,
-                                WebSocketPortRegistryPort webSocketRegistry) {
+                                OrderConciliationPort orderConciliation) {
         this.exchangeAdapterRepository = exchangeAdapterRepository;
         this.orderConciliation = orderConciliation;
-        this.webSocketRegistry = webSocketRegistry;
     }
 
     @Override
@@ -47,84 +40,24 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
             return;
         }
 
+        ExchangeOrderPort orderPort = exchangeAdapterRepository
+                .findOrderPortByName(command.exchangeId())
+                .orElseThrow(() -> new IllegalStateException(
+                        "No order port registered for exchangeId: " + command.exchangeId()));
+
         SendOrderRequest request = toSendOrderRequest(command, command.exchangeId());
+        OrderSubmissionResult result = orderPort.submitOrder(request);
 
-        try {
-            if (!tryDispatchViaWebSocketApi(request, command.exchangeId())
-                    && !tryDispatchViaRest(request, command.exchangeId())) {
-                dispatchViaStreaming(request, command.exchangeId());
-            }
-        } catch (OrderFilterViolationException | SymbolFilterLoadException ex) {
-            log.warn("dispatch: order rejected by local filter - clientOrderId={} exchange={} reason={}",
-                    command.clientOrderId(), command.exchangeId(), ex.getMessage());
-            orderConciliation.execute(toRejectedOrder(command, ex.getMessage()));
-            return;
+        if (result.isCompleted()) {
+            orderConciliation.execute(result.syncResult());
+        } else if (result.isFailed()) {
+            log.warn("dispatch: order rejected — clientOrderId={} exchange={} reason={}",
+                    command.clientOrderId(), command.exchangeId(), result.failureReason());
+            orderConciliation.execute(toRejectedOrder(command, result.failureReason()));
         }
 
-        log.debug("dispatch: order sent - clientOrderId={} exchange={} symbol={} type={}",
+        log.debug("dispatch: order sent — clientOrderId={} exchange={} symbol={} type={}",
                 command.clientOrderId(), command.exchangeId(), command.symbol(), command.type());
-    }
-
-    private boolean tryDispatchViaWebSocketApi(SendOrderRequest request, String exchangeId) {
-        WebSocketPort wsApiPort = webSocketRegistry.findUserStreamByExchangeName(exchangeId).orElse(null);
-        if (wsApiPort == null || !wsApiPort.isConnected()) {
-            return false;
-        }
-        ExchangeStreamingPort streamingPort = exchangeAdapterRepository.findStreamingByName(exchangeId).orElse(null);
-        if (streamingPort == null) {
-            return false;
-        }
-        try {
-            String message = streamingPort.formatMessage(request);
-            wsApiPort.sendMessage(message);
-            log.debug("dispatch: order sent via WebSocket API - clientOrderId={} exchange={}",
-                    request.getClientOrderId(), exchangeId);
-            return true;
-        } catch (Exception e) {
-            log.warn("dispatch: WS API send failed - falling back to REST - clientOrderId={} exchange={} reason={}",
-                    request.getClientOrderId(), exchangeId, e.getMessage());
-            return false;
-        }
-    }
-
-    private boolean tryDispatchViaRest(SendOrderRequest request, String exchangeId) {
-        ExchangeOrderExecutionPort executionPort = exchangeAdapterRepository
-                .findOrderExecutionByName(exchangeId)
-                .orElse(null);
-        if (executionPort == null) {
-            return false;
-        }
-
-        try {
-            OrderDataDto response = executionPort.submitOrder(request);
-            if (response == null || response.status() == null) {
-                log.warn("dispatch: REST submit returned empty status - fallback to streaming clientOrderId={} exchange={}",
-                        request.getClientOrderId(), exchangeId);
-                return false;
-            }
-
-            OrderDataDto normalized = normalizeClientOrderId(response, request.getClientOrderId());
-            orderConciliation.execute(normalized);
-            log.debug("dispatch: REST submit reconciled - clientOrderId={} exchange={} status={}",
-                    normalized.clientOrderId(), exchangeId, normalized.status());
-            return true;
-        } catch (UnsupportedOperationException ex) {
-            log.trace("dispatch: REST submit unsupported for exchange={} - fallback to streaming", exchangeId);
-            return false;
-        }
-    }
-
-    private void dispatchViaStreaming(SendOrderRequest request, String exchangeId) {
-        ExchangeStreamingPort streamingPort = exchangeAdapterRepository
-                .findStreamingByName(exchangeId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "No streaming capability found for exchangeId: " + exchangeId));
-
-        String message = streamingPort.formatMessage(request);
-        WebSocketPort webSocket = webSocketRegistry.findByExchangeName(exchangeId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "No WebSocket registered for exchangeId: " + exchangeId));
-        webSocket.sendMessage(message);
     }
 
     private SendOrderRequest toSendOrderRequest(OrderDispatchCommand command, String exchangeName) {
@@ -157,27 +90,6 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
                 OrderDataDto.OrderStatus.REJECTED,
                 rejectReason,
                 Instant.now()
-        );
-    }
-
-    private static OrderDataDto normalizeClientOrderId(OrderDataDto response, String fallbackClientOrderId) {
-        if (response.clientOrderId() != null && !response.clientOrderId().isBlank()) {
-            return response;
-        }
-        return new OrderDataDto(
-                response.orderId(),
-                fallbackClientOrderId,
-                response.symbol(),
-                response.side(),
-                response.type(),
-                response.quantity(),
-                response.executedQuantity(),
-                response.price(),
-                response.executedPrice(),
-                response.fee(),
-                response.status(),
-                response.rejectReason(),
-                response.timestamp()
         );
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryExchangeAdapterRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/repository/InMemoryExchangeAdapterRepository.java
@@ -1,5 +1,6 @@
 package com.marmitt.application.spring.repository;
 
+import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeAccountQueryPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeBootReadinessPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
@@ -35,13 +36,16 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
     private final Map<String, ExchangeAccountQueryPort> accountQueryAdapters = new ConcurrentHashMap<>();
     private final Map<String, ExchangeBootReadinessPort> bootReadinessAdapters = new ConcurrentHashMap<>();
     private final Map<UUID, String> adapterByPortfolio = new ConcurrentHashMap<>();
+    private final Map<String, ExchangeOrderPort> orderPorts = new ConcurrentHashMap<>();
 
     public InMemoryExchangeAdapterRepository(List<ExchangeStreamingPort> adapters,
                                              List<ExchangeUserStreamPort> userStreamAdapters,
-                                             List<UserStreamSessionPort> userStreamSessions) {
+                                             List<UserStreamSessionPort> userStreamSessions,
+                                             List<ExchangeOrderPort> orderPorts) {
         adapters.forEach(this::registerAllCapabilities);
         userStreamAdapters.forEach(this::registerUserStreamAdapter);
         userStreamSessions.forEach(this::registerUserStreamSession);
+        orderPorts.forEach(this::registerOrderPort);
     }
 
     @Override
@@ -150,6 +154,18 @@ public class InMemoryExchangeAdapterRepository implements ExchangeAdapterReposit
     @Override
     public Optional<UserStreamSessionPort> findUserStreamSessionByName(String exchangeName) {
         return Optional.ofNullable(userStreamSessionAdapters.get(normalize(exchangeName)));
+    }
+
+    @Override
+    public void registerOrderPort(ExchangeOrderPort port) {
+        String exchangeName = normalize(port.getExchangeName());
+        orderPorts.put(exchangeName, port);
+        log.info("Order port registered - exchange={}", exchangeName);
+    }
+
+    @Override
+    public Optional<ExchangeOrderPort> findOrderPortByName(String exchangeName) {
+        return Optional.ofNullable(orderPorts.get(normalize(exchangeName)));
     }
 
     @Override

--- a/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/connection/LinearBackoffReconnectionStrategyTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/connection/LinearBackoffReconnectionStrategyTest.java
@@ -153,6 +153,8 @@ class LinearBackoffReconnectionStrategyTest {
         @Override public Optional<UserStreamSessionPort> findUserStreamSessionByName(String n) { return Optional.empty(); }
         @Override public Optional<UserStreamSession> findActiveSession(UUID id) { return Optional.empty(); }
         @Override public void removeActiveSession(UUID id) {}
+        @Override public void registerOrderPort(com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort p) {}
+        @Override public Optional<com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort> findOrderPortByName(String n) { return Optional.empty(); }
         @Override public void blockDispatch(String n) {}
         @Override public void unblockDispatch(String n) {}
         @Override public boolean isDispatchBlocked(String n) { return false; }

--- a/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
@@ -2,17 +2,13 @@ package com.marmitt.application.spring.infrastructure.exchange;
 
 import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.domain.runner.ClientOrderId;
-import com.marmitt.core.dto.processing.ProcessingResult;
+import com.marmitt.core.dto.exchange.OrderSubmissionResult;
 import com.marmitt.core.dto.runner.OrderDispatchCommand;
-import com.marmitt.core.dto.websocket.MessageContext;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
-import com.marmitt.core.dto.websocket.data.ProcessorResponse;
-import com.marmitt.core.dto.websocket.request.MessageRequest;
-import com.marmitt.core.dto.websocket.request.SendCancelOrderRequest;
 import com.marmitt.core.dto.websocket.request.SendOrderRequest;
-import com.marmitt.core.dto.websocket.request.StreamSubscriptionRequest;
 import com.marmitt.core.enums.TransactionType;
 import com.marmitt.core.ports.inbound.runner.OrderConciliationPort;
+import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeAccountQueryPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeBootReadinessPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
@@ -22,8 +18,6 @@ import com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort
 import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSession;
 import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
-import com.marmitt.core.ports.outbound.websocket.WebSocketPort;
-import com.marmitt.core.ports.outbound.websocket.WebSocketPortRegistryPort;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -49,167 +43,82 @@ class OrderDispatchAdapterTest {
                 UUID.randomUUID(), SYMBOL, EXCHANGE, TransactionType.BUY, QTY, PRICE);
     }
 
-    @Test
-    void dispatch_usesWebSocketApi_whenUserStreamAvailable() {
-        RecordingWebSocketPort wsApiPort = new RecordingWebSocketPort();
-        RecordingConciliationPort conciliation = new RecordingConciliationPort();
-        StubStreamingPort streaming = new StubStreamingPort();
-
-        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(wsApiPort, null);
-        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, null);
-
-        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
-        adapter.dispatch(command());
-
-        assertEquals(1, wsApiPort.sentMessages.size(), "WS API must have received one message");
-        assertTrue(conciliation.received.isEmpty(), "conciliation must not be called when dispatching via WS API");
-    }
-
-    @Test
-    void dispatch_fallsBackToRest_whenNoUserStream() {
-        RecordingConciliationPort conciliation = new RecordingConciliationPort();
-        StubStreamingPort streaming = new StubStreamingPort();
-        StubOrderExecutionPort restPort = new StubOrderExecutionPort(OrderDataDto.OrderStatus.NEW);
-
-        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(null, null);
-        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, restPort);
-
-        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
-        adapter.dispatch(command());
-
-        assertEquals(1, conciliation.received.size(), "REST path must trigger conciliation");
-        assertEquals(OrderDataDto.OrderStatus.NEW, conciliation.received.get(0).status());
-    }
-
-    @Test
-    void dispatch_rest_propagatesRejectedStatus() {
-        RecordingConciliationPort conciliation = new RecordingConciliationPort();
-        StubStreamingPort streaming = new StubStreamingPort();
-        StubOrderExecutionPort restPort = new StubOrderExecutionPort(OrderDataDto.OrderStatus.REJECTED);
-
-        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(null, null);
-        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, restPort);
-
-        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
-        adapter.dispatch(command());
-
-        assertEquals(1, conciliation.received.size());
-        assertEquals(OrderDataDto.OrderStatus.REJECTED, conciliation.received.get(0).status());
+    private OrderDataDto sampleDto(OrderDataDto.OrderStatus status) {
+        return new OrderDataDto("123", "t01-BUY-001", Symbol.of(SYMBOL),
+                OrderDataDto.OrderSide.BUY, OrderDataDto.OrderType.LIMIT,
+                QTY, BigDecimal.ZERO, PRICE, BigDecimal.ZERO, BigDecimal.ZERO,
+                status, null, Instant.now());
     }
 
     @Test
     void dispatch_rejectsOrder_whenDispatchBlocked() {
-        RecordingWebSocketPort wsApiPort = new RecordingWebSocketPort();
         RecordingConciliationPort conciliation = new RecordingConciliationPort();
-        StubStreamingPort streaming = new StubStreamingPort();
-        StubOrderExecutionPort restPort = new StubOrderExecutionPort(OrderDataDto.OrderStatus.NEW);
-
-        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(wsApiPort, null);
-        StubAdapterRepository adapterRepo = new StubAdapterRepository(streaming, restPort) {
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(new StubOrderPort(OrderSubmissionResult.dispatched())) {
             @Override public boolean isDispatchBlocked(String exchangeName) { return true; }
         };
 
-        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
-        adapter.dispatch(command());
+        new OrderDispatchAdapter(adapterRepo, conciliation).dispatch(command());
 
-        assertTrue(wsApiPort.sentMessages.isEmpty(), "blocked dispatch must not send via WS API");
         assertEquals(1, conciliation.received.size(), "blocked dispatch must conciliate as REJECTED");
         assertEquals(OrderDataDto.OrderStatus.REJECTED, conciliation.received.get(0).status());
     }
 
     @Test
-    void dispatch_fallsBackToRest_whenUserStreamNotConnected() {
-        RecordingWebSocketPort disconnectedWsApiPort = new RecordingWebSocketPort() {
-            @Override public boolean isConnected() { return false; }
-        };
+    void dispatch_doesNotConciliate_whenPortReturnsDispatched() {
         RecordingConciliationPort conciliation = new RecordingConciliationPort();
-        StubStreamingPort streaming = new StubStreamingPort();
-        StubOrderExecutionPort restPort = new StubOrderExecutionPort(OrderDataDto.OrderStatus.NEW);
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.dispatched()));
 
-        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(disconnectedWsApiPort, null);
-        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, restPort);
+        new OrderDispatchAdapter(adapterRepo, conciliation).dispatch(command());
 
-        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
-        adapter.dispatch(command());
-
-        assertTrue(disconnectedWsApiPort.sentMessages.isEmpty(), "disconnected WS API must not receive messages");
-        assertEquals(1, conciliation.received.size(), "must fall back to REST conciliation");
+        assertTrue(conciliation.received.isEmpty(), "async dispatch must not trigger conciliation");
     }
 
     @Test
-    void dispatch_fallsBackToStreaming_whenNoUserStreamAndNoRest() {
-        RecordingWebSocketPort marketStreamPort = new RecordingWebSocketPort();
-        StubStreamingPort streaming = new StubStreamingPort();
-
-        WebSocketPortRegistryPort registry = new StubWebSocketRegistry(null, marketStreamPort);
-        ExchangeAdapterRepositoryPort adapterRepo = new StubAdapterRepository(streaming, null);
-
+    void dispatch_conciliates_whenPortReturnsCompleted() {
         RecordingConciliationPort conciliation = new RecordingConciliationPort();
-        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, conciliation, registry);
-        adapter.dispatch(command());
+        OrderDataDto dto = sampleDto(OrderDataDto.OrderStatus.NEW);
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.completed(dto)));
 
-        assertEquals(1, marketStreamPort.sentMessages.size(), "streaming must receive one message");
-        assertTrue(conciliation.received.isEmpty(), "conciliation must not be called on streaming path");
+        new OrderDispatchAdapter(adapterRepo, conciliation).dispatch(command());
+
+        assertEquals(1, conciliation.received.size());
+        assertEquals(OrderDataDto.OrderStatus.NEW, conciliation.received.get(0).status());
+    }
+
+    @Test
+    void dispatch_conciliatesRejected_whenPortReturnsFailed() {
+        RecordingConciliationPort conciliation = new RecordingConciliationPort();
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.failed("filter violation: stepSize")));
+
+        new OrderDispatchAdapter(adapterRepo, conciliation).dispatch(command());
+
+        assertEquals(1, conciliation.received.size());
+        assertEquals(OrderDataDto.OrderStatus.REJECTED, conciliation.received.get(0).status());
+        assertEquals("filter violation: stepSize", conciliation.received.get(0).rejectReason());
     }
 
     // ---- stubs ----
-
-    static class RecordingWebSocketPort implements WebSocketPort {
-        final List<String> sentMessages = new ArrayList<>();
-        @Override public void connect(String url, String exchangeName, UUID connectionId) {}
-        @Override public void disconnect(String exchangeName, UUID id) {}
-        @Override public void sendMessage(String message) { sentMessages.add(message); }
-        @Override public boolean isConnected() { return true; }
-    }
 
     static class RecordingConciliationPort implements OrderConciliationPort {
         final List<OrderDataDto> received = new ArrayList<>();
         @Override public void execute(OrderDataDto orderData) { received.add(orderData); }
     }
 
-    static class StubStreamingPort implements ExchangeStreamingPort {
+    static class StubOrderPort implements ExchangeOrderPort {
+        private final OrderSubmissionResult result;
+        StubOrderPort(OrderSubmissionResult result) { this.result = result; }
         @Override public String getExchangeName() { return EXCHANGE; }
-        @Override public boolean requiresPostConnection() { return false; }
-        @Override public String buildConnectionUrl(StreamSubscriptionRequest p, String n) { return ""; }
-        @Override public String formatMessage(MessageRequest request) { return "{\"method\":\"order.place\"}"; }
-        @Override public ProcessingResult<? extends ProcessorResponse> processMessage(String raw, MessageContext ctx) { return null; }
-    }
-
-    static class StubOrderExecutionPort implements ExchangeOrderExecutionPort {
-        private final OrderDataDto.OrderStatus status;
-        StubOrderExecutionPort(OrderDataDto.OrderStatus status) { this.status = status; }
-        @Override
-        public OrderDataDto submitOrder(SendOrderRequest request) {
-            return new OrderDataDto("123", request.getClientOrderId(), Symbol.of(SYMBOL),
-                    OrderDataDto.OrderSide.BUY, OrderDataDto.OrderType.LIMIT,
-                    QTY, BigDecimal.ZERO, PRICE, BigDecimal.ZERO, BigDecimal.ZERO,
-                    status, null, Instant.now());
-        }
-        @Override public OrderDataDto cancelOrder(SendCancelOrderRequest request) { throw new UnsupportedOperationException(); }
-    }
-
-    static class StubWebSocketRegistry implements WebSocketPortRegistryPort {
-        private final WebSocketPort userStream;
-        private final WebSocketPort marketStream;
-        StubWebSocketRegistry(WebSocketPort userStream, WebSocketPort marketStream) {
-            this.userStream = userStream;
-            this.marketStream = marketStream;
-        }
-        @Override public void register(String exchangeName, WebSocketPort port) {}
-        @Override public Optional<WebSocketPort> findByExchangeName(String exchangeName) { return Optional.ofNullable(marketStream); }
-        @Override public void registerUserStream(String exchangeName, WebSocketPort port) {}
-        @Override public Optional<WebSocketPort> findUserStreamByExchangeName(String exchangeName) { return Optional.ofNullable(userStream); }
+        @Override public OrderSubmissionResult submitOrder(SendOrderRequest request) { return result; }
     }
 
     static class StubAdapterRepository implements ExchangeAdapterRepositoryPort {
-        private final ExchangeStreamingPort streaming;
-        private final ExchangeOrderExecutionPort orderExecution;
-        StubAdapterRepository(ExchangeStreamingPort streaming, ExchangeOrderExecutionPort orderExecution) {
-            this.streaming = streaming;
-            this.orderExecution = orderExecution;
-        }
-        @Override public Optional<ExchangeStreamingPort> findStreamingByName(String n) { return Optional.ofNullable(streaming); }
-        @Override public Optional<ExchangeOrderExecutionPort> findOrderExecutionByName(String n) { return Optional.ofNullable(orderExecution); }
+        private final ExchangeOrderPort orderPort;
+        StubAdapterRepository(ExchangeOrderPort orderPort) { this.orderPort = orderPort; }
+        @Override public Optional<ExchangeOrderPort> findOrderPortByName(String n) { return Optional.ofNullable(orderPort); }
+        @Override public void registerOrderPort(ExchangeOrderPort p) {}
         @Override public void registerStreamingAdapter(ExchangeStreamingPort a) {}
         @Override public void registerUserStreamAdapter(ExchangeUserStreamPort a) {}
         @Override public void registerUserStreamSession(UserStreamSessionPort s) {}
@@ -222,6 +131,8 @@ class OrderDispatchAdapterTest {
         @Override public boolean hasAdapter(String n) { return true; }
         @Override public Set<String> getAllExchangeNames() { return Set.of(EXCHANGE); }
         @Override public int getAdapterCount() { return 1; }
+        @Override public Optional<ExchangeStreamingPort> findStreamingByName(String n) { return Optional.empty(); }
+        @Override public Optional<ExchangeOrderExecutionPort> findOrderExecutionByName(String n) { return Optional.empty(); }
         @Override public Optional<ExchangeOrderQueryPort> findOrderQueryByName(String n) { return Optional.empty(); }
         @Override public Optional<ExchangeAccountQueryPort> findAccountQueryByName(String n) { return Optional.empty(); }
         @Override public Optional<ExchangeBootReadinessPort> findBootReadinessByName(String n) { return Optional.empty(); }


### PR DESCRIPTION
## Summary

- Introduces `ExchangeOrderPort` (core outbound port) and `OrderSubmissionResult` (`Dispatched | Completed(dto) | Failed(reason)`)
- Creates `BinanceOrderAdapter` in adapter-binance encapsulating the 3-tier fallback: WS API → REST → Streaming
- Simplifies `OrderDispatchAdapter` to a blocked-dispatch guard + single port call — no more transport knowledge in spring-application
- Extends `ExchangeAdapterRepositoryPort` / `InMemoryExchangeAdapterRepository` with `registerOrderPort` / `findOrderPortByName`
- Adds `ExchangeOrderPort` beans for Mock and Coinbase adapters to complete coverage

## Motivation

Before this change, `OrderDispatchAdapter` (spring-application) queried two separate registries per dispatch and manually implemented Binance-specific transport selection logic. The adapter layer was never consulted — spring-application knew about user-data WebSocket for WS API orders, market WebSocket for streaming fallback, and REST as the middle tier.

## Test plan

- [x] `BinanceOrderAdapterTest` — 5 tests covering WS API, REST fallback, streaming fallback, filter violation, clientOrderId normalization
- [x] `OrderDispatchAdapterTest` — 4 tests covering blocked dispatch, Dispatched/Completed/Failed result handling
- [x] 110 spring-application integration tests pass (including `OrderLifecycleMockIntegrationTest`, `ProcessTradeSignalMockIntegrationTest`)
- [x] `./gradlew :core:test :adapter-binance:test :spring-application:test` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)