### PR TITLE
fix(boot): activate runner after boot recovery when status is CREATED

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/RunnerBootRecoveryUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/RunnerBootRecoveryUseCase.java
@@ -444,9 +444,19 @@ public class RunnerBootRecoveryUseCase {
         }
 
         if (!ctx.hasErrors()) {
-            latestRunner.completeReconciliation();
+            RunnerStatus currentStatus = latestRunner.getStatus();
+            if (currentStatus == RunnerStatus.CREATED) {
+                latestRunner.startInitializing();
+                latestRunner.activate();
+                ctx.note("Step 6: runner activated CREATED->ACTIVE.");
+            } else if (currentStatus == RunnerStatus.INITIALIZING) {
+                latestRunner.activate();
+                ctx.note("Step 6: runner activated INITIALIZING->ACTIVE.");
+            } else {
+                latestRunner.completeReconciliation();
+                ctx.note("Step 6: reconciliation completed and runner persisted.");
+            }
             strategyRunnerRepository.save(latestRunner);
-            ctx.note("Step 6: reconciliation completed and runner persisted.");
             return;
         }
 


### PR DESCRIPTION
## Problema

`step6FinalizeRunnerState` chamava `completeReconciliation()`, que só limpa a flag `isReconciling` sem alterar o status. Um runner criado via REST nasce em `CREATED` e, após o boot recovery, continuava `CREATED`. A query `findOperationalBySymbol` filtra por `status IN ('ACTIVE', 'HALTED')`, então o runner nunca recebia sinais de preço.

Descoberto durante testes com a Binance testnet: market data chegava normalmente mas `ProcessTradeSignalUseCase` logava `no operational runners for symbol=BTCUSDT exchange=BINANCE`.

## Fix

Transição explícita no caminho sem erros de `step6FinalizeRunnerState`:
- `CREATED` → `startInitializing()` → `activate()`
- `INITIALIZING` → `activate()`
- `ACTIVE` / `HALTED` → `completeReconciliation()` (comportamento anterior, para runners que passaram por recovery sem mudança de status)

## Test plan

- [ ] `./gradlew :core:test :spring-application:test` — verde (verificado)
- [ ] Restart com runner em CREATED: log deve exibir `Step 6: runner activated CREATED->ACTIVE`
- [ ] `findOperationalBySymbol` deve retornar 1 resultado após o boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)