### PR TITLE
feat(T28): camada agnóstica de consulta de saldo e histórico na exchange

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryExchangeBalanceUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryExchangeBalanceUseCase.java
@@ -1,0 +1,47 @@
+package com.marmitt.core.application.usecase.exchange;
+
+import com.marmitt.core.dto.exchange.ExchangeBalanceSnapshot;
+import com.marmitt.core.ports.inbound.exchange.QueryExchangeBalancePort;
+import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+
+/**
+ * Caso de uso agnóstico de consulta de saldo.
+ *
+ * <p>Resolve o {@link ExchangeAdapterDescriptor} da exchange pedida e despacha pela
+ * capacidade de conta, sem conhecer nenhum adapter concreto.
+ *
+ * <p><b>Fundação (T28):</b> o caminho agnóstico está montado, mas a recuperação real do
+ * snapshot e o mapeamento {@code AccountDataDto -> ExchangeBalanceSnapshot} são entregues
+ * em T29. Até lá, o caso de uso sinaliza "não implementado" via
+ * {@link UnsupportedOperationException}, convenção tratada graciosamente pelos consumidores.
+ */
+public class QueryExchangeBalanceUseCase implements QueryExchangeBalancePort {
+
+    private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
+
+    public QueryExchangeBalanceUseCase(ExchangeAdapterRepositoryPort exchangeAdapterRepository) {
+        this.exchangeAdapterRepository = exchangeAdapterRepository;
+    }
+
+    @Override
+    public ExchangeBalanceSnapshot queryBalances(String exchangeName) {
+        ExchangeAdapterDescriptor descriptor = resolveAdapter(exchangeName);
+
+        if (!descriptor.hasAccountQuery()) {
+            throw new UnsupportedOperationException(
+                    "Balance query capability is not available for exchange '" + exchangeName + "'");
+        }
+
+        // T29: reusar descriptor.accountQuery().queryAccountSnapshot() e mapear
+        // AccountDataDto -> ExchangeBalanceSnapshot, sem vazar o DTO de WebSocket.
+        throw new UnsupportedOperationException(
+                "Balance query is not implemented yet for exchange '" + exchangeName + "'");
+    }
+
+    private ExchangeAdapterDescriptor resolveAdapter(String exchangeName) {
+        return exchangeAdapterRepository.findAdapter(exchangeName)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Exchange '" + exchangeName + "' is not registered"));
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCase.java
@@ -1,0 +1,47 @@
+package com.marmitt.core.application.usecase.exchange;
+
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.ports.inbound.exchange.QueryTradeHistoryPort;
+import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Caso de uso agnóstico de consulta de histórico de trades.
+ *
+ * <p>Resolve o {@link ExchangeAdapterDescriptor} da exchange pedida e despacha pela
+ * capacidade de histórico, sem conhecer nenhum adapter concreto.
+ *
+ * <p><b>Fundação (T28):</b> nenhuma exchange liga {@code tradeHistory()} ainda, então
+ * {@code hasTradeHistory()} é {@code false} e o caso de uso sinaliza "não implementado"
+ * via {@link UnsupportedOperationException}. T30 liga o {@code BinanceTradeHistoryAdapter}
+ * existente ao accessor; o despacho aqui passa a retornar fills reais sem alteração.
+ */
+public class QueryTradeHistoryUseCase implements QueryTradeHistoryPort {
+
+    private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
+
+    public QueryTradeHistoryUseCase(ExchangeAdapterRepositoryPort exchangeAdapterRepository) {
+        this.exchangeAdapterRepository = exchangeAdapterRepository;
+    }
+
+    @Override
+    public List<TradeExecutionDto> queryTrades(String exchangeName, String symbol, Instant from, Instant to) {
+        ExchangeAdapterDescriptor descriptor = resolveAdapter(exchangeName);
+
+        if (!descriptor.hasTradeHistory()) {
+            throw new UnsupportedOperationException(
+                    "Trade history query capability is not available for exchange '" + exchangeName + "'");
+        }
+
+        return descriptor.tradeHistory().fetchTrades(symbol, from, to);
+    }
+
+    private ExchangeAdapterDescriptor resolveAdapter(String exchangeName) {
+        return exchangeAdapterRepository.findAdapter(exchangeName)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Exchange '" + exchangeName + "' is not registered"));
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/exchange/BalanceDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/exchange/BalanceDto.java
@@ -1,0 +1,28 @@
+package com.marmitt.core.dto.exchange;
+
+import java.math.BigDecimal;
+
+/**
+ * Saldo de um único asset na exchange, agnóstico de provider.
+ *
+ * <p>Contrato de saída do caminho de consulta de saldo (T28/T29). Substitui o uso
+ * direto de {@code AccountDataDto} (DTO de WebSocket) como contrato externo.
+ *
+ * @param asset  símbolo do ativo (ex.: "USDT", "BTC")
+ * @param free   saldo disponível
+ * @param locked saldo bloqueado em ordens abertas
+ * @param total  {@code free + locked}
+ */
+public record BalanceDto(
+        String asset,
+        BigDecimal free,
+        BigDecimal locked,
+        BigDecimal total
+) {
+
+    public static BalanceDto of(String asset, BigDecimal free, BigDecimal locked) {
+        BigDecimal safeFree = free != null ? free : BigDecimal.ZERO;
+        BigDecimal safeLocked = locked != null ? locked : BigDecimal.ZERO;
+        return new BalanceDto(asset, safeFree, safeLocked, safeFree.add(safeLocked));
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/exchange/ExchangeBalanceSnapshot.java
+++ b/core/src/main/java/com/marmitt/core/dto/exchange/ExchangeBalanceSnapshot.java
@@ -1,0 +1,38 @@
+package com.marmitt.core.dto.exchange;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Snapshot de saldos de uma exchange num instante, retornado pelo caminho de
+ * consulta agnóstico ({@code QueryExchangeBalancePort}).
+ *
+ * <p>A consulta traz a lista completa numa única chamada (decisão "lista completa +
+ * filtro opcional"); o filtro por asset é aplicado na borda via {@link #balanceOf(String)}.
+ *
+ * @param exchangeName exchange consultada (ex.: "BINANCE")
+ * @param balances     saldos por asset
+ * @param retrievedAt  instante em que o snapshot foi obtido
+ */
+public record ExchangeBalanceSnapshot(
+        String exchangeName,
+        List<BalanceDto> balances,
+        Instant retrievedAt
+) {
+
+    public ExchangeBalanceSnapshot {
+        balances = balances != null ? List.copyOf(balances) : List.of();
+    }
+
+    /** Retorna o saldo do {@code asset} informado (case-insensitive), se presente. */
+    public Optional<BalanceDto> balanceOf(String asset) {
+        if (asset == null) {
+            return Optional.empty();
+        }
+        return balances.stream()
+                .filter(b -> Objects.equals(asset.toUpperCase(), b.asset() == null ? null : b.asset().toUpperCase()))
+                .findFirst();
+    }
+}

--- a/core/src/main/java/com/marmitt/core/ports/inbound/exchange/QueryExchangeBalancePort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/exchange/QueryExchangeBalancePort.java
@@ -1,0 +1,21 @@
+package com.marmitt.core.ports.inbound.exchange;
+
+import com.marmitt.core.dto.exchange.ExchangeBalanceSnapshot;
+
+/**
+ * Caso de uso de consulta de saldo na exchange, agnóstico ao adapter.
+ *
+ * <p>Resolve o adapter pela {@code exchangeName} e retorna a lista completa de saldos
+ * numa única chamada; o filtro por asset é responsabilidade do consumidor
+ * ({@link ExchangeBalanceSnapshot#balanceOf(String)} ou query param na borda HTTP).
+ */
+public interface QueryExchangeBalancePort {
+
+    /**
+     * @param exchangeName exchange alvo (ex.: "BINANCE"), case-insensitive
+     * @return snapshot completo de saldos da exchange
+     * @throws IllegalArgumentException      se a exchange não estiver registrada
+     * @throws UnsupportedOperationException se a exchange não suportar consulta de saldo
+     */
+    ExchangeBalanceSnapshot queryBalances(String exchangeName);
+}

--- a/core/src/main/java/com/marmitt/core/ports/inbound/exchange/QueryTradeHistoryPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/inbound/exchange/QueryTradeHistoryPort.java
@@ -1,0 +1,27 @@
+package com.marmitt.core.ports.inbound.exchange;
+
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Caso de uso de consulta de histórico de trades na exchange, agnóstico ao adapter.
+ *
+ * <p>Resolve o adapter pela {@code exchangeName} e delega a busca de fills à capacidade
+ * de histórico do descriptor. Cada fill é um {@link TradeExecutionDto}; uma ordem pode
+ * gerar múltiplos fills (parciais).
+ */
+public interface QueryTradeHistoryPort {
+
+    /**
+     * @param exchangeName exchange alvo (ex.: "BINANCE"), case-insensitive
+     * @param symbol       par negociado (ex.: "BTCUSDT")
+     * @param from         início da janela (inclusivo)
+     * @param to           fim da janela (inclusivo)
+     * @return fills executados na janela
+     * @throws IllegalArgumentException      se a exchange não estiver registrada
+     * @throws UnsupportedOperationException se a exchange não suportar consulta de histórico
+     */
+    List<TradeExecutionDto> queryTrades(String exchangeName, String symbol, Instant from, Instant to);
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/ExchangeAdapterDescriptor.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/ExchangeAdapterDescriptor.java
@@ -36,6 +36,10 @@ public interface ExchangeAdapterDescriptor {
 
     ExchangeAccountQueryPort accountQuery();
 
+    boolean hasTradeHistory();
+
+    TradeHistoryQueryPort tradeHistory();
+
     boolean hasBootReadiness();
 
     ExchangeBootReadinessPort bootReadiness();

--- a/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryExchangeBalanceUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryExchangeBalanceUseCaseTest.java
@@ -1,0 +1,51 @@
+package com.marmitt.core.application.usecase.exchange;
+
+import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class QueryExchangeBalanceUseCaseTest {
+
+    private static final String EXCHANGE = "BINANCE";
+
+    private final ExchangeAdapterRepositoryPort repository = mock(ExchangeAdapterRepositoryPort.class);
+    private final QueryExchangeBalanceUseCase useCase = new QueryExchangeBalanceUseCase(repository);
+
+    @Test
+    void queryBalances_throwsWhenExchangeNotRegistered() {
+        when(repository.findAdapter("UNKNOWN")).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.queryBalances("UNKNOWN"));
+    }
+
+    @Test
+    void queryBalances_throwsUnsupportedWhenAccountQueryAbsent() {
+        ExchangeAdapterDescriptor descriptor = mock(ExchangeAdapterDescriptor.class);
+        when(descriptor.hasAccountQuery()).thenReturn(false);
+        when(repository.findAdapter("COINBASE")).thenReturn(Optional.of(descriptor));
+
+        UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class,
+                () -> useCase.queryBalances("COINBASE"));
+        assertTrue(ex.getMessage().contains("not available"));
+    }
+
+    // T28 é fundação: com a capacidade presente, o caminho de saldo ainda não está
+    // implementado (mapeamento entregue em T29) e sinaliza via UnsupportedOperationException.
+    @Test
+    void queryBalances_dispatchesToAdapterButSignalsPendingImplementation() {
+        ExchangeAdapterDescriptor descriptor = mock(ExchangeAdapterDescriptor.class);
+        when(descriptor.hasAccountQuery()).thenReturn(true);
+        when(repository.findAdapter(EXCHANGE)).thenReturn(Optional.of(descriptor));
+
+        UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class,
+                () -> useCase.queryBalances(EXCHANGE));
+        assertTrue(ex.getMessage().contains("not implemented yet"));
+    }
+}

--- a/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCaseTest.java
@@ -1,0 +1,74 @@
+package com.marmitt.core.application.usecase.exchange;
+
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
+import com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QueryTradeHistoryUseCaseTest {
+
+    private static final String EXCHANGE = "BINANCE";
+    private static final String SYMBOL = "BTCUSDT";
+    private static final Instant FROM = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant TO = Instant.parse("2026-01-02T00:00:00Z");
+
+    private final ExchangeAdapterRepositoryPort repository = mock(ExchangeAdapterRepositoryPort.class);
+    private final QueryTradeHistoryUseCase useCase = new QueryTradeHistoryUseCase(repository);
+
+    @Test
+    void queryTrades_throwsWhenExchangeNotRegistered() {
+        when(repository.findAdapter("UNKNOWN")).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> useCase.queryTrades("UNKNOWN", SYMBOL, FROM, TO));
+    }
+
+    @Test
+    void queryTrades_throwsUnsupportedWhenCapabilityAbsent() {
+        ExchangeAdapterDescriptor descriptor = mock(ExchangeAdapterDescriptor.class);
+        when(descriptor.hasTradeHistory()).thenReturn(false);
+        when(repository.findAdapter(EXCHANGE)).thenReturn(Optional.of(descriptor));
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> useCase.queryTrades(EXCHANGE, SYMBOL, FROM, TO));
+    }
+
+    @Test
+    void queryTrades_dispatchesToResolvedAdapterWhenCapabilityPresent() {
+        ExchangeAdapterDescriptor descriptor = mock(ExchangeAdapterDescriptor.class);
+        TradeHistoryQueryPort tradeHistory = mock(TradeHistoryQueryPort.class);
+        List<TradeExecutionDto> fills = List.of(fill());
+
+        when(descriptor.hasTradeHistory()).thenReturn(true);
+        when(descriptor.tradeHistory()).thenReturn(tradeHistory);
+        when(tradeHistory.fetchTrades(SYMBOL, FROM, TO)).thenReturn(fills);
+        when(repository.findAdapter(EXCHANGE)).thenReturn(Optional.of(descriptor));
+
+        List<TradeExecutionDto> result = useCase.queryTrades(EXCHANGE, SYMBOL, FROM, TO);
+
+        assertSame(fills, result);
+        verify(tradeHistory).fetchTrades(eq(SYMBOL), eq(FROM), eq(TO));
+    }
+
+    private static TradeExecutionDto fill() {
+        return new TradeExecutionDto(
+                "trade-1", 100234L, null, SYMBOL,
+                new BigDecimal("50000"), new BigDecimal("0.01"),
+                new BigDecimal("500"), new BigDecimal("0.0001"), "BNB",
+                Instant.parse("2026-01-01T10:00:00Z"), true);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/repository/DefaultExchangeAdapterDescriptor.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/repository/DefaultExchangeAdapterDescriptor.java
@@ -3,6 +3,7 @@ package com.marmitt.application.spring.repository;
 import com.marmitt.core.exceptions.UnsupportedCapabilityException;
 import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
 import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
+import com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeAccountQueryPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeBootReadinessPort;
 import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
@@ -21,6 +22,7 @@ public final class DefaultExchangeAdapterDescriptor implements ExchangeAdapterDe
     private final ExchangeOrderExecutionPort orderExecution;
     private final ExchangeOrderQueryPort orderQuery;
     private final ExchangeAccountQueryPort accountQuery;
+    private final TradeHistoryQueryPort tradeHistory;
     private final ExchangeBootReadinessPort bootReadiness;
 
     private DefaultExchangeAdapterDescriptor(Builder builder) {
@@ -32,6 +34,7 @@ public final class DefaultExchangeAdapterDescriptor implements ExchangeAdapterDe
         this.orderExecution = builder.orderExecution;
         this.orderQuery = builder.orderQuery;
         this.accountQuery = builder.accountQuery;
+        this.tradeHistory = builder.tradeHistory;
         this.bootReadiness = builder.bootReadiness;
     }
 
@@ -86,6 +89,13 @@ public final class DefaultExchangeAdapterDescriptor implements ExchangeAdapterDe
         return accountQuery;
     }
 
+    @Override public boolean hasTradeHistory() { return tradeHistory != null; }
+
+    @Override public TradeHistoryQueryPort tradeHistory() {
+        if (tradeHistory == null) throw new UnsupportedCapabilityException(exchangeName, "tradeHistory");
+        return tradeHistory;
+    }
+
     @Override public boolean hasBootReadiness() { return bootReadiness != null; }
 
     @Override public ExchangeBootReadinessPort bootReadiness() {
@@ -102,6 +112,7 @@ public final class DefaultExchangeAdapterDescriptor implements ExchangeAdapterDe
         private ExchangeOrderExecutionPort orderExecution;
         private ExchangeOrderQueryPort orderQuery;
         private ExchangeAccountQueryPort accountQuery;
+        private TradeHistoryQueryPort tradeHistory;
         private ExchangeBootReadinessPort bootReadiness;
 
         private Builder(String exchangeName) {
@@ -115,6 +126,7 @@ public final class DefaultExchangeAdapterDescriptor implements ExchangeAdapterDe
         public Builder orderExecution(ExchangeOrderExecutionPort orderExecution) { this.orderExecution = orderExecution; return this; }
         public Builder orderQuery(ExchangeOrderQueryPort orderQuery) { this.orderQuery = orderQuery; return this; }
         public Builder accountQuery(ExchangeAccountQueryPort accountQuery) { this.accountQuery = accountQuery; return this; }
+        public Builder tradeHistory(TradeHistoryQueryPort tradeHistory) { this.tradeHistory = tradeHistory; return this; }
         public Builder bootReadiness(ExchangeBootReadinessPort bootReadiness) { this.bootReadiness = bootReadiness; return this; }
 
         public DefaultExchangeAdapterDescriptor build() {

--- a/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
@@ -124,6 +124,8 @@ class OrderDispatchAdapterTest {
         @Override public com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort orderQuery() { throw new com.marmitt.core.exceptions.UnsupportedCapabilityException(EXCHANGE, "orderQuery"); }
         @Override public boolean hasAccountQuery() { return false; }
         @Override public com.marmitt.core.ports.outbound.exchange.rest.ExchangeAccountQueryPort accountQuery() { throw new com.marmitt.core.exceptions.UnsupportedCapabilityException(EXCHANGE, "accountQuery"); }
+        @Override public boolean hasTradeHistory() { return false; }
+        @Override public com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort tradeHistory() { throw new com.marmitt.core.exceptions.UnsupportedCapabilityException(EXCHANGE, "tradeHistory"); }
         @Override public boolean hasBootReadiness() { return false; }
         @Override public com.marmitt.core.ports.outbound.exchange.rest.ExchangeBootReadinessPort bootReadiness() { throw new com.marmitt.core.exceptions.UnsupportedCapabilityException(EXCHANGE, "bootReadiness"); }
     }


### PR DESCRIPTION
## Summary
- Adiciona a fundação agnóstica (T28) para consulta de **saldo** e **histórico de trades** na exchange, expondo as capacidades por um caminho de use case que não conhece adapter concreto. Prepara T29 (saldo) e T30 (histórico).
- `ExchangeAdapterDescriptor` ganha `hasTradeHistory()` / `tradeHistory()` no mesmo padrão de `accountQuery()`; `DefaultExchangeAdapterDescriptor` recebe campo, accessor e builder. **Não é ligado a nenhum adapter** — capability `false` em todas as exchanges (T30 liga o `BinanceTradeHistoryAdapter` existente).
- Novos ports inbound `QueryExchangeBalancePort` / `QueryTradeHistoryPort`, DTOs de saída `BalanceDto` / `ExchangeBalanceSnapshot` (filtro opcional por asset na borda, sem vazar `AccountDataDto`), e use cases `QueryExchangeBalanceUseCase` / `QueryTradeHistoryUseCase` que resolvem o descriptor, checam capability e despacham.
- Capacidade ausente/pendente sinaliza `UnsupportedOperationException`, tratado graciosamente pelos consumidores.

## Validation
- `./scripts/gradle-run.ps1 :core:compileJava :spring-application:compileJava`: passed
- `./scripts/gradle-run.ps1 :core:test --tests "com.marmitt.core.application.usecase.exchange.*"`: passed
- `./scripts/gradle-run.ps1 :spring-application:compileTestJava`: passed
- `./scripts/gradle-run.ps1 :spring-application:test --tests "...OrderDispatchAdapterTest"`: passed

## Documentation
- Sem impacto documental nesta fundação (caminho ainda não ligado/exposto). Conforme a spec do T28, a atualização de `/.ai` (Ports Reference / descriptor) fica para quando o caminho de use case for ligado em T29/T30. Sem impacto em `docs/` de negócio.

## Scope notes
- Decisão confirmada com o autor: assinatura de saldo = **lista completa + filtro opcional** (`ExchangeBalanceSnapshot queryBalances(exchangeName)`).
- Deliberadamente fora do escopo (T29/T30): wiring de `tradeHistory()` nos adapter configs, mapeamento real `AccountDataDto -> ExchangeBalanceSnapshot`, endpoints/beans Spring.
- Convenção: o accessor do descriptor lança `UnsupportedCapabilityException` (padrão já existente para todos os accessors); o use case lança `UnsupportedOperationException` para o caminho não suportado.