### PR TITLE
feat(t18): trade reconciliation report

### DIFF
--- a/adapter-binance/build.gradle
+++ b/adapter-binance/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
 }
 
 test {

--- a/adapter-binance/src/main/java/com/marmitt/binance/rest/BinanceRestRequestBuilder.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/rest/BinanceRestRequestBuilder.java
@@ -15,6 +15,7 @@ public class BinanceRestRequestBuilder {
     private static final String ORDER_PATH       = "/api/v3/order";
     private static final String OPEN_ORDERS_PATH = "/api/v3/openOrders";
     private static final String ACCOUNT_PATH     = "/api/v3/account";
+    private static final String MY_TRADES_PATH   = "/api/v3/myTrades";
 
     private final String restBaseUrl;
     private final BinanceRequestSigner signer;
@@ -69,6 +70,23 @@ public class BinanceRestRequestBuilder {
 
     public RestRequest buildAccountSnapshot() {
         return get(ACCOUNT_PATH, Map.of());
+    }
+
+    public RestRequest buildMyTrades(String symbol, long startTime, long endTime) {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("symbol", symbol);
+        params.put("startTime", String.valueOf(startTime));
+        params.put("endTime", String.valueOf(endTime));
+        params.put("limit", "1000");
+        return get(MY_TRADES_PATH, params);
+    }
+
+    public RestRequest buildMyTradesFromId(String symbol, long fromId) {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("symbol", symbol);
+        params.put("fromId", String.valueOf(fromId));
+        params.put("limit", "1000");
+        return get(MY_TRADES_PATH, params);
     }
 
     private RestRequest get(String path, Map<String, String> params) {

--- a/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
@@ -1,0 +1,100 @@
+package com.marmitt.binance.trade;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.binance.rest.BinanceRestRequestBuilder;
+import com.marmitt.binance.rest.HttpClientPort;
+import com.marmitt.binance.rest.RestRequest;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class BinanceTradeHistoryAdapter implements TradeHistoryQueryPort {
+
+    private static final int PAGE_LIMIT = 1000;
+
+    private final BinanceRestRequestBuilder requestBuilder;
+    private final HttpClientPort httpClient;
+    private final ObjectMapper objectMapper;
+
+    public BinanceTradeHistoryAdapter(BinanceRestRequestBuilder requestBuilder,
+                                      HttpClientPort httpClient,
+                                      ObjectMapper objectMapper) {
+        this.requestBuilder = requestBuilder;
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<TradeExecutionDto> fetchTrades(String symbol, Instant from, Instant to) {
+        List<TradeExecutionDto> all = new ArrayList<>();
+        long startTime = from.toEpochMilli();
+        long endTime = to.toEpochMilli();
+
+        List<TradeExecutionDto> page = fetchPage(requestBuilder.buildMyTrades(symbol, startTime, endTime));
+        all.addAll(page);
+
+        // Paginate: if full page returned, advance using fromId of last trade
+        while (page.size() == PAGE_LIMIT) {
+            long lastId = Long.parseLong(page.getLast().exchangeTradeId());
+            page = fetchPage(requestBuilder.buildMyTradesFromId(symbol, lastId + 1));
+            // Filter client-side to stay within endTime since fromId ignores time range
+            page = page.stream()
+                    .filter(t -> !t.executedAt().isAfter(to))
+                    .toList();
+            all.addAll(page);
+            if (page.size() < PAGE_LIMIT) break;
+        }
+
+        log.debug("reconciliation: fetched {} trades for symbol={} from={} to={}", all.size(), symbol, from, to);
+        return all;
+    }
+
+    private List<TradeExecutionDto> fetchPage(RestRequest req) {
+        HttpClientPort.HttpResponse response;
+        try {
+            response = httpClient.get(req.url(), req.headers());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to fetch myTrades from Binance: " + e.getMessage(), e);
+        }
+
+        if (!response.isSuccessful()) {
+            throw new RuntimeException(
+                    "Binance myTrades returned HTTP " + response.statusCode() + ": " + response.body());
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(response.body());
+            List<TradeExecutionDto> trades = new ArrayList<>(root.size());
+            for (JsonNode node : root) {
+                trades.add(parseTrade(node));
+            }
+            return trades;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse myTrades response: " + e.getMessage(), e);
+        }
+    }
+
+    private TradeExecutionDto parseTrade(JsonNode node) {
+        return new TradeExecutionDto(
+                node.path("id").asText(),
+                node.path("orderId").asLong(),
+                node.path("clientOrderId").asText(null),
+                node.path("symbol").asText(),
+                new BigDecimal(node.path("price").asText()),
+                new BigDecimal(node.path("qty").asText()),
+                new BigDecimal(node.path("quoteQty").asText()),
+                new BigDecimal(node.path("commission").asText("0")),
+                node.path("commissionAsset").asText(null),
+                Instant.ofEpochMilli(node.path("time").asLong()),
+                node.path("isBuyer").asBoolean()
+        );
+    }
+}

--- a/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
@@ -19,6 +19,8 @@ import java.util.List;
 public class BinanceTradeHistoryAdapter implements TradeHistoryQueryPort {
 
     private static final int PAGE_LIMIT = 1000;
+    // Binance caps startTime/endTime window at 24 hours for GET /api/v3/myTrades
+    private static final long WINDOW_MS = 24L * 60 * 60 * 1000;
 
     private final BinanceRestRequestBuilder requestBuilder;
     private final HttpClientPort httpClient;
@@ -33,28 +35,47 @@ public class BinanceTradeHistoryAdapter implements TradeHistoryQueryPort {
     }
 
     @Override
+    public String getExchangeName() {
+        return "BINANCE";
+    }
+
+    @Override
     public List<TradeExecutionDto> fetchTrades(String symbol, Instant from, Instant to) {
         List<TradeExecutionDto> all = new ArrayList<>();
-        long startTime = from.toEpochMilli();
-        long endTime = to.toEpochMilli();
+        long windowStart = from.toEpochMilli();
+        long totalEnd = to.toEpochMilli();
 
-        List<TradeExecutionDto> page = fetchPage(requestBuilder.buildMyTrades(symbol, startTime, endTime));
+        while (windowStart <= totalEnd) {
+            // Keep each Binance request within the 24-hour limit.
+            // Last window uses totalEnd so it always covers the requested endpoint exactly.
+            boolean isLastWindow = (totalEnd - windowStart) <= WINDOW_MS;
+            long windowEnd = isLastWindow ? totalEnd : windowStart + WINDOW_MS - 1;
+            fetchWindowInto(symbol, windowStart, windowEnd, all);
+            if (isLastWindow) break;
+            windowStart = windowEnd + 1;
+        }
+
+        log.debug("reconciliation: fetched {} trades for symbol={} from={} to={}", all.size(), symbol, from, to);
+        return all;
+    }
+
+    private void fetchWindowInto(String symbol, long startMs, long endMs, List<TradeExecutionDto> all) {
+        Instant windowEndInstant = Instant.ofEpochMilli(endMs);
+
+        List<TradeExecutionDto> page = fetchPage(requestBuilder.buildMyTrades(symbol, startMs, endMs));
         all.addAll(page);
 
         // Paginate: if full page returned, advance using fromId of last trade
         while (page.size() == PAGE_LIMIT) {
             long lastId = Long.parseLong(page.getLast().exchangeTradeId());
             page = fetchPage(requestBuilder.buildMyTradesFromId(symbol, lastId + 1));
-            // Filter client-side to stay within endTime since fromId ignores time range
+            // Filter client-side to stay within this window's end (fromId ignores time range)
             page = page.stream()
-                    .filter(t -> !t.executedAt().isAfter(to))
+                    .filter(t -> !t.executedAt().isAfter(windowEndInstant))
                     .toList();
             all.addAll(page);
             if (page.size() < PAGE_LIMIT) break;
         }
-
-        log.debug("reconciliation: fetched {} trades for symbol={} from={} to={}", all.size(), symbol, from, to);
-        return all;
     }
 
     private List<TradeExecutionDto> fetchPage(RestRequest req) {

--- a/adapter-binance/src/test/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapterTest.java
+++ b/adapter-binance/src/test/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapterTest.java
@@ -128,6 +128,35 @@ class BinanceTradeHistoryAdapterTest {
         assertThrows(RuntimeException.class, () -> adapter.fetchTrades(SYMBOL, FROM, TO));
     }
 
+    @Test
+    void fetchTrades_issuesSingleRequestWhenWindowIsWithin24Hours() throws IOException {
+        // FROM → TO is exactly 24h; should produce 1 buildMyTrades call, not 2
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        when(httpClient.get(any(), any())).thenReturn(new HttpClientPort.HttpResponse(200, "[]"));
+
+        adapter.fetchTrades(SYMBOL, FROM, TO);
+
+        verify(requestBuilder, times(1)).buildMyTrades(anyString(), anyLong(), anyLong());
+    }
+
+    @Test
+    void fetchTrades_splitsIntoTwoWindowsWhenPeriodSpans48Hours() throws IOException {
+        // 48h → 2 separate buildMyTrades calls (one per 24h window)
+        Instant from48 = Instant.parse("2026-01-01T00:00:00Z");
+        Instant to48 = Instant.parse("2026-01-03T00:00:00Z");
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        when(httpClient.get(any(), any())).thenReturn(new HttpClientPort.HttpResponse(200, "[]"));
+
+        adapter.fetchTrades(SYMBOL, from48, to48);
+
+        verify(requestBuilder, times(2)).buildMyTrades(anyString(), anyLong(), anyLong());
+    }
+
+    @Test
+    void getExchangeName_returnsBinance() {
+        assertEquals("BINANCE", adapter.getExchangeName());
+    }
+
     private static String buildTradeJsonArray(int count, long startId) {
         StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < count; i++) {

--- a/adapter-binance/src/test/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapterTest.java
+++ b/adapter-binance/src/test/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapterTest.java
@@ -1,0 +1,148 @@
+package com.marmitt.binance.trade;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.binance.rest.BinanceRestRequestBuilder;
+import com.marmitt.binance.rest.HttpClientPort;
+import com.marmitt.binance.rest.RestRequest;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BinanceTradeHistoryAdapterTest {
+
+    private static final String SYMBOL = "BTCUSDT";
+    private static final Instant FROM = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant TO = Instant.parse("2026-01-02T00:00:00Z");
+    private static final RestRequest DUMMY_REQ =
+            new RestRequest("GET", "https://api.binance.com/api/v3/myTrades?...", Map.of(), null);
+
+    private final BinanceRestRequestBuilder requestBuilder = mock(BinanceRestRequestBuilder.class);
+    private final HttpClientPort httpClient = mock(HttpClientPort.class);
+    private final ObjectMapper objectMapper = buildObjectMapper();
+
+    private final BinanceTradeHistoryAdapter adapter =
+            new BinanceTradeHistoryAdapter(requestBuilder, httpClient, objectMapper);
+
+    @Test
+    void fetchTrades_parsesJsonFieldsCorrectly() throws IOException {
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        String json = """
+                [{"id":"28457","orderId":100234,"clientOrderId":"client-1","symbol":"BTCUSDT",
+                  "price":"50000.00","qty":"0.01","quoteQty":"500.00","commission":"0.0001",
+                  "commissionAsset":"BNB","time":1699865549590,"isBuyer":true}]
+                """;
+        when(httpClient.get(any(), any())).thenReturn(new HttpClientPort.HttpResponse(200, json));
+
+        List<TradeExecutionDto> result = adapter.fetchTrades(SYMBOL, FROM, TO);
+
+        assertEquals(1, result.size());
+        TradeExecutionDto trade = result.get(0);
+        assertEquals("28457", trade.exchangeTradeId());
+        assertEquals(100234L, trade.exchangeOrderId());
+        assertEquals("client-1", trade.clientOrderId());
+        assertEquals("BTCUSDT", trade.symbol());
+        assertEquals(0, new BigDecimal("50000.00").compareTo(trade.price()));
+        assertEquals(0, new BigDecimal("0.01").compareTo(trade.qty()));
+        assertEquals(0, new BigDecimal("500.00").compareTo(trade.quoteQty()));
+        assertEquals(0, new BigDecimal("0.0001").compareTo(trade.commission()));
+        assertEquals("BNB", trade.commissionAsset());
+        assertEquals(Instant.ofEpochMilli(1699865549590L), trade.executedAt());
+        assertEquals(true, trade.isBuy());
+    }
+
+    @Test
+    void fetchTrades_returnsEmptyListWhenJsonArrayIsEmpty() throws IOException {
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        when(httpClient.get(any(), any())).thenReturn(new HttpClientPort.HttpResponse(200, "[]"));
+
+        List<TradeExecutionDto> result = adapter.fetchTrades(SYMBOL, FROM, TO);
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void fetchTrades_paginatesWhenFullPageIsReturned() throws IOException {
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        when(requestBuilder.buildMyTradesFromId(anyString(), anyLong())).thenReturn(DUMMY_REQ);
+
+        String firstPage = buildTradeJsonArray(1000, 0L);
+        String secondPage = """
+                [{"id":"1001","orderId":100234,"clientOrderId":"client-1000","symbol":"BTCUSDT",
+                  "price":"50000","qty":"0.01","quoteQty":"500","commission":"0.0001",
+                  "commissionAsset":"BNB","time":1699865549590,"isBuyer":true}]
+                """;
+
+        when(httpClient.get(any(), any()))
+                .thenReturn(new HttpClientPort.HttpResponse(200, firstPage))
+                .thenReturn(new HttpClientPort.HttpResponse(200, secondPage));
+
+        List<TradeExecutionDto> result = adapter.fetchTrades(SYMBOL, FROM, TO);
+
+        assertEquals(1001, result.size());
+        verify(requestBuilder, times(1)).buildMyTrades(anyString(), anyLong(), anyLong());
+        verify(requestBuilder, times(1)).buildMyTradesFromId(anyString(), anyLong());
+    }
+
+    @Test
+    void fetchTrades_throwsRuntimeExceptionWhenHttpErrorReturned() throws IOException {
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        when(httpClient.get(any(), any()))
+                .thenReturn(new HttpClientPort.HttpResponse(400, "{\"code\":-1100,\"msg\":\"Illegal characters\"}"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> adapter.fetchTrades(SYMBOL, FROM, TO));
+        assertEquals(true, ex.getMessage().contains("400"));
+    }
+
+    @Test
+    void fetchTrades_throwsRuntimeExceptionOnIoException() throws IOException {
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        when(httpClient.get(any(), any())).thenThrow(new IOException("connection refused"));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> adapter.fetchTrades(SYMBOL, FROM, TO));
+        assertEquals(true, ex.getMessage().contains("connection refused"));
+    }
+
+    @Test
+    void fetchTrades_throwsRuntimeExceptionWhenJsonIsMalformed() throws IOException {
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        when(httpClient.get(any(), any()))
+                .thenReturn(new HttpClientPort.HttpResponse(200, "not-json"));
+
+        assertThrows(RuntimeException.class, () -> adapter.fetchTrades(SYMBOL, FROM, TO));
+    }
+
+    private static String buildTradeJsonArray(int count, long startId) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(String.format(
+                    "{\"id\":\"%d\",\"orderId\":100234,\"clientOrderId\":\"client-%d\",\"symbol\":\"BTCUSDT\"," +
+                    "\"price\":\"50000\",\"qty\":\"0.01\",\"quoteQty\":\"500\",\"commission\":\"0.0001\"," +
+                    "\"commissionAsset\":\"BNB\",\"time\":1699865549590,\"isBuyer\":true}",
+                    startId + i, i));
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static ObjectMapper buildObjectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCase.java
@@ -23,6 +23,12 @@ public class ReconcileTradesUseCase implements ReconcileTradesPort {
 
     @Override
     public ReconciliationReportDto reconcile(ReconciliationRequest request) {
+        if (!tradeHistoryQueryPort.getExchangeName().equalsIgnoreCase(request.exchangeId())) {
+            throw new IllegalArgumentException(
+                    "Exchange '" + request.exchangeId() + "' is not supported; "
+                    + "configured adapter serves '" + tradeHistoryQueryPort.getExchangeName() + "'");
+        }
+
         List<TradeExecutionDto> exchangeFills = tradeHistoryQueryPort.fetchTrades(
                 request.symbol(), request.from(), request.to());
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCase.java
@@ -1,0 +1,34 @@
+package com.marmitt.core.application.usecase.reconciliation;
+
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
+import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.ports.inbound.reconciliation.ReconcileTradesPort;
+import com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+
+import java.util.List;
+
+public class ReconcileTradesUseCase implements ReconcileTradesPort {
+
+    private final TradeHistoryQueryPort tradeHistoryQueryPort;
+    private final StrategyRunnerRepositoryPort strategyRunnerRepository;
+
+    public ReconcileTradesUseCase(TradeHistoryQueryPort tradeHistoryQueryPort,
+                                  StrategyRunnerRepositoryPort strategyRunnerRepository) {
+        this.tradeHistoryQueryPort = tradeHistoryQueryPort;
+        this.strategyRunnerRepository = strategyRunnerRepository;
+    }
+
+    @Override
+    public ReconciliationReportDto reconcile(ReconciliationRequest request) {
+        List<TradeExecutionDto> exchangeFills = tradeHistoryQueryPort.fetchTrades(
+                request.symbol(), request.from(), request.to());
+
+        List<Transaction> localTransactions = strategyRunnerRepository.findFilledBySymbolAndPeriod(
+                request.symbol(), request.from(), request.to());
+
+        return ReconciliationMatcher.match(exchangeFills, localTransactions, request);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCase.java
@@ -27,7 +27,7 @@ public class ReconcileTradesUseCase implements ReconcileTradesPort {
                 request.symbol(), request.from(), request.to());
 
         List<Transaction> localTransactions = strategyRunnerRepository.findFilledBySymbolAndPeriod(
-                request.symbol(), request.from(), request.to());
+                request.symbol(), request.exchangeId(), request.from(), request.to());
 
         return ReconciliationMatcher.match(exchangeFills, localTransactions, request);
     }

--- a/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcher.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcher.java
@@ -14,7 +14,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +22,8 @@ import java.util.stream.Collectors;
 final class ReconciliationMatcher {
 
     private static final BigDecimal QTY_TOLERANCE = new BigDecimal("0.000001");
+    // Absolute tolerance for quote value comparison (e.g. USDT rounding differences from partial fills)
+    private static final BigDecimal QUOTE_TOLERANCE = new BigDecimal("0.01");
 
     private ReconciliationMatcher() {}
 
@@ -31,37 +32,57 @@ final class ReconciliationMatcher {
             List<Transaction> localTransactions,
             ReconciliationRequest request) {
 
-        Map<String, List<TradeExecutionDto>> fillsByClientOrderId = exchangeFills.stream()
-                .filter(f -> f.clientOrderId() != null && !f.clientOrderId().isBlank())
+        // Binance GET /api/v3/myTrades does not return clientOrderId; group by orderId (always present).
+        Map<String, List<TradeExecutionDto>> fillsByOrderId = exchangeFills.stream()
                 .collect(Collectors.groupingBy(
-                        TradeExecutionDto::clientOrderId,
+                        f -> String.valueOf(f.exchangeOrderId()),
                         LinkedHashMap::new,
                         Collectors.toList()));
 
-        Map<String, Transaction> localByClientOrderId = localTransactions.stream()
-                .collect(Collectors.toMap(Transaction::getClientOrderId, t -> t, (a, b) -> a, LinkedHashMap::new));
+        // Index submitted local transactions by their exchangeOrderId (set on order submission).
+        // Transactions without an exchangeOrderId were never successfully submitted.
+        Map<String, Transaction> localByOrderId = new LinkedHashMap<>();
+        List<Transaction> neverSubmitted = new ArrayList<>();
+        for (Transaction t : localTransactions) {
+            if (t.getExchangeOrderId() != null && !t.getExchangeOrderId().isBlank()) {
+                localByOrderId.put(t.getExchangeOrderId(), t);
+            } else {
+                neverSubmitted.add(t);
+            }
+        }
 
         List<ReconciliationEntryDto> entries = new ArrayList<>();
         int matched = 0, divergent = 0, exchangeOnly = 0, localOnly = 0;
 
-        for (Map.Entry<String, List<TradeExecutionDto>> e : fillsByClientOrderId.entrySet()) {
-            String clientOrderId = e.getKey();
+        for (Map.Entry<String, List<TradeExecutionDto>> e : fillsByOrderId.entrySet()) {
             ExchangeSideDto exchangeSide = aggregate(e.getValue());
-            Transaction local = localByClientOrderId.remove(clientOrderId);
+            Transaction local = localByOrderId.remove(e.getKey());
 
             if (local == null) {
                 exchangeOnly++;
+                // Use exchange clientOrderId when available (e.g. some exchange environments return it)
+                String displayId = e.getValue().get(0).clientOrderId() != null
+                        ? e.getValue().get(0).clientOrderId()
+                        : "order-" + e.getKey();
                 entries.add(new ReconciliationEntryDto(
-                        ReconciliationStatus.EXCHANGE_ONLY, clientOrderId, exchangeSide, null));
+                        ReconciliationStatus.EXCHANGE_ONLY, displayId, exchangeSide, null));
             } else {
                 LocalSideDto localSide = toLocalSide(local);
+
                 BigDecimal localQty = local.getExecutedQuantity() != null
                         ? local.getExecutedQuantity()
                         : BigDecimal.ZERO;
                 boolean qtyMatch = exchangeSide.executedQty().subtract(localQty).abs()
                         .compareTo(QTY_TOLERANCE) <= 0;
 
-                ReconciliationStatus status = qtyMatch
+                // Compare executed quote value to catch price discrepancies (same qty, wrong price)
+                BigDecimal localExecValue = local.getExecutedPrice() != null && local.getExecutedQuantity() != null
+                        ? local.getExecutedPrice().multiply(local.getExecutedQuantity())
+                        : local.getTotal();
+                boolean quoteMatch = exchangeSide.totalQuote().subtract(localExecValue).abs()
+                        .compareTo(QUOTE_TOLERANCE) <= 0;
+
+                ReconciliationStatus status = qtyMatch && quoteMatch
                         ? ReconciliationStatus.MATCHED
                         : ReconciliationStatus.DIVERGENT;
 
@@ -69,26 +90,25 @@ final class ReconciliationMatcher {
                 else divergent++;
 
                 if (status != ReconciliationStatus.MATCHED || request.includeMatched()) {
-                    entries.add(new ReconciliationEntryDto(status, clientOrderId, exchangeSide, localSide));
+                    entries.add(new ReconciliationEntryDto(
+                            status, local.getClientOrderId(), exchangeSide, localSide));
                 }
             }
         }
 
-        // Remaining local transactions have no exchange confirmation
-        for (Transaction local : localByClientOrderId.values()) {
+        // Submitted local transactions with no matching exchange fill
+        for (Transaction local : localByOrderId.values()) {
             localOnly++;
             entries.add(new ReconciliationEntryDto(
-                    ReconciliationStatus.LOCAL_ONLY,
-                    local.getClientOrderId(),
-                    null,
-                    toLocalSide(local)));
+                    ReconciliationStatus.LOCAL_ONLY, local.getClientOrderId(), null, toLocalSide(local)));
         }
 
-        // Exchange-only entries from Binance without our clientOrderId format (manual trades, etc.)
-        long unmatchedExchangeCount = exchangeFills.stream()
-                .filter(f -> f.clientOrderId() == null || f.clientOrderId().isBlank())
-                .count();
-        exchangeOnly += (int) unmatchedExchangeCount;
+        // Never-submitted local transactions (no exchangeOrderId) — always LOCAL_ONLY
+        for (Transaction local : neverSubmitted) {
+            localOnly++;
+            entries.add(new ReconciliationEntryDto(
+                    ReconciliationStatus.LOCAL_ONLY, local.getClientOrderId(), null, toLocalSide(local)));
+        }
 
         int total = matched + divergent + exchangeOnly + localOnly;
         ReconciliationSummaryDto summary = new ReconciliationSummaryDto(

--- a/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcher.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcher.java
@@ -1,0 +1,141 @@
+package com.marmitt.core.application.usecase.reconciliation;
+
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.reconciliation.ExchangeSideDto;
+import com.marmitt.core.dto.reconciliation.LocalSideDto;
+import com.marmitt.core.dto.reconciliation.ReconciliationEntryDto;
+import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
+import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
+import com.marmitt.core.dto.reconciliation.ReconciliationSummaryDto;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.enums.ReconciliationStatus;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+final class ReconciliationMatcher {
+
+    private static final BigDecimal QTY_TOLERANCE = new BigDecimal("0.000001");
+
+    private ReconciliationMatcher() {}
+
+    static ReconciliationReportDto match(
+            List<TradeExecutionDto> exchangeFills,
+            List<Transaction> localTransactions,
+            ReconciliationRequest request) {
+
+        Map<String, List<TradeExecutionDto>> fillsByClientOrderId = exchangeFills.stream()
+                .filter(f -> f.clientOrderId() != null && !f.clientOrderId().isBlank())
+                .collect(Collectors.groupingBy(
+                        TradeExecutionDto::clientOrderId,
+                        LinkedHashMap::new,
+                        Collectors.toList()));
+
+        Map<String, Transaction> localByClientOrderId = localTransactions.stream()
+                .collect(Collectors.toMap(Transaction::getClientOrderId, t -> t, (a, b) -> a, LinkedHashMap::new));
+
+        List<ReconciliationEntryDto> entries = new ArrayList<>();
+        int matched = 0, divergent = 0, exchangeOnly = 0, localOnly = 0;
+
+        for (Map.Entry<String, List<TradeExecutionDto>> e : fillsByClientOrderId.entrySet()) {
+            String clientOrderId = e.getKey();
+            ExchangeSideDto exchangeSide = aggregate(e.getValue());
+            Transaction local = localByClientOrderId.remove(clientOrderId);
+
+            if (local == null) {
+                exchangeOnly++;
+                entries.add(new ReconciliationEntryDto(
+                        ReconciliationStatus.EXCHANGE_ONLY, clientOrderId, exchangeSide, null));
+            } else {
+                LocalSideDto localSide = toLocalSide(local);
+                BigDecimal localQty = local.getExecutedQuantity() != null
+                        ? local.getExecutedQuantity()
+                        : BigDecimal.ZERO;
+                boolean qtyMatch = exchangeSide.executedQty().subtract(localQty).abs()
+                        .compareTo(QTY_TOLERANCE) <= 0;
+
+                ReconciliationStatus status = qtyMatch
+                        ? ReconciliationStatus.MATCHED
+                        : ReconciliationStatus.DIVERGENT;
+
+                if (status == ReconciliationStatus.MATCHED) matched++;
+                else divergent++;
+
+                if (status != ReconciliationStatus.MATCHED || request.includeMatched()) {
+                    entries.add(new ReconciliationEntryDto(status, clientOrderId, exchangeSide, localSide));
+                }
+            }
+        }
+
+        // Remaining local transactions have no exchange confirmation
+        for (Transaction local : localByClientOrderId.values()) {
+            localOnly++;
+            entries.add(new ReconciliationEntryDto(
+                    ReconciliationStatus.LOCAL_ONLY,
+                    local.getClientOrderId(),
+                    null,
+                    toLocalSide(local)));
+        }
+
+        // Exchange-only entries from Binance without our clientOrderId format (manual trades, etc.)
+        long unmatchedExchangeCount = exchangeFills.stream()
+                .filter(f -> f.clientOrderId() == null || f.clientOrderId().isBlank())
+                .count();
+        exchangeOnly += (int) unmatchedExchangeCount;
+
+        int total = matched + divergent + exchangeOnly + localOnly;
+        ReconciliationSummaryDto summary = new ReconciliationSummaryDto(
+                total, matched, divergent, exchangeOnly, localOnly);
+
+        return new ReconciliationReportDto(
+                request.symbol(), request.from(), request.to(), summary, entries);
+    }
+
+    private static ExchangeSideDto aggregate(List<TradeExecutionDto> fills) {
+        BigDecimal totalQty = BigDecimal.ZERO;
+        BigDecimal totalQuote = BigDecimal.ZERO;
+        BigDecimal totalFees = BigDecimal.ZERO;
+        String feeAsset = null;
+        Instant firstFill = null;
+        Instant lastFill = null;
+        long orderId = 0;
+
+        for (TradeExecutionDto f : fills) {
+            totalQty = totalQty.add(f.qty());
+            totalQuote = totalQuote.add(f.quoteQty());
+            if (f.commission() != null) totalFees = totalFees.add(f.commission());
+            if (feeAsset == null && f.commissionAsset() != null) feeAsset = f.commissionAsset();
+            if (firstFill == null || f.executedAt().isBefore(firstFill)) firstFill = f.executedAt();
+            if (lastFill == null || f.executedAt().isAfter(lastFill)) lastFill = f.executedAt();
+            orderId = f.exchangeOrderId();
+        }
+
+        BigDecimal avgPrice = totalQty.compareTo(BigDecimal.ZERO) > 0
+                ? totalQuote.divide(totalQty, 8, RoundingMode.HALF_UP)
+                : BigDecimal.ZERO;
+
+        return new ExchangeSideDto(
+                orderId, fills.size(), totalQty, avgPrice,
+                totalQuote, totalFees, feeAsset, firstFill, lastFill);
+    }
+
+    private static LocalSideDto toLocalSide(Transaction t) {
+        return new LocalSideDto(
+                t.getId(),
+                t.getRunnerId(),
+                t.getType(),
+                t.getStatus(),
+                t.getExecutedQuantity(),
+                t.getExecutedPrice(),
+                t.getTotal(),
+                t.getRequestedAt(),
+                t.getUpdatedAt());
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcher.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcher.java
@@ -1,6 +1,7 @@
 package com.marmitt.core.application.usecase.reconciliation;
 
 import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.enums.TransactionType;
 import com.marmitt.core.dto.reconciliation.ExchangeSideDto;
 import com.marmitt.core.dto.reconciliation.LocalSideDto;
 import com.marmitt.core.dto.reconciliation.ReconciliationEntryDto;
@@ -82,7 +83,10 @@ final class ReconciliationMatcher {
                 boolean quoteMatch = exchangeSide.totalQuote().subtract(localExecValue).abs()
                         .compareTo(QUOTE_TOLERANCE) <= 0;
 
-                ReconciliationStatus status = qtyMatch && quoteMatch
+                // Compare trade side — a BUY fill against a SELL local record is a critical discrepancy
+                boolean sideMatch = exchangeSide.isBuy() == (local.getType() == TransactionType.BUY);
+
+                ReconciliationStatus status = qtyMatch && quoteMatch && sideMatch
                         ? ReconciliationStatus.MATCHED
                         : ReconciliationStatus.DIVERGENT;
 
@@ -126,6 +130,7 @@ final class ReconciliationMatcher {
         Instant firstFill = null;
         Instant lastFill = null;
         long orderId = 0;
+        boolean isBuy = fills.get(0).isBuy(); // all fills for an order share the same side
 
         for (TradeExecutionDto f : fills) {
             totalQty = totalQty.add(f.qty());
@@ -143,7 +148,7 @@ final class ReconciliationMatcher {
 
         return new ExchangeSideDto(
                 orderId, fills.size(), totalQty, avgPrice,
-                totalQuote, totalFees, feeAsset, firstFill, lastFill);
+                totalQuote, totalFees, feeAsset, firstFill, lastFill, isBuy);
     }
 
     private static LocalSideDto toLocalSide(Transaction t) {

--- a/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcher.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcher.java
@@ -73,6 +73,10 @@ final class ReconciliationMatcher {
                 BigDecimal localQty = local.getExecutedQuantity() != null
                         ? local.getExecutedQuantity()
                         : BigDecimal.ZERO;
+                // NOTE: localQty is cumulative (all-time); exchangeSide.executedQty() is windowed.
+                // Orders with fills on both sides of the from/to boundary will appear DIVERGENT
+                // even when correct. Fixing this requires fetching all fills per order from Binance
+                // (outside T18 scope; tracked as a known limitation of window-scoped reconciliation).
                 boolean qtyMatch = exchangeSide.executedQty().subtract(localQty).abs()
                         .compareTo(QTY_TOLERANCE) <= 0;
 

--- a/core/src/main/java/com/marmitt/core/domain/runner/Transaction.java
+++ b/core/src/main/java/com/marmitt/core/domain/runner/Transaction.java
@@ -90,6 +90,12 @@ public class Transaction {
     private final Instant requestedAt;
     private Instant updatedAt;
     private Instant executedAt;
+    /**
+     * Timestamp of the most recent partial fill. Set by {@link #partialFill} and NOT overwritten
+     * by {@link #cancel()}, so it survives PARTIAL → CANCELED transitions intact.
+     * Used as the time-filter anchor for CANCELED transactions in reconciliation queries.
+     */
+    private Instant lastPartialFillAt;
     private String rejectReason;
     private Long version;
 
@@ -149,6 +155,7 @@ public class Transaction {
             Instant requestedAt,
             Instant updatedAt,
             Instant executedAt,
+            Instant lastPartialFillAt,
             String rejectReason,
             Long version
     ) {
@@ -170,6 +177,7 @@ public class Transaction {
         this.requestedAt = Objects.requireNonNull(requestedAt, "requestedAt cannot be null");
         this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt cannot be null");
         this.executedAt = executedAt;
+        this.lastPartialFillAt = lastPartialFillAt;
         this.rejectReason = rejectReason;
         this.version = version;
     }
@@ -208,6 +216,7 @@ public class Transaction {
         this.executedPrice = avgExecutedPrice;
         this.status = TransactionStatus.PARTIAL;
         this.updatedAt = Instant.now();
+        this.lastPartialFillAt = this.updatedAt;
     }
 
     /**

--- a/core/src/main/java/com/marmitt/core/dto/reconciliation/ExchangeSideDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/reconciliation/ExchangeSideDto.java
@@ -1,0 +1,17 @@
+package com.marmitt.core.dto.reconciliation;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Aggregated view of all fills for one order on the exchange side. */
+public record ExchangeSideDto(
+        long exchangeOrderId,
+        int fillCount,
+        BigDecimal executedQty,
+        BigDecimal avgPrice,
+        BigDecimal totalQuote,
+        BigDecimal totalFees,
+        String feeAsset,
+        Instant firstFillAt,
+        Instant lastFillAt
+) {}

--- a/core/src/main/java/com/marmitt/core/dto/reconciliation/ExchangeSideDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/reconciliation/ExchangeSideDto.java
@@ -13,5 +13,6 @@ public record ExchangeSideDto(
         BigDecimal totalFees,
         String feeAsset,
         Instant firstFillAt,
-        Instant lastFillAt
+        Instant lastFillAt,
+        boolean isBuy
 ) {}

--- a/core/src/main/java/com/marmitt/core/dto/reconciliation/LocalSideDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/reconciliation/LocalSideDto.java
@@ -1,0 +1,21 @@
+package com.marmitt.core.dto.reconciliation;
+
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/** Local transaction data for one side of a reconciliation entry. */
+public record LocalSideDto(
+        UUID transactionId,
+        UUID runnerId,
+        TransactionType type,
+        TransactionStatus status,
+        BigDecimal executedQty,
+        BigDecimal executedPrice,
+        BigDecimal total,
+        Instant requestedAt,
+        Instant updatedAt
+) {}

--- a/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationEntryDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationEntryDto.java
@@ -1,0 +1,10 @@
+package com.marmitt.core.dto.reconciliation;
+
+import com.marmitt.core.enums.ReconciliationStatus;
+
+public record ReconciliationEntryDto(
+        ReconciliationStatus status,
+        String clientOrderId,
+        ExchangeSideDto exchangeSide,
+        LocalSideDto localSide
+) {}

--- a/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationReportDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationReportDto.java
@@ -1,0 +1,12 @@
+package com.marmitt.core.dto.reconciliation;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ReconciliationReportDto(
+        String symbol,
+        Instant from,
+        Instant to,
+        ReconciliationSummaryDto summary,
+        List<ReconciliationEntryDto> entries
+) {}

--- a/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationRequest.java
@@ -1,0 +1,10 @@
+package com.marmitt.core.dto.reconciliation;
+
+import java.time.Instant;
+
+public record ReconciliationRequest(
+        String symbol,
+        Instant from,
+        Instant to,
+        boolean includeMatched
+) {}

--- a/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationRequest.java
+++ b/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationRequest.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 
 public record ReconciliationRequest(
         String symbol,
+        String exchangeId,
         Instant from,
         Instant to,
         boolean includeMatched

--- a/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationSummaryDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/reconciliation/ReconciliationSummaryDto.java
@@ -1,0 +1,9 @@
+package com.marmitt.core.dto.reconciliation;
+
+public record ReconciliationSummaryDto(
+        int total,
+        int matched,
+        int divergent,
+        int exchangeOnly,
+        int localOnly
+) {}

--- a/core/src/main/java/com/marmitt/core/dto/reconciliation/TradeExecutionDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/reconciliation/TradeExecutionDto.java
@@ -1,0 +1,22 @@
+package com.marmitt.core.dto.reconciliation;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Generic representation of a single fill event returned by the exchange.
+ * One order can produce multiple fills (partial fills); each is one TradeExecutionDto.
+ */
+public record TradeExecutionDto(
+        String exchangeTradeId,
+        long exchangeOrderId,
+        String clientOrderId,
+        String symbol,
+        BigDecimal price,
+        BigDecimal qty,
+        BigDecimal quoteQty,
+        BigDecimal commission,
+        String commissionAsset,
+        Instant executedAt,
+        boolean isBuy
+) {}

--- a/core/src/main/java/com/marmitt/core/enums/ReconciliationStatus.java
+++ b/core/src/main/java/com/marmitt/core/enums/ReconciliationStatus.java
@@ -1,0 +1,12 @@
+package com.marmitt.core.enums;
+
+public enum ReconciliationStatus {
+    /** Exists on both sides; qty and value within tolerance. */
+    MATCHED,
+    /** Exists on both sides but qty or total value diverges beyond tolerance. */
+    DIVERGENT,
+    /** Trade executed on exchange with no corresponding local transaction. */
+    EXCHANGE_ONLY,
+    /** Local transaction (FILLED or PARTIAL) with no exchange trade confirming it. */
+    LOCAL_ONLY
+}

--- a/core/src/main/java/com/marmitt/core/ports/inbound/reconciliation/ReconcileTradesPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/reconciliation/ReconcileTradesPort.java
@@ -1,0 +1,9 @@
+package com.marmitt.core.ports.inbound.reconciliation;
+
+import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
+import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
+
+public interface ReconcileTradesPort {
+
+    ReconciliationReportDto reconcile(ReconciliationRequest request);
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/TradeHistoryQueryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/TradeHistoryQueryPort.java
@@ -11,6 +11,9 @@ import java.util.List;
  */
 public interface TradeHistoryQueryPort {
 
+    /** Exchange identifier this adapter serves (e.g. "BINANCE"). Case-insensitive. */
+    String getExchangeName();
+
     /**
      * Fetches all fills for {@code symbol} executed within [{@code from}, {@code to}].
      * Multiple fills for the same order (partial fills) are returned as separate entries.

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/TradeHistoryQueryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/TradeHistoryQueryPort.java
@@ -1,0 +1,21 @@
+package com.marmitt.core.ports.outbound.exchange;
+
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Outbound port for fetching historical trade fills from the exchange.
+ * Each entry represents a single fill event; one order may produce multiple entries.
+ */
+public interface TradeHistoryQueryPort {
+
+    /**
+     * Fetches all fills for {@code symbol} executed within [{@code from}, {@code to}].
+     * Multiple fills for the same order (partial fills) are returned as separate entries.
+     *
+     * @throws RuntimeException if the exchange is unreachable or returns an error
+     */
+    List<TradeExecutionDto> fetchTrades(String symbol, Instant from, Instant to);
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/repository/StrategyRunnerRepositoryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/repository/StrategyRunnerRepositoryPort.java
@@ -237,12 +237,13 @@ public interface StrategyRunnerRepositoryPort {
     void saveAtomicTransactionAndMatch(Transaction transaction, TransactionMatch match);
 
     /**
-     * Busca transações com status FILLED ou PARTIAL para um símbolo dentro de um período.
+     * Busca transações com status FILLED ou PARTIAL para um símbolo e exchange dentro de um período.
      * Usado pela reconciliação de trades para comparar com o histórico da exchange.
      *
-     * @param symbol par de trading (ex: "BTCUSDT")
-     * @param from   início do período (inclusive)
-     * @param to     fim do período (inclusive)
+     * @param symbol     par de trading (ex: "BTCUSDT")
+     * @param exchangeId identificador da exchange (ex: "BINANCE") — filtra apenas runners dessa exchange
+     * @param from       início do período (inclusive)
+     * @param to         fim do período (inclusive)
      */
-    List<Transaction> findFilledBySymbolAndPeriod(String symbol, Instant from, Instant to);
+    List<Transaction> findFilledBySymbolAndPeriod(String symbol, String exchangeId, Instant from, Instant to);
 }

--- a/core/src/main/java/com/marmitt/core/ports/outbound/repository/StrategyRunnerRepositoryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/repository/StrategyRunnerRepositoryPort.java
@@ -235,4 +235,14 @@ public interface StrategyRunnerRepositoryPort {
      * @see <a href="docs/IMPLEMENTATION_GUIDE.md">IG Seção 6.2.1</a>
      */
     void saveAtomicTransactionAndMatch(Transaction transaction, TransactionMatch match);
+
+    /**
+     * Busca transações com status FILLED ou PARTIAL para um símbolo dentro de um período.
+     * Usado pela reconciliação de trades para comparar com o histórico da exchange.
+     *
+     * @param symbol par de trading (ex: "BTCUSDT")
+     * @param from   início do período (inclusive)
+     * @param to     fim do período (inclusive)
+     */
+    List<Transaction> findFilledBySymbolAndPeriod(String symbol, Instant from, Instant to);
 }

--- a/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCaseTest.java
@@ -1,0 +1,110 @@
+package com.marmitt.core.application.usecase.reconciliation;
+
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
+import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ReconcileTradesUseCaseTest {
+
+    private static final String SYMBOL = "BTCUSDT";
+    private static final Instant FROM = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant TO = Instant.parse("2026-01-02T00:00:00Z");
+
+    private final TradeHistoryQueryPort tradeHistoryQueryPort = mock(TradeHistoryQueryPort.class);
+    private final StrategyRunnerRepositoryPort strategyRunnerRepository = mock(StrategyRunnerRepositoryPort.class);
+    private final ReconcileTradesUseCase useCase =
+            new ReconcileTradesUseCase(tradeHistoryQueryPort, strategyRunnerRepository);
+
+    @Test
+    void reconcile_delegatesToBothPortsWithCorrectArgumentsAndReturnsMatchedReport() {
+        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, FROM, TO, true);
+
+        // Exchange fill with orderId=100234; local tx with exchangeOrderId="100234" → MATCHED
+        when(tradeHistoryQueryPort.fetchTrades(SYMBOL, FROM, TO)).thenReturn(List.of(fill("0.01")));
+        when(strategyRunnerRepository.findFilledBySymbolAndPeriod(SYMBOL, FROM, TO))
+                .thenReturn(List.of(localTx("client-1", "0.01")));
+
+        ReconciliationReportDto report = useCase.reconcile(request);
+
+        verify(tradeHistoryQueryPort).fetchTrades(eq(SYMBOL), eq(FROM), eq(TO));
+        verify(strategyRunnerRepository).findFilledBySymbolAndPeriod(eq(SYMBOL), eq(FROM), eq(TO));
+        assertEquals(1, report.summary().matched());
+    }
+
+    @Test
+    void reconcile_returnsEmptyReportWhenBothPortsReturnEmpty() {
+        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, FROM, TO, false);
+        when(tradeHistoryQueryPort.fetchTrades(SYMBOL, FROM, TO)).thenReturn(List.of());
+        when(strategyRunnerRepository.findFilledBySymbolAndPeriod(SYMBOL, FROM, TO)).thenReturn(List.of());
+
+        ReconciliationReportDto report = useCase.reconcile(request);
+
+        assertEquals(0, report.summary().total());
+        assertEquals(SYMBOL, report.symbol());
+    }
+
+    @Test
+    void reconcile_propagatesExceptionFromExchangePort() {
+        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, FROM, TO, false);
+        when(tradeHistoryQueryPort.fetchTrades(SYMBOL, FROM, TO))
+                .thenThrow(new RuntimeException("Exchange unreachable"));
+
+        assertThrows(RuntimeException.class, () -> useCase.reconcile(request));
+    }
+
+    // Binance myTrades does not return clientOrderId; matching is done by exchangeOrderId.
+    // fill.exchangeOrderId=100234 matches localTx.exchangeOrderId="100234".
+    private static TradeExecutionDto fill(String qty) {
+        BigDecimal amount = new BigDecimal(qty);
+        return new TradeExecutionDto(
+                "trade-1", 100234L, null, "BTCUSDT",
+                new BigDecimal("50000"), amount,
+                amount.multiply(new BigDecimal("50000")),
+                new BigDecimal("0.0001"), "BNB",
+                Instant.parse("2026-01-01T10:00:00Z"), true);
+    }
+
+    private static Transaction localTx(String clientOrderId, String qty) {
+        BigDecimal amount = new BigDecimal(qty);
+        return Transaction.reconstitute()
+                .id(UUID.randomUUID())
+                .runnerId(UUID.randomUUID())
+                .clientOrderId(clientOrderId)
+                .exchangeOrderId("100234")
+                .status(TransactionStatus.FILLED)
+                .type(TransactionType.BUY)
+                .symbol("BTCUSDT")
+                .quantity(amount)
+                .executedQuantity(amount)
+                .price(new BigDecimal("50000"))
+                .executedPrice(new BigDecimal("50000"))
+                .total(amount.multiply(new BigDecimal("50000")))
+                .confidence(null)
+                .reasoning(null)
+                .targetLotId(null)
+                .requestedAt(Instant.parse("2026-01-01T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-01-01T10:00:00Z"))
+                .executedAt(Instant.parse("2026-01-01T10:00:00Z"))
+                .rejectReason(null)
+                .version(0L)
+                .build();
+    }
+}

--- a/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCaseTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 class ReconcileTradesUseCaseTest {
 
     private static final String SYMBOL = "BTCUSDT";
+    private static final String EXCHANGE_ID = "BINANCE";
     private static final Instant FROM = Instant.parse("2026-01-01T00:00:00Z");
     private static final Instant TO = Instant.parse("2026-01-02T00:00:00Z");
 
@@ -33,10 +34,9 @@ class ReconcileTradesUseCaseTest {
     private final ReconcileTradesUseCase useCase =
             new ReconcileTradesUseCase(tradeHistoryQueryPort, strategyRunnerRepository);
 
-    private static final String EXCHANGE_ID = "BINANCE";
-
     @Test
     void reconcile_delegatesToBothPortsWithCorrectArgumentsAndReturnsMatchedReport() {
+        when(tradeHistoryQueryPort.getExchangeName()).thenReturn(EXCHANGE_ID);
         ReconciliationRequest request = new ReconciliationRequest(SYMBOL, EXCHANGE_ID, FROM, TO, true);
 
         // Exchange fill with orderId=100234; local tx with exchangeOrderId="100234" → MATCHED
@@ -53,6 +53,7 @@ class ReconcileTradesUseCaseTest {
 
     @Test
     void reconcile_returnsEmptyReportWhenBothPortsReturnEmpty() {
+        when(tradeHistoryQueryPort.getExchangeName()).thenReturn(EXCHANGE_ID);
         ReconciliationRequest request = new ReconciliationRequest(SYMBOL, EXCHANGE_ID, FROM, TO, false);
         when(tradeHistoryQueryPort.fetchTrades(SYMBOL, FROM, TO)).thenReturn(List.of());
         when(strategyRunnerRepository.findFilledBySymbolAndPeriod(SYMBOL, EXCHANGE_ID, FROM, TO)).thenReturn(List.of());
@@ -64,7 +65,16 @@ class ReconcileTradesUseCaseTest {
     }
 
     @Test
+    void reconcile_throwsWhenExchangeIdDoesNotMatchConfiguredAdapter() {
+        when(tradeHistoryQueryPort.getExchangeName()).thenReturn("BINANCE");
+        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, "COINBASE", FROM, TO, false);
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.reconcile(request));
+    }
+
+    @Test
     void reconcile_propagatesExceptionFromExchangePort() {
+        when(tradeHistoryQueryPort.getExchangeName()).thenReturn(EXCHANGE_ID);
         ReconciliationRequest request = new ReconciliationRequest(SYMBOL, EXCHANGE_ID, FROM, TO, false);
         when(tradeHistoryQueryPort.fetchTrades(SYMBOL, FROM, TO))
                 .thenThrow(new RuntimeException("Exchange unreachable"));

--- a/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconcileTradesUseCaseTest.java
@@ -33,27 +33,29 @@ class ReconcileTradesUseCaseTest {
     private final ReconcileTradesUseCase useCase =
             new ReconcileTradesUseCase(tradeHistoryQueryPort, strategyRunnerRepository);
 
+    private static final String EXCHANGE_ID = "BINANCE";
+
     @Test
     void reconcile_delegatesToBothPortsWithCorrectArgumentsAndReturnsMatchedReport() {
-        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, FROM, TO, true);
+        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, EXCHANGE_ID, FROM, TO, true);
 
         // Exchange fill with orderId=100234; local tx with exchangeOrderId="100234" → MATCHED
         when(tradeHistoryQueryPort.fetchTrades(SYMBOL, FROM, TO)).thenReturn(List.of(fill("0.01")));
-        when(strategyRunnerRepository.findFilledBySymbolAndPeriod(SYMBOL, FROM, TO))
+        when(strategyRunnerRepository.findFilledBySymbolAndPeriod(SYMBOL, EXCHANGE_ID, FROM, TO))
                 .thenReturn(List.of(localTx("client-1", "0.01")));
 
         ReconciliationReportDto report = useCase.reconcile(request);
 
         verify(tradeHistoryQueryPort).fetchTrades(eq(SYMBOL), eq(FROM), eq(TO));
-        verify(strategyRunnerRepository).findFilledBySymbolAndPeriod(eq(SYMBOL), eq(FROM), eq(TO));
+        verify(strategyRunnerRepository).findFilledBySymbolAndPeriod(eq(SYMBOL), eq(EXCHANGE_ID), eq(FROM), eq(TO));
         assertEquals(1, report.summary().matched());
     }
 
     @Test
     void reconcile_returnsEmptyReportWhenBothPortsReturnEmpty() {
-        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, FROM, TO, false);
+        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, EXCHANGE_ID, FROM, TO, false);
         when(tradeHistoryQueryPort.fetchTrades(SYMBOL, FROM, TO)).thenReturn(List.of());
-        when(strategyRunnerRepository.findFilledBySymbolAndPeriod(SYMBOL, FROM, TO)).thenReturn(List.of());
+        when(strategyRunnerRepository.findFilledBySymbolAndPeriod(SYMBOL, EXCHANGE_ID, FROM, TO)).thenReturn(List.of());
 
         ReconciliationReportDto report = useCase.reconcile(request);
 
@@ -63,7 +65,7 @@ class ReconcileTradesUseCaseTest {
 
     @Test
     void reconcile_propagatesExceptionFromExchangePort() {
-        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, FROM, TO, false);
+        ReconciliationRequest request = new ReconciliationRequest(SYMBOL, EXCHANGE_ID, FROM, TO, false);
         when(tradeHistoryQueryPort.fetchTrades(SYMBOL, FROM, TO))
                 .thenThrow(new RuntimeException("Exchange unreachable"));
 

--- a/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcherTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcherTest.java
@@ -303,6 +303,6 @@ class ReconciliationMatcherTest {
     }
 
     private static ReconciliationRequest request(boolean includeMatched) {
-        return new ReconciliationRequest("BTCUSDT", FROM, TO, includeMatched);
+        return new ReconciliationRequest("BTCUSDT", "BINANCE", FROM, TO, includeMatched);
     }
 }

--- a/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcherTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcherTest.java
@@ -66,6 +66,38 @@ class ReconciliationMatcherTest {
     }
 
     @Test
+    void matchReturnsDivergentWhenSideDiffers() {
+        // Exchange fill is BUY but local transaction is SELL → side mismatch
+        TradeExecutionDto buyFill = new TradeExecutionDto(
+                "t1", ORDER_ID, null, "BTCUSDT",
+                new BigDecimal("50000"), new BigDecimal("0.01"), new BigDecimal("500"),
+                new BigDecimal("0.0001"), "BNB", FILL_AT, true /* isBuy */);
+        Transaction sellLocal = Transaction.reconstitute()
+                .id(UUID.randomUUID())
+                .runnerId(UUID.randomUUID())
+                .clientOrderId("client-1")
+                .exchangeOrderId(String.valueOf(ORDER_ID))
+                .status(TransactionStatus.FILLED)
+                .type(TransactionType.SELL)   // opposite side
+                .symbol("BTCUSDT")
+                .quantity(new BigDecimal("0.01"))
+                .executedQuantity(new BigDecimal("0.01"))
+                .price(new BigDecimal("50000"))
+                .executedPrice(new BigDecimal("50000"))
+                .total(new BigDecimal("500"))
+                .confidence(null).reasoning(null).targetLotId(null)
+                .requestedAt(FILL_AT).updatedAt(FILL_AT).executedAt(FILL_AT)
+                .rejectReason(null).version(0L)
+                .build();
+
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(buyFill), List.of(sellLocal), request(true));
+
+        assertEquals(1, report.summary().divergent());
+        assertEquals(ReconciliationStatus.DIVERGENT, report.entries().get(0).status());
+    }
+
+    @Test
     void matchReturnsMatchedWhenQtyAndQuoteAreBothWithinTolerance() {
         // qty diff = 0.000001 (≤ QTY_TOLERANCE), quote diff = 0.005 (< QUOTE_TOLERANCE 0.01)
         ReconciliationReportDto report = ReconciliationMatcher.match(

--- a/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcherTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/reconciliation/ReconciliationMatcherTest.java
@@ -1,0 +1,276 @@
+package com.marmitt.core.application.usecase.reconciliation;
+
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
+import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.enums.ReconciliationStatus;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for ReconciliationMatcher — matching is keyed on exchangeOrderId because
+ * Binance GET /api/v3/myTrades does not return clientOrderId in the response payload.
+ */
+class ReconciliationMatcherTest {
+
+    private static final Instant FROM = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant TO = Instant.parse("2026-01-02T00:00:00Z");
+    private static final Instant FILL_AT = Instant.parse("2026-01-01T10:00:00Z");
+    private static final long ORDER_ID = 100234L;
+
+    @Test
+    void matchReturnsMatchedWhenQtyAndQuoteMatchWithinTolerance() {
+        // Exchange fill and local tx share the same orderId — both qty and quote match
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fill(ORDER_ID, "0.01", "500.00")),
+                List.of(localTx("client-1", ORDER_ID, "0.01", "50000", "500.00")),
+                request(true));
+
+        assertEquals(1, report.summary().matched());
+        assertEquals(0, report.summary().divergent());
+        assertEquals(1, report.entries().size());
+        assertEquals(ReconciliationStatus.MATCHED, report.entries().get(0).status());
+        assertEquals("client-1", report.entries().get(0).clientOrderId());
+    }
+
+    @Test
+    void matchReturnsDivergentWhenQtyDiffersAboveTolerance() {
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fill(ORDER_ID, "0.01", "500.00")),
+                List.of(localTx("client-1", ORDER_ID, "0.02", "50000", "1000.00")),
+                request(true));
+
+        assertEquals(1, report.summary().divergent());
+        assertEquals(ReconciliationStatus.DIVERGENT, report.entries().get(0).status());
+    }
+
+    @Test
+    void matchReturnsDivergentWhenQtyMatchesButQuoteDiffersAboveTolerance() {
+        // Same qty, different execution price → quote diverges
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fill(ORDER_ID, "0.01", "500.00")),           // exchange: 500 USDT
+                List.of(localTx("client-1", ORDER_ID, "0.01", "60000", "600.00")),  // local: 600 USDT
+                request(true));
+
+        assertEquals(1, report.summary().divergent());
+    }
+
+    @Test
+    void matchReturnsMatchedWhenQtyAndQuoteAreBothWithinTolerance() {
+        // qty diff = 0.000001 (≤ QTY_TOLERANCE), quote diff = 0.005 (< QUOTE_TOLERANCE 0.01)
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fill(ORDER_ID, "0.010001", "500.005")),
+                List.of(localTx("client-1", ORDER_ID, "0.010000", "50000", "500.00")),
+                request(true));
+
+        assertEquals(1, report.summary().matched());
+    }
+
+    @Test
+    void matchReturnsExchangeOnlyWhenNoLocalTransactionForOrderId() {
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fill(ORDER_ID, "0.01", "500.00")),
+                List.of(),
+                request(true));
+
+        assertEquals(1, report.summary().exchangeOnly());
+        assertEquals(ReconciliationStatus.EXCHANGE_ONLY, report.entries().get(0).status());
+    }
+
+    @Test
+    void matchExchangeOnlyEntryUsesClientOrderIdFromFillWhenAvailable() {
+        TradeExecutionDto fillWithClientId = new TradeExecutionDto(
+                "t1", ORDER_ID, "client-from-exchange", "BTCUSDT",
+                new BigDecimal("50000"), new BigDecimal("0.01"), new BigDecimal("500"),
+                new BigDecimal("0.0001"), "BNB", FILL_AT, true);
+
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fillWithClientId), List.of(), request(true));
+
+        assertEquals("client-from-exchange", report.entries().get(0).clientOrderId());
+    }
+
+    @Test
+    void matchExchangeOnlyEntryFallsBackToOrderIdLabelWhenClientOrderIdIsNull() {
+        // Binance does not return clientOrderId in myTrades — null is the expected real-world case
+        TradeExecutionDto fillNullClientId = new TradeExecutionDto(
+                "t1", ORDER_ID, null, "BTCUSDT",
+                new BigDecimal("50000"), new BigDecimal("0.01"), new BigDecimal("500"),
+                new BigDecimal("0.0001"), "BNB", FILL_AT, true);
+
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fillNullClientId), List.of(), request(true));
+
+        assertEquals("order-" + ORDER_ID, report.entries().get(0).clientOrderId());
+    }
+
+    @Test
+    void matchReturnsLocalOnlyWhenNoExchangeFillForExchangeOrderId() {
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(),
+                List.of(localTx("client-1", ORDER_ID, "0.01", "50000", "500.00")),
+                request(true));
+
+        assertEquals(1, report.summary().localOnly());
+        assertEquals(ReconciliationStatus.LOCAL_ONLY, report.entries().get(0).status());
+        assertEquals("client-1", report.entries().get(0).clientOrderId());
+    }
+
+    @Test
+    void matchReturnsLocalOnlyForNeverSubmittedTransaction() {
+        // Transaction with no exchangeOrderId was never successfully submitted
+        Transaction neverSubmitted = localTxNoExchangeOrderId("client-pending");
+
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(), List.of(neverSubmitted), request(true));
+
+        assertEquals(1, report.summary().localOnly());
+        assertEquals("client-pending", report.entries().get(0).clientOrderId());
+    }
+
+    @Test
+    void matchExcludesMatchedEntriesFromListWhenIncludeMatchedFalse() {
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fill(ORDER_ID, "0.01", "500.00")),
+                List.of(localTx("client-1", ORDER_ID, "0.01", "50000", "500.00")),
+                request(false));
+
+        assertEquals(1, report.summary().matched());
+        assertTrue(report.entries().isEmpty());
+    }
+
+    @Test
+    void matchIncludesMatchedEntriesWhenIncludeMatchedTrue() {
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fill(ORDER_ID, "0.01", "500.00")),
+                List.of(localTx("client-1", ORDER_ID, "0.01", "50000", "500.00")),
+                request(true));
+
+        assertEquals(1, report.summary().matched());
+        assertEquals(1, report.entries().size());
+    }
+
+    @Test
+    void matchAggregatesMultipleFillsForSameExchangeOrderId() {
+        long orderId = 100234L;
+        TradeExecutionDto fill1 = new TradeExecutionDto(
+                "t1", orderId, null, "BTCUSDT",
+                new BigDecimal("50000"), new BigDecimal("0.005"), new BigDecimal("250"),
+                new BigDecimal("0.0001"), "BNB", FILL_AT, true);
+        TradeExecutionDto fill2 = new TradeExecutionDto(
+                "t2", orderId, null, "BTCUSDT",
+                new BigDecimal("50000"), new BigDecimal("0.005"), new BigDecimal("250"),
+                new BigDecimal("0.0001"), "BNB", FILL_AT.plusSeconds(60), true);
+
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fill1, fill2),
+                List.of(localTx("client-1", orderId, "0.01", "50000", "500.00")),
+                request(true));
+
+        assertEquals(1, report.summary().matched());
+        assertEquals(2, report.entries().get(0).exchangeSide().fillCount());
+    }
+
+    @Test
+    void matchSummaryTotalEqualsAllCategorySum() {
+        long orderId2 = 200001L;
+        ReconciliationReportDto report = ReconciliationMatcher.match(
+                List.of(fill(ORDER_ID, "0.01", "500.00"), fill(orderId2, "0.02", "1000.00")),
+                List.of(
+                        localTx("client-matched", ORDER_ID, "0.01", "50000", "500.00"),
+                        localTx("client-local-only", 300001L, "0.03", "50000", "1500.00")),
+                request(true));
+
+        assertEquals(1, report.summary().matched());
+        assertEquals(1, report.summary().exchangeOnly());
+        assertEquals(1, report.summary().localOnly());
+        assertEquals(3, report.summary().total());
+    }
+
+    @Test
+    void matchReturnsEmptyReportWhenBothListsAreEmpty() {
+        ReconciliationReportDto report = ReconciliationMatcher.match(List.of(), List.of(), request(true));
+
+        assertEquals(0, report.summary().total());
+        assertTrue(report.entries().isEmpty());
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static TradeExecutionDto fill(long exchangeOrderId, String qty, String quoteQty) {
+        return new TradeExecutionDto(
+                "trade-1", exchangeOrderId,
+                null,       // clientOrderId not returned by Binance myTrades
+                "BTCUSDT",
+                new BigDecimal("50000"),
+                new BigDecimal(qty),
+                new BigDecimal(quoteQty),
+                new BigDecimal("0.0001"), "BNB", FILL_AT, true);
+    }
+
+    private static Transaction localTx(String clientOrderId, long exchangeOrderId,
+                                       String qty, String execPrice, String total) {
+        BigDecimal amount = new BigDecimal(qty);
+        return Transaction.reconstitute()
+                .id(UUID.randomUUID())
+                .runnerId(UUID.randomUUID())
+                .clientOrderId(clientOrderId)
+                .exchangeOrderId(String.valueOf(exchangeOrderId))
+                .status(TransactionStatus.FILLED)
+                .type(TransactionType.BUY)
+                .symbol("BTCUSDT")
+                .quantity(amount)
+                .executedQuantity(amount)
+                .price(new BigDecimal(execPrice))
+                .executedPrice(new BigDecimal(execPrice))
+                .total(new BigDecimal(total))
+                .confidence(null)
+                .reasoning(null)
+                .targetLotId(null)
+                .requestedAt(FILL_AT)
+                .updatedAt(FILL_AT)
+                .executedAt(FILL_AT)
+                .rejectReason(null)
+                .version(0L)
+                .build();
+    }
+
+    private static Transaction localTxNoExchangeOrderId(String clientOrderId) {
+        return Transaction.reconstitute()
+                .id(UUID.randomUUID())
+                .runnerId(UUID.randomUUID())
+                .clientOrderId(clientOrderId)
+                .exchangeOrderId(null)
+                .status(TransactionStatus.PENDING)
+                .type(TransactionType.BUY)
+                .symbol("BTCUSDT")
+                .quantity(new BigDecimal("0.01"))
+                .executedQuantity(null)
+                .price(new BigDecimal("50000"))
+                .executedPrice(null)
+                .total(new BigDecimal("500"))
+                .confidence(null)
+                .reasoning(null)
+                .targetLotId(null)
+                .requestedAt(FILL_AT)
+                .updatedAt(FILL_AT)
+                .executedAt(null)
+                .rejectReason(null)
+                .version(0L)
+                .build();
+    }
+
+    private static ReconciliationRequest request(boolean includeMatched) {
+        return new ReconciliationRequest("BTCUSDT", FROM, TO, includeMatched);
+    }
+}

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -22,6 +22,8 @@ Trilha de tarefas para habilitar operação com a API da Binance (testnet), pré
 | T14 | Refactor Fronteiras Arquiteturais: Transporte e Negócio | Alta | Claude | Concluído |
 | T15 | ExchangeOrderPort: Mover seleção de transporte para adapter-binance | Média | Claude | Concluído |
 | T16 | ExchangeAdapterDescriptor: Centralizar capabilities por adapter | Média | Claude | Concluído |
+| T17 | Loki: Agregação de Logs                                          | Média | Claude | Pendente  |
+| T18 | Trade Reconciliation Report                                      | Média | Claude | Pendente  |
 
 ## Ordem de execução
 
@@ -62,6 +64,9 @@ T15  ExchangeOrderPort                  ← seleção de transporte no adapter-b
        ↓
 T16  ExchangeAdapterDescriptor          ← capabilities por adapter, repositório simplificado
        ↓
+T17  Loki                               ← agregação de logs, alertas de ERROR
+T18  Trade Reconciliation Report        ← auditoria fills Binance vs local (independente)
+       ↓
    produção
 ```
 
@@ -74,3 +79,5 @@ T16  ExchangeAdapterDescriptor          ← capabilities por adapter, repositór
 - Nenhuma ordem é enviada violando filtros de símbolo (stepSize, minNotional, tickSize).
 - Kill switch interrompe todos os runners sem efeito financeiro residual.
 - Métricas visíveis no Grafana durante staging.
+- Logs de ERROR agregados no Loki e acessíveis por `clientOrderId` no Grafana.
+- Relatório de reconciliação mostra `binanceOnly=0` e `localOnly=0` após sessão sem falhas.

--- a/docs/tasks/T18-trade-reconciliation-report.md
+++ b/docs/tasks/T18-trade-reconciliation-report.md
@@ -129,13 +129,14 @@ Inclui status: `FILLED`, `PARTIALLY_FILLED`. Ignora `SUBMITTED`, `PENDING`, `CAN
 ### 5. Endpoint REST (em `spring-application`)
 
 ```
-GET /api/reconciliation?symbol=BTCUSDT&from=2025-01-01T00:00:00Z&to=2025-01-02T00:00:00Z
+GET /api/reconciliation?symbol=BTCUSDT&from=2025-01-01T00:00:00Z&to=2025-01-02T00:00:00Z&exchangeId=BINANCE
 ```
 
 Parâmetros:
 - `symbol` — obrigatório
 - `from` — ISO-8601, obrigatório
 - `to` — ISO-8601, obrigatório
+- `exchangeId` — identificador da exchange, default `BINANCE` (único exchange suportado atualmente)
 - `includeMatched` — boolean, default `false` (oculta MATCHED para reduzir ruído)
 
 Response: `200 OK` com `ReconciliationReportDto` em JSON.

--- a/docs/tasks/T18-trade-reconciliation-report.md
+++ b/docs/tasks/T18-trade-reconciliation-report.md
@@ -1,0 +1,192 @@
+# T18 — Trade Reconciliation Report
+
+**Complexidade:** Média  
+**Responsável:** Claude  
+**Dependências:** T5 (REST API Binance), T16 (ExchangeAdapterDescriptor)  
+**Status:** Pendente
+
+---
+
+## Descrição
+
+Após horas de operação em testnet, é necessário validar se o que a Binance executou bate com o que o sistema registrou localmente. Esta tarefa implementa um endpoint de auditoria read-only que:
+
+1. Consulta o histórico de trades executados na Binance via `GET /api/v3/myTrades`
+2. Consulta as transações e fills registrados localmente no banco
+3. Cruza os dois lados pelo `clientOrderId` (chave local) e `orderId` (chave Binance)
+4. Retorna um relatório com as divergências encontradas
+
+**O relatório não corrige nada.** É uma ferramenta de inspeção para o operador identificar se o sistema está operando corretamente.
+
+---
+
+## Modelo do relatório
+
+```
+ReconciliationReportDto
+├── period: { from, to }
+├── symbol: String
+├── summary: { total, matched, divergent, binanceOnly, localOnly }
+└── entries: List<ReconciliationEntryDto>
+    ├── status: MATCHED | DIVERGENT | BINANCE_ONLY | LOCAL_ONLY
+    ├── clientOrderId: String (null se BINANCE_ONLY sem clientOrderId reconhecido)
+    ├── binanceSide: { orderId, executedQty, avgPrice, totalQuote, fees, time }  (null se LOCAL_ONLY)
+    └── localSide:   { transactionId, runnerId, executedQty, avgPrice, totalQuote, status, updatedAt }  (null se BINANCE_ONLY)
+```
+
+**Categorias de status:**
+
+| Status | Significado |
+|---|---|
+| `MATCHED` | Trade existe nos dois lados com qty e valor dentro da tolerância |
+| `DIVERGENT` | Trade existe nos dois lados mas qty ou valor discrepam além da tolerância |
+| `BINANCE_ONLY` | Trade executado na Binance sem transação local correspondente (fill perdido) |
+| `LOCAL_ONLY` | Transação local marcada como FILLED/PARTIALLY_FILLED sem trade Binance confirmando |
+
+---
+
+## Escopo técnico
+
+### 1. Port de consulta histórica Binance (outbound, em `core`)
+
+```java
+// core/src/main/java/com/marmitt/core/ports/outbound/exchange/TradeHistoryQueryPort.java
+public interface TradeHistoryQueryPort {
+    List<BinanceTradeDto> fetchTrades(String symbol, Instant from, Instant to);
+}
+```
+
+```java
+// core/src/main/java/com/marmitt/core/dto/exchange/BinanceTradeDto.java
+public record BinanceTradeDto(
+    long orderId,
+    String clientOrderId,
+    String symbol,
+    BigDecimal price,
+    BigDecimal qty,
+    BigDecimal quoteQty,
+    BigDecimal commission,
+    String commissionAsset,
+    Instant time,
+    boolean isBuyer
+) {}
+```
+
+---
+
+### 2. Use case de reconciliação (em `core`)
+
+```java
+// core/.../usecase/reconciliation/ReconcileTradesUseCase.java
+public class ReconcileTradesUseCase {
+
+    public ReconciliationReportDto reconcile(ReconciliationRequest request) {
+        List<BinanceTradeDto> binanceTrades = tradeHistoryQueryPort.fetchTrades(
+            request.symbol(), request.from(), request.to());
+
+        List<Transaction> localTransactions = strategyRunnerRepository
+            .findByPeriodAndSymbol(request.symbol(), request.from(), request.to());
+
+        return ReconciliationMatcher.match(binanceTrades, localTransactions, request);
+    }
+}
+```
+
+**Lógica de matching em `ReconciliationMatcher`:**
+1. Indexar `localTransactions` por `clientOrderId`
+2. Para cada trade Binance: buscar local por `clientOrderId`
+   - Encontrou: comparar `executedQty` e `totalQuote` com tolerância de 8 casas decimais → `MATCHED` ou `DIVERGENT`
+   - Não encontrou: `BINANCE_ONLY`
+3. Transações locais não referenciadas por nenhum trade Binance → `LOCAL_ONLY`
+   - Filtrar apenas status `FILLED` e `PARTIALLY_FILLED` (SUBMITTED/PENDING não são divergência)
+
+---
+
+### 3. Implementação do port na Binance (em `adapter-binance`)
+
+`BinanceTradeHistoryAdapter` chama `GET /api/v3/myTrades`:
+
+```
+GET /api/v3/myTrades?symbol=BTCUSDT&startTime=<epoch_ms>&endTime=<epoch_ms>&limit=1000
+Authorization: HMAC-SHA256 (já implementado em T3)
+```
+
+Paginação: se Binance retornar 1000 registros (limite máximo), reemitir query com `fromId` do último trade até cobrir o período completo.
+
+---
+
+### 4. Query nova no repositório local
+
+```java
+// StrategyRunnerRepositoryPort — adicionar:
+List<Transaction> findFilledBySymbolAndPeriod(String symbol, Instant from, Instant to);
+```
+
+Inclui status: `FILLED`, `PARTIALLY_FILLED`. Ignora `SUBMITTED`, `PENDING`, `CANCELLED`.
+
+---
+
+### 5. Endpoint REST (em `spring-application`)
+
+```
+GET /api/reconciliation?symbol=BTCUSDT&from=2025-01-01T00:00:00Z&to=2025-01-02T00:00:00Z
+```
+
+Parâmetros:
+- `symbol` — obrigatório
+- `from` — ISO-8601, obrigatório
+- `to` — ISO-8601, obrigatório
+- `includeMatched` — boolean, default `false` (oculta MATCHED para reduzir ruído)
+
+Response: `200 OK` com `ReconciliationReportDto` em JSON.
+
+---
+
+### 6. Wiring em `spring-application`
+
+Em `BinanceMarketStreamConfiguration` (ou nova `BinanceReconciliationConfiguration`):
+```java
+@Bean
+public TradeHistoryQueryPort binanceTradeHistoryAdapter(...) {
+    return new BinanceTradeHistoryAdapter(binanceRestClient);
+}
+
+@Bean
+public ReconcileTradesUseCase reconcileTradesUseCase(
+    TradeHistoryQueryPort tradeHistoryQueryPort,
+    StrategyRunnerRepositoryPort strategyRunnerRepository) {
+    return new ReconcileTradesUseCase(tradeHistoryQueryPort, strategyRunnerRepository);
+}
+```
+
+---
+
+## Arquivos a criar/editar
+
+| Arquivo | Ação |
+|---|---|
+| `core/.../ports/outbound/exchange/TradeHistoryQueryPort.java` | Criar |
+| `core/.../dto/exchange/BinanceTradeDto.java` | Criar |
+| `core/.../dto/reconciliation/ReconciliationReportDto.java` | Criar |
+| `core/.../dto/reconciliation/ReconciliationEntryDto.java` | Criar |
+| `core/.../dto/reconciliation/ReconciliationRequest.java` | Criar |
+| `core/.../usecase/reconciliation/ReconcileTradesUseCase.java` | Criar |
+| `core/.../usecase/reconciliation/ReconciliationMatcher.java` | Criar |
+| `core/.../ports/outbound/repository/StrategyRunnerRepositoryPort.java` | Editar — adicionar `findFilledBySymbolAndPeriod` |
+| `adapter-binance/.../BinanceTradeHistoryAdapter.java` | Criar |
+| `spring-application/.../controller/ReconciliationController.java` | Criar |
+| `spring-application/.../persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java` | Editar — implementar nova query |
+| `spring-application/.../persistence/repository/RunnerTransactionJdbcRepository.java` | Editar — adicionar query JDBC |
+
+---
+
+## Critérios de aceitação
+
+1. `GET /api/reconciliation?symbol=BTCUSDT&from=...&to=...` retorna `200 OK` com JSON estruturado.
+2. Um trade executado na Binance aparece como `MATCHED` com a transação local correspondente.
+3. Uma transação local `FILLED` sem confirmação Binance aparece como `LOCAL_ONLY`.
+4. O campo `summary.binanceOnly` é `0` após uma sessão sem erros de conciliação de fills.
+5. O relatório cobre fills de ordens parcialmente preenchidas (múltiplos fills para o mesmo `clientOrderId`).
+6. `includeMatched=false` (default) omite entradas `MATCHED` do array `entries` mas mantém o count no `summary`.
+7. Período com mais de 1000 trades (limite da API Binance) é paginado automaticamente — relatório completo.
+8. Se Binance retornar erro (ex: API key inválida), endpoint retorna `502` com mensagem de erro descritiva.

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/ReconciliationConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/ReconciliationConfig.java
@@ -4,10 +4,12 @@ import com.marmitt.core.application.usecase.reconciliation.ReconcileTradesUseCas
 import com.marmitt.core.ports.inbound.reconciliation.ReconcileTradesPort;
 import com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ConditionalOnExpression("!'${binance.api-key:}'.isBlank() && !'${binance.api-secret:}'.isBlank()")
 public class ReconciliationConfig {
 
     @Bean

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/ReconciliationConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/ReconciliationConfig.java
@@ -4,7 +4,6 @@ import com.marmitt.core.application.usecase.reconciliation.ReconcileTradesUseCas
 import com.marmitt.core.ports.inbound.reconciliation.ReconcileTradesPort;
 import com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,7 +11,6 @@ import org.springframework.context.annotation.Configuration;
 public class ReconciliationConfig {
 
     @Bean
-    @ConditionalOnBean(TradeHistoryQueryPort.class)
     public ReconcileTradesPort reconcileTradesUseCase(
             TradeHistoryQueryPort tradeHistoryQueryPort,
             StrategyRunnerRepositoryPort strategyRunnerRepository) {

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/ReconciliationConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/ReconciliationConfig.java
@@ -1,0 +1,21 @@
+package com.marmitt.application.spring.config.core;
+
+import com.marmitt.core.application.usecase.reconciliation.ReconcileTradesUseCase;
+import com.marmitt.core.ports.inbound.reconciliation.ReconcileTradesPort;
+import com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ReconciliationConfig {
+
+    @Bean
+    @ConditionalOnBean(TradeHistoryQueryPort.class)
+    public ReconcileTradesPort reconcileTradesUseCase(
+            TradeHistoryQueryPort tradeHistoryQueryPort,
+            StrategyRunnerRepositoryPort strategyRunnerRepository) {
+        return new ReconcileTradesUseCase(tradeHistoryQueryPort, strategyRunnerRepository);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfiguration.java
@@ -11,7 +11,10 @@ import com.marmitt.binance.BinanceOrderAdapter;
 import com.marmitt.binance.BinanceUserStreamAdapter;
 import com.marmitt.binance.BinanceUserStreamSessionAdapter;
 import com.marmitt.binance.auth.BinanceCredentials;
+import com.marmitt.binance.auth.BinanceRequestSigner;
 import com.marmitt.binance.filters.SymbolFilterCache;
+import com.marmitt.binance.rest.BinanceRestRequestBuilder;
+import com.marmitt.binance.trade.BinanceTradeHistoryAdapter;
 import com.marmitt.core.enums.StreamChannel;
 import com.marmitt.core.ports.outbound.events.EventPublisherPort;
 import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
@@ -121,6 +124,16 @@ public class BinanceAdapterConfiguration {
                 binanceMarketStreamAdapter,
                 binanceMarketStreamAdapter
         );
+    }
+
+    @Bean
+    public BinanceTradeHistoryAdapter binanceTradeHistoryAdapter(BinanceProperties properties,
+                                                                  OkHttpClient binanceRestClient,
+                                                                  ObjectMapper objectMapper) {
+        BinanceCredentials credentials = new BinanceCredentials(properties.getApiKey(), properties.getApiSecret());
+        BinanceRequestSigner signer = new BinanceRequestSigner(credentials);
+        BinanceRestRequestBuilder requestBuilder = new BinanceRestRequestBuilder(properties.getRestBaseUrl(), signer);
+        return new BinanceTradeHistoryAdapter(requestBuilder, new OkHttpClientAdapter(binanceRestClient), objectMapper);
     }
 
     @Bean

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
@@ -16,7 +16,7 @@ import java.time.Instant;
 
 @Slf4j
 @RestController
-@RequestMapping("/reconciliation")
+@RequestMapping("/api/reconciliation")
 @ConditionalOnBean(ReconcileTradesPort.class)
 public class ReconciliationController {
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
@@ -4,7 +4,6 @@ import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
 import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
 import com.marmitt.core.ports.inbound.reconciliation.ReconcileTradesPort;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +16,6 @@ import java.time.Instant;
 @Slf4j
 @RestController
 @RequestMapping("/api/reconciliation")
-@ConditionalOnBean(ReconcileTradesPort.class)
 public class ReconciliationController {
 
     private final ReconcileTradesPort reconcileTradesPort;
@@ -35,7 +33,7 @@ public class ReconciliationController {
     @GetMapping
     public ResponseEntity<?> reconcile(
             @RequestParam String symbol,
-            @RequestParam String exchangeId,
+            @RequestParam(defaultValue = "BINANCE") String exchangeId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
             @RequestParam(defaultValue = "false") boolean includeMatched) {

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
@@ -1,0 +1,64 @@
+package com.marmitt.application.spring.controller;
+
+import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
+import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
+import com.marmitt.core.ports.inbound.reconciliation.ReconcileTradesPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+
+@Slf4j
+@RestController
+@RequestMapping("/reconciliation")
+@ConditionalOnBean(ReconcileTradesPort.class)
+public class ReconciliationController {
+
+    private final ReconcileTradesPort reconcileTradesPort;
+
+    public ReconciliationController(ReconcileTradesPort reconcileTradesPort) {
+        this.reconcileTradesPort = reconcileTradesPort;
+    }
+
+    /**
+     * GET /reconciliation?symbol=BTCUSDT&from=2025-01-01T00:00:00Z&to=2025-01-02T00:00:00Z
+     *
+     * @param includeMatched when false (default), MATCHED entries are omitted from the entries list
+     *                       but still counted in summary.matched
+     */
+    @GetMapping
+    public ResponseEntity<?> reconcile(
+            @RequestParam String symbol,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
+            @RequestParam(defaultValue = "false") boolean includeMatched) {
+
+        if (from.isAfter(to)) {
+            return ResponseEntity.badRequest().body("'from' must be before 'to'");
+        }
+
+        log.info("reconciliation: symbol={} from={} to={} includeMatched={}", symbol, from, to, includeMatched);
+
+        try {
+            ReconciliationReportDto report = reconcileTradesPort.reconcile(
+                    new ReconciliationRequest(symbol, from, to, includeMatched));
+            log.info("reconciliation: done symbol={} total={} matched={} divergent={} exchangeOnly={} localOnly={}",
+                    symbol,
+                    report.summary().total(),
+                    report.summary().matched(),
+                    report.summary().divergent(),
+                    report.summary().exchangeOnly(),
+                    report.summary().localOnly());
+            return ResponseEntity.ok(report);
+        } catch (RuntimeException e) {
+            log.error("reconciliation: failed symbol={} error={}", symbol, e.getMessage(), e);
+            return ResponseEntity.status(502).body("Exchange query failed: " + e.getMessage());
+        }
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
@@ -27,7 +27,7 @@ public class ReconciliationController {
     }
 
     /**
-     * GET /reconciliation?symbol=BTCUSDT&from=2025-01-01T00:00:00Z&to=2025-01-02T00:00:00Z
+     * GET /api/reconciliation?symbol=BTCUSDT&exchangeId=BINANCE&from=2025-01-01T00:00:00Z&to=2025-01-02T00:00:00Z
      *
      * @param includeMatched when false (default), MATCHED entries are omitted from the entries list
      *                       but still counted in summary.matched
@@ -35,6 +35,7 @@ public class ReconciliationController {
     @GetMapping
     public ResponseEntity<?> reconcile(
             @RequestParam String symbol,
+            @RequestParam String exchangeId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
             @RequestParam(defaultValue = "false") boolean includeMatched) {
@@ -43,11 +44,12 @@ public class ReconciliationController {
             return ResponseEntity.badRequest().body("'from' must be before 'to'");
         }
 
-        log.info("reconciliation: symbol={} from={} to={} includeMatched={}", symbol, from, to, includeMatched);
+        log.info("reconciliation: symbol={} exchangeId={} from={} to={} includeMatched={}",
+                symbol, exchangeId, from, to, includeMatched);
 
         try {
             ReconciliationReportDto report = reconcileTradesPort.reconcile(
-                    new ReconciliationRequest(symbol, from, to, includeMatched));
+                    new ReconciliationRequest(symbol, exchangeId, from, to, includeMatched));
             log.info("reconciliation: done symbol={} total={} matched={} divergent={} exchangeOnly={} localOnly={}",
                     symbol,
                     report.summary().total(),

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
@@ -58,6 +58,9 @@ public class ReconciliationController {
                     report.summary().exchangeOnly(),
                     report.summary().localOnly());
             return ResponseEntity.ok(report);
+        } catch (IllegalArgumentException e) {
+            log.warn("reconciliation: bad request symbol={} error={}", symbol, e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
         } catch (RuntimeException e) {
             log.error("reconciliation: failed symbol={} error={}", symbol, e.getMessage(), e);
             return ResponseEntity.status(502).body("Exchange query failed: " + e.getMessage());

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
@@ -4,6 +4,7 @@ import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
 import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
 import com.marmitt.core.ports.inbound.reconciliation.ReconcileTradesPort;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +17,7 @@ import java.time.Instant;
 @Slf4j
 @RestController
 @RequestMapping("/api/reconciliation")
+@ConditionalOnExpression("!'${binance.api-key:}'.isBlank() && !'${binance.api-secret:}'.isBlank()")
 public class ReconciliationController {
 
     private final ReconcileTradesPort reconcileTradesPort;

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
@@ -368,13 +368,13 @@ public class JdbcStrategyRunnerRepositoryAdapter implements StrategyRunnerReposi
     }
 
     @Override
-    public List<Transaction> findFilledBySymbolAndPeriod(String symbol, Instant from, Instant to) {
+    public List<Transaction> findFilledBySymbolAndPeriod(String symbol, String exchangeId, Instant from, Instant to) {
         long start = System.nanoTime();
-        List<Transaction> result = transactionRepo.findFilledBySymbolAndPeriod(symbol, from, to).stream()
+        List<Transaction> result = transactionRepo.findFilledBySymbolAndPeriod(symbol, exchangeId, from, to).stream()
                 .map(StrategyRunnerEntityMapper::toDomain)
                 .toList();
-        log.trace("[REPO] transaction.findFilledBySymbolAndPeriod({}, {}, {}) - {}ms - {} results",
-                symbol, from, to, RepoTiming.elapsedMs(start), result.size());
+        log.trace("[REPO] transaction.findFilledBySymbolAndPeriod({}, {}, {}, {}) - {}ms - {} results",
+                symbol, exchangeId, from, to, RepoTiming.elapsedMs(start), result.size());
         return result;
     }
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/adapter/JdbcStrategyRunnerRepositoryAdapter.java
@@ -367,6 +367,17 @@ public class JdbcStrategyRunnerRepositoryAdapter implements StrategyRunnerReposi
         return locked;
     }
 
+    @Override
+    public List<Transaction> findFilledBySymbolAndPeriod(String symbol, Instant from, Instant to) {
+        long start = System.nanoTime();
+        List<Transaction> result = transactionRepo.findFilledBySymbolAndPeriod(symbol, from, to).stream()
+                .map(StrategyRunnerEntityMapper::toDomain)
+                .toList();
+        log.trace("[REPO] transaction.findFilledBySymbolAndPeriod({}, {}, {}) - {}ms - {} results",
+                symbol, from, to, RepoTiming.elapsedMs(start), result.size());
+        return result;
+    }
+
     private static void validateOpenedByInvariant(Position position) {
         PositionStatus status = position.getStatus();
         boolean active = status == PositionStatus.OPEN || status == PositionStatus.CLOSING;

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/entity/RunnerTransactionEntity.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/entity/RunnerTransactionEntity.java
@@ -53,6 +53,7 @@ public class RunnerTransactionEntity {
     private Instant requestedAt;
     private Instant updatedAt;
     private Instant executedAt;
+    private Instant lastPartialFillAt;
     private String rejectReason;
 
     @Version

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/mapper/StrategyRunnerEntityMapper.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/mapper/StrategyRunnerEntityMapper.java
@@ -138,6 +138,7 @@ public class StrategyRunnerEntityMapper {
                 .requestedAt(domain.getRequestedAt())
                 .updatedAt(domain.getUpdatedAt())
                 .executedAt(domain.getExecutedAt())
+                .lastPartialFillAt(domain.getLastPartialFillAt())
                 .rejectReason(domain.getRejectReason())
                 .version(domain.getVersion())
                 .build();
@@ -163,6 +164,7 @@ public class StrategyRunnerEntityMapper {
                 .requestedAt(entity.getRequestedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .executedAt(entity.getExecutedAt())
+                .lastPartialFillAt(entity.getLastPartialFillAt())
                 .rejectReason(entity.getRejectReason())
                 .version(entity.getVersion())
                 .build();

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
@@ -35,9 +35,19 @@ public interface RunnerTransactionJdbcRepository extends CrudRepository<RunnerTr
             @Param("limit") int limit
     );
 
-    @Query("SELECT * FROM transactions WHERE symbol = :symbol AND status IN ('FILLED', 'PARTIAL') AND COALESCE(executed_at, requested_at) >= :from AND COALESCE(executed_at, requested_at) <= :to ORDER BY COALESCE(executed_at, requested_at)")
+    @Query("""
+            SELECT t.* FROM transactions t
+            JOIN strategy_runners sr ON sr.id = t.runner_id
+            WHERE t.symbol = :symbol
+              AND UPPER(sr.exchange_id) = UPPER(:exchangeId)
+              AND t.status IN ('FILLED', 'PARTIAL')
+              AND COALESCE(t.executed_at, t.updated_at) >= :from
+              AND COALESCE(t.executed_at, t.updated_at) <= :to
+            ORDER BY COALESCE(t.executed_at, t.updated_at)
+            """)
     List<RunnerTransactionEntity> findFilledBySymbolAndPeriod(
             @Param("symbol") String symbol,
+            @Param("exchangeId") String exchangeId,
             @Param("from") Instant from,
             @Param("to") Instant to
     );

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
@@ -40,7 +40,8 @@ public interface RunnerTransactionJdbcRepository extends CrudRepository<RunnerTr
             JOIN strategy_runners sr ON sr.id = t.runner_id
             WHERE t.symbol = :symbol
               AND UPPER(sr.exchange_id) = UPPER(:exchangeId)
-              AND t.status IN ('FILLED', 'PARTIAL')
+              AND (t.status IN ('FILLED', 'PARTIAL')
+                   OR (t.status = 'CANCELED' AND t.executed_quantity > 0))
               AND COALESCE(t.executed_at, t.updated_at) >= :from
               AND COALESCE(t.executed_at, t.updated_at) <= :to
             ORDER BY COALESCE(t.executed_at, t.updated_at)

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
@@ -35,7 +35,7 @@ public interface RunnerTransactionJdbcRepository extends CrudRepository<RunnerTr
             @Param("limit") int limit
     );
 
-    @Query("SELECT * FROM transactions WHERE symbol = :symbol AND status IN ('FILLED', 'PARTIAL') AND requested_at >= :from AND requested_at <= :to ORDER BY requested_at")
+    @Query("SELECT * FROM transactions WHERE symbol = :symbol AND status IN ('FILLED', 'PARTIAL') AND COALESCE(executed_at, requested_at) >= :from AND COALESCE(executed_at, requested_at) <= :to ORDER BY COALESCE(executed_at, requested_at)")
     List<RunnerTransactionEntity> findFilledBySymbolAndPeriod(
             @Param("symbol") String symbol,
             @Param("from") Instant from,

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
@@ -34,4 +34,11 @@ public interface RunnerTransactionJdbcRepository extends CrudRepository<RunnerTr
             @Param("updatedBefore") Instant updatedBefore,
             @Param("limit") int limit
     );
+
+    @Query("SELECT * FROM transactions WHERE symbol = :symbol AND status IN ('FILLED', 'PARTIAL') AND requested_at >= :from AND requested_at <= :to ORDER BY requested_at")
+    List<RunnerTransactionEntity> findFilledBySymbolAndPeriod(
+            @Param("symbol") String symbol,
+            @Param("from") Instant from,
+            @Param("to") Instant to
+    );
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/persistence/repository/RunnerTransactionJdbcRepository.java
@@ -40,11 +40,16 @@ public interface RunnerTransactionJdbcRepository extends CrudRepository<RunnerTr
             JOIN strategy_runners sr ON sr.id = t.runner_id
             WHERE t.symbol = :symbol
               AND UPPER(sr.exchange_id) = UPPER(:exchangeId)
-              AND (t.status IN ('FILLED', 'PARTIAL')
-                   OR (t.status = 'CANCELED' AND t.executed_quantity > 0))
-              AND COALESCE(t.executed_at, t.updated_at) >= :from
-              AND COALESCE(t.executed_at, t.updated_at) <= :to
-            ORDER BY COALESCE(t.executed_at, t.updated_at)
+              AND (
+                (t.status IN ('FILLED', 'PARTIAL')
+                 AND COALESCE(t.executed_at, t.updated_at) >= :from
+                 AND COALESCE(t.executed_at, t.updated_at) <= :to)
+                OR
+                (t.status = 'CANCELED' AND t.executed_quantity > 0
+                 AND t.last_partial_fill_at >= :from
+                 AND t.last_partial_fill_at <= :to)
+              )
+            ORDER BY COALESCE(t.executed_at, t.last_partial_fill_at, t.updated_at)
             """)
     List<RunnerTransactionEntity> findFilledBySymbolAndPeriod(
             @Param("symbol") String symbol,

--- a/spring-application/src/main/resources/db/migration/V11__add_last_partial_fill_at_to_transactions.sql
+++ b/spring-application/src/main/resources/db/migration/V11__add_last_partial_fill_at_to_transactions.sql
@@ -1,0 +1,4 @@
+-- Stores the timestamp of the last partial fill event independently of updated_at.
+-- updated_at is overwritten by cancel(), losing the fill time for PARTIAL→CANCELED orders.
+-- This column is set only by partialFill() and remains stable through subsequent status changes.
+ALTER TABLE transactions ADD COLUMN last_partial_fill_at TIMESTAMPTZ;

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
@@ -43,6 +43,7 @@ class ReconciliationControllerTest {
 
         mockMvc.perform(get("/api/reconciliation")
                         .param("symbol", "BTCUSDT")
+                        .param("exchangeId", "BINANCE")
                         .param("from", "2026-01-01T00:00:00Z")
                         .param("to", "2026-01-02T00:00:00Z"))
                 .andExpect(status().isOk())
@@ -56,6 +57,7 @@ class ReconciliationControllerTest {
     void reconcile_returnsBadRequestWhenFromIsAfterTo() throws Exception {
         mockMvc.perform(get("/api/reconciliation")
                         .param("symbol", "BTCUSDT")
+                        .param("exchangeId", "BINANCE")
                         .param("from", "2026-01-02T00:00:00Z")
                         .param("to", "2026-01-01T00:00:00Z"))
                 .andExpect(status().isBadRequest());
@@ -68,13 +70,14 @@ class ReconciliationControllerTest {
 
         mockMvc.perform(get("/api/reconciliation")
                         .param("symbol", "BTCUSDT")
+                        .param("exchangeId", "BINANCE")
                         .param("from", "2026-01-01T00:00:00Z")
                         .param("to", "2026-01-02T00:00:00Z"))
                 .andExpect(status().isBadGateway());
     }
 
     @Test
-    void reconcile_passesIncludeMatchedParamToUseCase() throws Exception {
+    void reconcile_passesAllParamsToUseCase() throws Exception {
         ReconciliationReportDto report = new ReconciliationReportDto(
                 "BTCUSDT",
                 Instant.parse("2026-01-01T00:00:00Z"),
@@ -85,6 +88,7 @@ class ReconciliationControllerTest {
 
         mockMvc.perform(get("/api/reconciliation")
                         .param("symbol", "BTCUSDT")
+                        .param("exchangeId", "BINANCE")
                         .param("from", "2026-01-01T00:00:00Z")
                         .param("to", "2026-01-02T00:00:00Z")
                         .param("includeMatched", "true"))
@@ -93,6 +97,7 @@ class ReconciliationControllerTest {
         verify(reconcileTradesPort).reconcile(
                 new ReconciliationRequest(
                         "BTCUSDT",
+                        "BINANCE",
                         Instant.parse("2026-01-01T00:00:00Z"),
                         Instant.parse("2026-01-02T00:00:00Z"),
                         true));

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
@@ -64,6 +64,19 @@ class ReconciliationControllerTest {
     }
 
     @Test
+    void reconcile_returns400WhenExchangeIdNotSupported() throws Exception {
+        when(reconcileTradesPort.reconcile(any(ReconciliationRequest.class)))
+                .thenThrow(new IllegalArgumentException("Exchange 'COINBASE' is not supported"));
+
+        mockMvc.perform(get("/api/reconciliation")
+                        .param("symbol", "BTCUSDT")
+                        .param("exchangeId", "COINBASE")
+                        .param("from", "2026-01-01T00:00:00Z")
+                        .param("to", "2026-01-02T00:00:00Z"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void reconcile_returns502WhenExchangeThrows() throws Exception {
         when(reconcileTradesPort.reconcile(any(ReconciliationRequest.class)))
                 .thenThrow(new RuntimeException("Binance timeout"));

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
@@ -1,0 +1,100 @@
+package com.marmitt.application.spring.controller;
+
+import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
+import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
+import com.marmitt.core.dto.reconciliation.ReconciliationSummaryDto;
+import com.marmitt.core.ports.inbound.reconciliation.ReconcileTradesPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReconciliationControllerTest {
+
+    private final ReconcileTradesPort reconcileTradesPort = mock(ReconcileTradesPort.class);
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ReconciliationController(reconcileTradesPort)).build();
+    }
+
+    @Test
+    void reconcile_returnsOkWithSummaryWhenRequestIsValid() throws Exception {
+        ReconciliationReportDto report = new ReconciliationReportDto(
+                "BTCUSDT",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"),
+                new ReconciliationSummaryDto(3, 2, 1, 0, 0),
+                List.of());
+
+        when(reconcileTradesPort.reconcile(any(ReconciliationRequest.class))).thenReturn(report);
+
+        mockMvc.perform(get("/reconciliation")
+                        .param("symbol", "BTCUSDT")
+                        .param("from", "2026-01-01T00:00:00Z")
+                        .param("to", "2026-01-02T00:00:00Z"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.symbol").value("BTCUSDT"))
+                .andExpect(jsonPath("$.summary.total").value(3))
+                .andExpect(jsonPath("$.summary.matched").value(2))
+                .andExpect(jsonPath("$.summary.divergent").value(1));
+    }
+
+    @Test
+    void reconcile_returnsBadRequestWhenFromIsAfterTo() throws Exception {
+        mockMvc.perform(get("/reconciliation")
+                        .param("symbol", "BTCUSDT")
+                        .param("from", "2026-01-02T00:00:00Z")
+                        .param("to", "2026-01-01T00:00:00Z"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void reconcile_returns502WhenExchangeThrows() throws Exception {
+        when(reconcileTradesPort.reconcile(any(ReconciliationRequest.class)))
+                .thenThrow(new RuntimeException("Binance timeout"));
+
+        mockMvc.perform(get("/reconciliation")
+                        .param("symbol", "BTCUSDT")
+                        .param("from", "2026-01-01T00:00:00Z")
+                        .param("to", "2026-01-02T00:00:00Z"))
+                .andExpect(status().isBadGateway());
+    }
+
+    @Test
+    void reconcile_passesIncludeMatchedParamToUseCase() throws Exception {
+        ReconciliationReportDto report = new ReconciliationReportDto(
+                "BTCUSDT",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"),
+                new ReconciliationSummaryDto(0, 0, 0, 0, 0),
+                List.of());
+        when(reconcileTradesPort.reconcile(any(ReconciliationRequest.class))).thenReturn(report);
+
+        mockMvc.perform(get("/reconciliation")
+                        .param("symbol", "BTCUSDT")
+                        .param("from", "2026-01-01T00:00:00Z")
+                        .param("to", "2026-01-02T00:00:00Z")
+                        .param("includeMatched", "true"))
+                .andExpect(status().isOk());
+
+        verify(reconcileTradesPort).reconcile(
+                new ReconciliationRequest(
+                        "BTCUSDT",
+                        Instant.parse("2026-01-01T00:00:00Z"),
+                        Instant.parse("2026-01-02T00:00:00Z"),
+                        true));
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
@@ -41,7 +41,7 @@ class ReconciliationControllerTest {
 
         when(reconcileTradesPort.reconcile(any(ReconciliationRequest.class))).thenReturn(report);
 
-        mockMvc.perform(get("/reconciliation")
+        mockMvc.perform(get("/api/reconciliation")
                         .param("symbol", "BTCUSDT")
                         .param("from", "2026-01-01T00:00:00Z")
                         .param("to", "2026-01-02T00:00:00Z"))
@@ -54,7 +54,7 @@ class ReconciliationControllerTest {
 
     @Test
     void reconcile_returnsBadRequestWhenFromIsAfterTo() throws Exception {
-        mockMvc.perform(get("/reconciliation")
+        mockMvc.perform(get("/api/reconciliation")
                         .param("symbol", "BTCUSDT")
                         .param("from", "2026-01-02T00:00:00Z")
                         .param("to", "2026-01-01T00:00:00Z"))
@@ -66,7 +66,7 @@ class ReconciliationControllerTest {
         when(reconcileTradesPort.reconcile(any(ReconciliationRequest.class)))
                 .thenThrow(new RuntimeException("Binance timeout"));
 
-        mockMvc.perform(get("/reconciliation")
+        mockMvc.perform(get("/api/reconciliation")
                         .param("symbol", "BTCUSDT")
                         .param("from", "2026-01-01T00:00:00Z")
                         .param("to", "2026-01-02T00:00:00Z"))
@@ -83,7 +83,7 @@ class ReconciliationControllerTest {
                 List.of());
         when(reconcileTradesPort.reconcile(any(ReconciliationRequest.class))).thenReturn(report);
 
-        mockMvc.perform(get("/reconciliation")
+        mockMvc.perform(get("/api/reconciliation")
                         .param("symbol", "BTCUSDT")
                         .param("from", "2026-01-01T00:00:00Z")
                         .param("to", "2026-01-02T00:00:00Z")

--- a/spring-application/src/test/java/com/marmitt/application/spring/reconciliation/ReconciliationIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/reconciliation/ReconciliationIntegrationTest.java
@@ -135,10 +135,12 @@ class ReconciliationIntegrationTest {
     }
 
     @Test
-    void findFilledBySymbolAndPeriod_includesCanceledTransactionsWithPartialExecution() {
-        Instant updatedAt = Instant.parse("2026-01-01T10:00:00Z");
-        insertTransactionWithStatus("BTCUSDT", "BINANCE", "client-canceled-partial",
-                new BigDecimal("0.005"), "CANCELED", updatedAt);
+    void findFilledBySymbolAndPeriod_includesCanceledTransactionsWhenFillWasInWindow() {
+        // Fill at 10:00 (inside window), cancel at 12:00 (also inside, but different time)
+        Instant fillAt = Instant.parse("2026-01-01T10:00:00Z");
+        Instant cancelAt = Instant.parse("2026-01-01T12:00:00Z");
+        insertCanceledPartialTransaction("BTCUSDT", "BINANCE", "client-canceled-partial",
+                new BigDecimal("0.005"), fillAt, cancelAt);
 
         List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
                 "BTCUSDT", "BINANCE",
@@ -150,10 +152,26 @@ class ReconciliationIntegrationTest {
     }
 
     @Test
+    void findFilledBySymbolAndPeriod_excludesCanceledTransactionsWhenFillWasOutsideWindow() {
+        // Fill before window, cancel inside window — cancel time must NOT be used as fill time
+        Instant fillAt = Instant.parse("2025-12-31T10:00:00Z");   // before window
+        Instant cancelAt = Instant.parse("2026-01-01T10:00:00Z"); // inside window
+        insertCanceledPartialTransaction("BTCUSDT", "BINANCE", "client-old-canceled",
+                new BigDecimal("0.005"), fillAt, cancelAt);
+
+        List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
+                "BTCUSDT", "BINANCE",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"));
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
     void findFilledBySymbolAndPeriod_excludesCanceledTransactionsWithNoExecution() {
-        Instant updatedAt = Instant.parse("2026-01-01T10:00:00Z");
-        insertTransactionWithStatus("BTCUSDT", "BINANCE", "client-canceled-zero",
-                BigDecimal.ZERO, "CANCELED", updatedAt);
+        Instant cancelAt = Instant.parse("2026-01-01T10:00:00Z");
+        insertCanceledPartialTransaction("BTCUSDT", "BINANCE", "client-canceled-zero",
+                BigDecimal.ZERO, null, cancelAt);
 
         List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
                 "BTCUSDT", "BINANCE",
@@ -165,11 +183,6 @@ class ReconciliationIntegrationTest {
 
     private void insertFilledTransaction(String symbol, String exchangeId, String clientOrderId,
                                          BigDecimal qty, Instant executedAt) {
-        insertTransactionWithStatus(symbol, exchangeId, clientOrderId, qty, "FILLED", executedAt);
-    }
-
-    private void insertTransactionWithStatus(String symbol, String exchangeId, String clientOrderId,
-                                              BigDecimal executedQty, String status, Instant updatedAt) {
         UUID portfolioId = UUID.randomUUID();
         UUID runnerId = UUID.randomUUID();
         String shortCode = UUID.randomUUID().toString().substring(0, 4).toUpperCase();
@@ -187,15 +200,50 @@ class ReconciliationIntegrationTest {
                 "0.1, 1, 1, false, NOW())",
                 runnerId, portfolioId, shortCode, UUID.randomUUID(), symbol, exchangeId);
 
-        // For FILLED: executed_at is set (time filter uses it). For CANCELED/PARTIAL: uses updated_at.
-        boolean isFilled = "FILLED".equals(status);
+        // executed_at used as the time filter (COALESCE(executed_at, updated_at)); for PARTIAL, updated_at would be used
         jdbcTemplate.update(
                 "INSERT INTO transactions (id, runner_id, client_order_id, exchange_order_id, status, type, " +
                 "symbol, quantity, executed_quantity, price, executed_price, total, requested_at, updated_at, executed_at, version) " +
-                "VALUES (?, ?, ?, '100234', ?, 'BUY', ?, 0.01, ?, 50000, 50000, ?, NOW(), ?, ?, 0)",
-                UUID.randomUUID(), runnerId, clientOrderId, status, symbol,
+                "VALUES (?, ?, ?, '100234', 'FILLED', 'BUY', ?, ?, ?, 50000, 50000, ?, NOW(), ?, ?, 0)",
+                UUID.randomUUID(), runnerId, clientOrderId, symbol,
+                qty, qty, qty.multiply(new BigDecimal("50000")),
+                Timestamp.from(executedAt),
+                Timestamp.from(executedAt));
+    }
+
+    /**
+     * Inserts a CANCELED transaction with partial execution.
+     * fillAt = the time the partial fill occurred (stored in last_partial_fill_at).
+     * cancelAt = the time cancel() was called (stored in updated_at, which would overwrite fillAt).
+     * Pass fillAt=null to simulate a CANCELED order with zero execution.
+     */
+    private void insertCanceledPartialTransaction(String symbol, String exchangeId, String clientOrderId,
+                                                   BigDecimal executedQty, Instant fillAt, Instant cancelAt) {
+        UUID portfolioId = UUID.randomUUID();
+        UUID runnerId = UUID.randomUUID();
+        String shortCode = UUID.randomUUID().toString().substring(0, 4).toUpperCase();
+
+        jdbcTemplate.update(
+                "INSERT INTO portfolios (id, name, is_active, safe_mode_status, capital_pooling_mode, created_at) " +
+                "VALUES (?, ?, true, 'NORMAL', 'SHARED', NOW())",
+                portfolioId, "test-portfolio-" + portfolioId);
+
+        jdbcTemplate.update(
+                "INSERT INTO strategy_runners (id, portfolio_id, short_code, strategy_id, strategy_name, symbol, " +
+                "exchange_id, status, status_changed_at, execution_policy, accounting_policy_type, " +
+                "max_allocation_percent, max_open_positions, max_pending_orders, is_reconciling, created_at) " +
+                "VALUES (?, ?, ?, ?, 'Test Strategy', ?, ?, 'ACTIVE', NOW(), 'SINGLE', 'FIFO', " +
+                "0.1, 1, 1, false, NOW())",
+                runnerId, portfolioId, shortCode, UUID.randomUUID(), symbol, exchangeId);
+
+        jdbcTemplate.update(
+                "INSERT INTO transactions (id, runner_id, client_order_id, exchange_order_id, status, type, " +
+                "symbol, quantity, executed_quantity, price, executed_price, total, requested_at, " +
+                "updated_at, executed_at, last_partial_fill_at, version) " +
+                "VALUES (?, ?, ?, '100234', 'CANCELED', 'BUY', ?, 0.01, ?, 50000, 50000, ?, NOW(), ?, NULL, ?, 0)",
+                UUID.randomUUID(), runnerId, clientOrderId, symbol,
                 executedQty, executedQty.multiply(new BigDecimal("50000")),
-                Timestamp.from(updatedAt),
-                isFilled ? Timestamp.from(updatedAt) : null);
+                Timestamp.from(cancelAt),
+                fillAt != null ? Timestamp.from(fillAt) : null);
     }
 }

--- a/spring-application/src/test/java/com/marmitt/application/spring/reconciliation/ReconciliationIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/reconciliation/ReconciliationIntegrationTest.java
@@ -134,8 +134,42 @@ class ReconciliationIntegrationTest {
         assertEquals("client-3", result.get(2).getClientOrderId());
     }
 
+    @Test
+    void findFilledBySymbolAndPeriod_includesCanceledTransactionsWithPartialExecution() {
+        Instant updatedAt = Instant.parse("2026-01-01T10:00:00Z");
+        insertTransactionWithStatus("BTCUSDT", "BINANCE", "client-canceled-partial",
+                new BigDecimal("0.005"), "CANCELED", updatedAt);
+
+        List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
+                "BTCUSDT", "BINANCE",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"));
+
+        assertEquals(1, result.size());
+        assertEquals("client-canceled-partial", result.get(0).getClientOrderId());
+    }
+
+    @Test
+    void findFilledBySymbolAndPeriod_excludesCanceledTransactionsWithNoExecution() {
+        Instant updatedAt = Instant.parse("2026-01-01T10:00:00Z");
+        insertTransactionWithStatus("BTCUSDT", "BINANCE", "client-canceled-zero",
+                BigDecimal.ZERO, "CANCELED", updatedAt);
+
+        List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
+                "BTCUSDT", "BINANCE",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"));
+
+        assertEquals(0, result.size());
+    }
+
     private void insertFilledTransaction(String symbol, String exchangeId, String clientOrderId,
                                          BigDecimal qty, Instant executedAt) {
+        insertTransactionWithStatus(symbol, exchangeId, clientOrderId, qty, "FILLED", executedAt);
+    }
+
+    private void insertTransactionWithStatus(String symbol, String exchangeId, String clientOrderId,
+                                              BigDecimal executedQty, String status, Instant updatedAt) {
         UUID portfolioId = UUID.randomUUID();
         UUID runnerId = UUID.randomUUID();
         String shortCode = UUID.randomUUID().toString().substring(0, 4).toUpperCase();
@@ -153,14 +187,15 @@ class ReconciliationIntegrationTest {
                 "0.1, 1, 1, false, NOW())",
                 runnerId, portfolioId, shortCode, UUID.randomUUID(), symbol, exchangeId);
 
-        // executed_at used as the time filter (COALESCE(executed_at, updated_at)); for PARTIAL, updated_at would be used
+        // For FILLED: executed_at is set (time filter uses it). For CANCELED/PARTIAL: uses updated_at.
+        boolean isFilled = "FILLED".equals(status);
         jdbcTemplate.update(
                 "INSERT INTO transactions (id, runner_id, client_order_id, exchange_order_id, status, type, " +
                 "symbol, quantity, executed_quantity, price, executed_price, total, requested_at, updated_at, executed_at, version) " +
-                "VALUES (?, ?, ?, '100234', 'FILLED', 'BUY', ?, ?, ?, 50000, 50000, ?, NOW(), ?, ?, 0)",
-                UUID.randomUUID(), runnerId, clientOrderId, symbol,
-                qty, qty, qty.multiply(new BigDecimal("50000")),
-                Timestamp.from(executedAt),
-                Timestamp.from(executedAt));
+                "VALUES (?, ?, ?, '100234', ?, 'BUY', ?, 0.01, ?, 50000, 50000, ?, NOW(), ?, ?, 0)",
+                UUID.randomUUID(), runnerId, clientOrderId, status, symbol,
+                executedQty, executedQty.multiply(new BigDecimal("50000")),
+                Timestamp.from(updatedAt),
+                isFilled ? Timestamp.from(updatedAt) : null);
     }
 }

--- a/spring-application/src/test/java/com/marmitt/application/spring/reconciliation/ReconciliationIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/reconciliation/ReconciliationIntegrationTest.java
@@ -66,10 +66,10 @@ class ReconciliationIntegrationTest {
     @Test
     void findFilledBySymbolAndPeriod_returnsFilledTransactionsWithinPeriod() {
         Instant requestedAt = Instant.parse("2026-01-01T10:00:00Z");
-        insertFilledTransaction("BTCUSDT", "client-1", new BigDecimal("0.01"), requestedAt);
+        insertFilledTransaction("BTCUSDT", "BINANCE", "client-1", new BigDecimal("0.01"), requestedAt);
 
         List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
-                "BTCUSDT",
+                "BTCUSDT", "BINANCE",
                 Instant.parse("2026-01-01T00:00:00Z"),
                 Instant.parse("2026-01-02T00:00:00Z"));
 
@@ -81,10 +81,10 @@ class ReconciliationIntegrationTest {
     @Test
     void findFilledBySymbolAndPeriod_excludesTransactionsOutsidePeriod() {
         Instant outside = Instant.parse("2026-01-03T10:00:00Z"); // after range
-        insertFilledTransaction("BTCUSDT", "client-outside", new BigDecimal("0.01"), outside);
+        insertFilledTransaction("BTCUSDT", "BINANCE", "client-outside", new BigDecimal("0.01"), outside);
 
         List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
-                "BTCUSDT",
+                "BTCUSDT", "BINANCE",
                 Instant.parse("2026-01-01T00:00:00Z"),
                 Instant.parse("2026-01-02T00:00:00Z"));
 
@@ -94,10 +94,10 @@ class ReconciliationIntegrationTest {
     @Test
     void findFilledBySymbolAndPeriod_excludesTransactionsByDifferentSymbol() {
         Instant requestedAt = Instant.parse("2026-01-01T10:00:00Z");
-        insertFilledTransaction("ETHUSDT", "client-eth", new BigDecimal("1.0"), requestedAt);
+        insertFilledTransaction("ETHUSDT", "BINANCE", "client-eth", new BigDecimal("1.0"), requestedAt);
 
         List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
-                "BTCUSDT",
+                "BTCUSDT", "BINANCE",
                 Instant.parse("2026-01-01T00:00:00Z"),
                 Instant.parse("2026-01-02T00:00:00Z"));
 
@@ -105,13 +105,26 @@ class ReconciliationIntegrationTest {
     }
 
     @Test
-    void findFilledBySymbolAndPeriod_returnsMultipleTransactionsOrderedByRequestedAt() {
-        insertFilledTransaction("BTCUSDT", "client-1", new BigDecimal("0.01"), Instant.parse("2026-01-01T08:00:00Z"));
-        insertFilledTransaction("BTCUSDT", "client-2", new BigDecimal("0.02"), Instant.parse("2026-01-01T12:00:00Z"));
-        insertFilledTransaction("BTCUSDT", "client-3", new BigDecimal("0.03"), Instant.parse("2026-01-01T16:00:00Z"));
+    void findFilledBySymbolAndPeriod_excludesTransactionsByDifferentExchange() {
+        Instant requestedAt = Instant.parse("2026-01-01T10:00:00Z");
+        insertFilledTransaction("BTCUSDT", "COINBASE", "client-coinbase", new BigDecimal("0.01"), requestedAt);
 
         List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
-                "BTCUSDT",
+                "BTCUSDT", "BINANCE",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"));
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void findFilledBySymbolAndPeriod_returnsMultipleTransactionsOrderedByExecutedAt() {
+        insertFilledTransaction("BTCUSDT", "BINANCE", "client-1", new BigDecimal("0.01"), Instant.parse("2026-01-01T08:00:00Z"));
+        insertFilledTransaction("BTCUSDT", "BINANCE", "client-2", new BigDecimal("0.02"), Instant.parse("2026-01-01T12:00:00Z"));
+        insertFilledTransaction("BTCUSDT", "BINANCE", "client-3", new BigDecimal("0.03"), Instant.parse("2026-01-01T16:00:00Z"));
+
+        List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
+                "BTCUSDT", "BINANCE",
                 Instant.parse("2026-01-01T00:00:00Z"),
                 Instant.parse("2026-01-02T00:00:00Z"));
 
@@ -121,7 +134,8 @@ class ReconciliationIntegrationTest {
         assertEquals("client-3", result.get(2).getClientOrderId());
     }
 
-    private void insertFilledTransaction(String symbol, String clientOrderId, BigDecimal qty, Instant requestedAt) {
+    private void insertFilledTransaction(String symbol, String exchangeId, String clientOrderId,
+                                         BigDecimal qty, Instant executedAt) {
         UUID portfolioId = UUID.randomUUID();
         UUID runnerId = UUID.randomUUID();
         String shortCode = UUID.randomUUID().toString().substring(0, 4).toUpperCase();
@@ -135,18 +149,18 @@ class ReconciliationIntegrationTest {
                 "INSERT INTO strategy_runners (id, portfolio_id, short_code, strategy_id, strategy_name, symbol, " +
                 "exchange_id, status, status_changed_at, execution_policy, accounting_policy_type, " +
                 "max_allocation_percent, max_open_positions, max_pending_orders, is_reconciling, created_at) " +
-                "VALUES (?, ?, ?, ?, 'Test Strategy', ?, 'MOCK', 'ACTIVE', NOW(), 'SINGLE', 'FIFO', " +
+                "VALUES (?, ?, ?, ?, 'Test Strategy', ?, ?, 'ACTIVE', NOW(), 'SINGLE', 'FIFO', " +
                 "0.1, 1, 1, false, NOW())",
-                runnerId, portfolioId, shortCode, UUID.randomUUID(), symbol);
+                runnerId, portfolioId, shortCode, UUID.randomUUID(), symbol, exchangeId);
 
-        // executed_at is the time filter column used by findFilledBySymbolAndPeriod (COALESCE(executed_at, requested_at))
+        // executed_at used as the time filter (COALESCE(executed_at, updated_at)); for PARTIAL, updated_at would be used
         jdbcTemplate.update(
                 "INSERT INTO transactions (id, runner_id, client_order_id, exchange_order_id, status, type, " +
                 "symbol, quantity, executed_quantity, price, executed_price, total, requested_at, updated_at, executed_at, version) " +
-                "VALUES (?, ?, ?, '100234', 'FILLED', 'BUY', ?, ?, ?, 50000, 50000, ?, ?, NOW(), ?, 0)",
+                "VALUES (?, ?, ?, '100234', 'FILLED', 'BUY', ?, ?, ?, 50000, 50000, ?, NOW(), ?, ?, 0)",
                 UUID.randomUUID(), runnerId, clientOrderId, symbol,
                 qty, qty, qty.multiply(new BigDecimal("50000")),
-                Timestamp.from(requestedAt),
-                Timestamp.from(requestedAt));
+                Timestamp.from(executedAt),
+                Timestamp.from(executedAt));
     }
 }

--- a/spring-application/src/test/java/com/marmitt/application/spring/reconciliation/ReconciliationIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/reconciliation/ReconciliationIntegrationTest.java
@@ -1,0 +1,152 @@
+package com.marmitt.application.spring.reconciliation;
+
+import com.marmitt.application.spring.CTradeApplication;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration test for the T18 reconciliation DB query against real PostgreSQL.
+ * Controller HTTP behavior is covered by ReconciliationControllerTest (standaloneSetup).
+ */
+@Testcontainers
+@SpringBootTest(
+        classes = CTradeApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class ReconciliationIntegrationTest {
+
+    @Container
+    @SuppressWarnings("resource")
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("ctrade")
+            .withUsername("ctrade")
+            .withPassword("ctrade123");
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("runner.boot.orchestrator-enabled", () -> "false");
+        registry.add("runner.recovery.transaction.enabled", () -> "false");
+    }
+
+    @Autowired
+    StrategyRunnerRepositoryPort strategyRunnerRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        jdbcTemplate.execute("TRUNCATE TABLE portfolios CASCADE");
+    }
+
+    @Test
+    void findFilledBySymbolAndPeriod_returnsFilledTransactionsWithinPeriod() {
+        Instant requestedAt = Instant.parse("2026-01-01T10:00:00Z");
+        insertFilledTransaction("BTCUSDT", "client-1", new BigDecimal("0.01"), requestedAt);
+
+        List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
+                "BTCUSDT",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"));
+
+        assertEquals(1, result.size());
+        assertEquals("client-1", result.get(0).getClientOrderId());
+        assertEquals(0, new BigDecimal("0.01").compareTo(result.get(0).getExecutedQuantity()));
+    }
+
+    @Test
+    void findFilledBySymbolAndPeriod_excludesTransactionsOutsidePeriod() {
+        Instant outside = Instant.parse("2026-01-03T10:00:00Z"); // after range
+        insertFilledTransaction("BTCUSDT", "client-outside", new BigDecimal("0.01"), outside);
+
+        List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
+                "BTCUSDT",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"));
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void findFilledBySymbolAndPeriod_excludesTransactionsByDifferentSymbol() {
+        Instant requestedAt = Instant.parse("2026-01-01T10:00:00Z");
+        insertFilledTransaction("ETHUSDT", "client-eth", new BigDecimal("1.0"), requestedAt);
+
+        List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
+                "BTCUSDT",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"));
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void findFilledBySymbolAndPeriod_returnsMultipleTransactionsOrderedByRequestedAt() {
+        insertFilledTransaction("BTCUSDT", "client-1", new BigDecimal("0.01"), Instant.parse("2026-01-01T08:00:00Z"));
+        insertFilledTransaction("BTCUSDT", "client-2", new BigDecimal("0.02"), Instant.parse("2026-01-01T12:00:00Z"));
+        insertFilledTransaction("BTCUSDT", "client-3", new BigDecimal("0.03"), Instant.parse("2026-01-01T16:00:00Z"));
+
+        List<Transaction> result = strategyRunnerRepository.findFilledBySymbolAndPeriod(
+                "BTCUSDT",
+                Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-01-02T00:00:00Z"));
+
+        assertEquals(3, result.size());
+        assertEquals("client-1", result.get(0).getClientOrderId());
+        assertEquals("client-2", result.get(1).getClientOrderId());
+        assertEquals("client-3", result.get(2).getClientOrderId());
+    }
+
+    private void insertFilledTransaction(String symbol, String clientOrderId, BigDecimal qty, Instant requestedAt) {
+        UUID portfolioId = UUID.randomUUID();
+        UUID runnerId = UUID.randomUUID();
+        String shortCode = UUID.randomUUID().toString().substring(0, 4).toUpperCase();
+
+        jdbcTemplate.update(
+                "INSERT INTO portfolios (id, name, is_active, safe_mode_status, capital_pooling_mode, created_at) " +
+                "VALUES (?, ?, true, 'NORMAL', 'SHARED', NOW())",
+                portfolioId, "test-portfolio-" + portfolioId);
+
+        jdbcTemplate.update(
+                "INSERT INTO strategy_runners (id, portfolio_id, short_code, strategy_id, strategy_name, symbol, " +
+                "exchange_id, status, status_changed_at, execution_policy, accounting_policy_type, " +
+                "max_allocation_percent, max_open_positions, max_pending_orders, is_reconciling, created_at) " +
+                "VALUES (?, ?, ?, ?, 'Test Strategy', ?, 'MOCK', 'ACTIVE', NOW(), 'SINGLE', 'FIFO', " +
+                "0.1, 1, 1, false, NOW())",
+                runnerId, portfolioId, shortCode, UUID.randomUUID(), symbol);
+
+        // executed_at is the time filter column used by findFilledBySymbolAndPeriod (COALESCE(executed_at, requested_at))
+        jdbcTemplate.update(
+                "INSERT INTO transactions (id, runner_id, client_order_id, exchange_order_id, status, type, " +
+                "symbol, quantity, executed_quantity, price, executed_price, total, requested_at, updated_at, executed_at, version) " +
+                "VALUES (?, ?, ?, '100234', 'FILLED', 'BUY', ?, ?, ?, 50000, 50000, ?, ?, NOW(), ?, 0)",
+                UUID.randomUUID(), runnerId, clientOrderId, symbol,
+                qty, qty, qty.multiply(new BigDecimal("50000")),
+                Timestamp.from(requestedAt),
+                Timestamp.from(requestedAt));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /reconciliation?symbol=BTCUSDT&from=...&to=...` endpoint that crosses Binance `myTrades` fills with local transactions and returns a categorized audit report
- Report is **read-only** — exposes discrepancies, does not correct anything
- Controlled via `includeMatched=false` (default) to suppress OK entries and show only what needs attention

## Architecture

```
core
├── TradeHistoryQueryPort (outbound)        ← exchange fetches fills
├── ReconcileTradesPort (inbound)           ← use case entry point
├── ReconcileTradesUseCase + ReconciliationMatcher
└── dto/reconciliation/                     ← generic DTOs, no exchange details

adapter-binance
└── BinanceTradeHistoryAdapter              ← calls GET /api/v3/myTrades, paginates via fromId

spring-application
├── BinanceTradeHistoryAdapter bean
├── ReconciliationConfig (ConditionalOnBean — off when no Binance credentials)
└── ReconciliationController GET /reconciliation
```

## Report categories

| Status | Meaning |
|---|---|
| `MATCHED` | Both sides agree on qty (within 1e-6 tolerance) |
| `DIVERGENT` | Both sides exist but quantities diverge |
| `EXCHANGE_ONLY` | Fill on Binance with no local transaction |
| `LOCAL_ONLY` | Local FILLED/PARTIAL transaction with no Binance confirmation |

## Test plan
- [ ] Build passes: `./gradlew :core:test :adapter-binance:test :spring-application:test`
- [ ] After a testnet session: `GET /reconciliation?symbol=BTCUSDT&from=T1&to=T2` returns 200 with `summary.exchangeOnly=0` and `summary.localOnly=0`
- [ ] With `includeMatched=false` (default): entries list contains only DIVERGENT/EXCHANGE_ONLY/LOCAL_ONLY
- [ ] With `includeMatched=true`: entries list also includes MATCHED entries
- [ ] If Binance API unavailable: endpoint returns 502 with error message
- [ ] Period with `from > to` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)