### PR TITLE
feat(T29): implementar consulta de saldo na exchange via caminho agnóstico

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryExchangeBalanceUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryExchangeBalanceUseCase.java
@@ -1,20 +1,28 @@
 package com.marmitt.core.application.usecase.exchange;
 
+import com.marmitt.core.dto.exchange.BalanceDto;
 import com.marmitt.core.dto.exchange.ExchangeBalanceSnapshot;
+import com.marmitt.core.dto.websocket.data.AccountDataDto;
 import com.marmitt.core.ports.inbound.exchange.QueryExchangeBalancePort;
 import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
 
 /**
  * Caso de uso agnóstico de consulta de saldo.
  *
  * <p>Resolve o {@link ExchangeAdapterDescriptor} da exchange pedida e despacha pela
- * capacidade de conta, sem conhecer nenhum adapter concreto.
+ * capacidade de conta, sem conhecer nenhum adapter concreto. Reusa o snapshot de conta
+ * já existente ({@code accountQuery().queryAccountSnapshot()}) — sem rota REST duplicada —
+ * e o traduz para o contrato dedicado {@link ExchangeBalanceSnapshot}, evitando vazar
+ * {@link AccountDataDto} (DTO de WebSocket) para fora do core.
  *
- * <p><b>Fundação (T28):</b> o caminho agnóstico está montado, mas a recuperação real do
- * snapshot e o mapeamento {@code AccountDataDto -> ExchangeBalanceSnapshot} são entregues
- * em T29. Até lá, o caso de uso sinaliza "não implementado" via
- * {@link UnsupportedOperationException}, convenção tratada graciosamente pelos consumidores.
+ * <p>Retorna a lista completa de saldos numa única chamada; o filtro por asset é
+ * responsabilidade do consumidor ({@link ExchangeBalanceSnapshot#balanceOf(String)}).
  */
 public class QueryExchangeBalanceUseCase implements QueryExchangeBalancePort {
 
@@ -33,10 +41,24 @@ public class QueryExchangeBalanceUseCase implements QueryExchangeBalancePort {
                     "Balance query capability is not available for exchange '" + exchangeName + "'");
         }
 
-        // T29: reusar descriptor.accountQuery().queryAccountSnapshot() e mapear
-        // AccountDataDto -> ExchangeBalanceSnapshot, sem vazar o DTO de WebSocket.
-        throw new UnsupportedOperationException(
-                "Balance query is not implemented yet for exchange '" + exchangeName + "'");
+        AccountDataDto account = descriptor.accountQuery().queryAccountSnapshot();
+        return toSnapshot(descriptor.exchangeName(), account);
+    }
+
+    private static ExchangeBalanceSnapshot toSnapshot(String exchangeName, AccountDataDto account) {
+        Map<String, BigDecimal> free = account.balances() != null ? account.balances() : Map.of();
+        Map<String, BigDecimal> locked = account.lockedBalances() != null ? account.lockedBalances() : Map.of();
+
+        // Union of both maps so an asset present in only one side is still reported.
+        TreeSet<String> assets = new TreeSet<>();
+        assets.addAll(free.keySet());
+        assets.addAll(locked.keySet());
+
+        List<BalanceDto> balances = assets.stream()
+                .map(asset -> BalanceDto.of(asset, free.get(asset), locked.get(asset)))
+                .toList();
+
+        return new ExchangeBalanceSnapshot(exchangeName, balances, account.lastUpdateTime());
     }
 
     private ExchangeAdapterDescriptor resolveAdapter(String exchangeName) {

--- a/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryExchangeBalanceUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryExchangeBalanceUseCaseTest.java
@@ -1,11 +1,19 @@
 package com.marmitt.core.application.usecase.exchange;
 
+import com.marmitt.core.dto.exchange.BalanceDto;
+import com.marmitt.core.dto.exchange.ExchangeBalanceSnapshot;
+import com.marmitt.core.dto.websocket.data.AccountDataDto;
 import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeAccountQueryPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -14,6 +22,7 @@ import static org.mockito.Mockito.when;
 class QueryExchangeBalanceUseCaseTest {
 
     private static final String EXCHANGE = "BINANCE";
+    private static final Instant AS_OF = Instant.parse("2026-01-01T10:00:00Z");
 
     private final ExchangeAdapterRepositoryPort repository = mock(ExchangeAdapterRepositoryPort.class);
     private final QueryExchangeBalanceUseCase useCase = new QueryExchangeBalanceUseCase(repository);
@@ -36,16 +45,53 @@ class QueryExchangeBalanceUseCaseTest {
         assertTrue(ex.getMessage().contains("not available"));
     }
 
-    // T28 é fundação: com a capacidade presente, o caminho de saldo ainda não está
-    // implementado (mapeamento entregue em T29) e sinaliza via UnsupportedOperationException.
     @Test
-    void queryBalances_dispatchesToAdapterButSignalsPendingImplementation() {
-        ExchangeAdapterDescriptor descriptor = mock(ExchangeAdapterDescriptor.class);
-        when(descriptor.hasAccountQuery()).thenReturn(true);
+    void queryBalances_mapsAccountSnapshotToBalanceSnapshot() {
+        AccountDataDto account = new AccountDataDto(
+                "acc-1",
+                Map.of("USDT", new BigDecimal("100.50"), "BTC", new BigDecimal("0.20")),
+                Map.of("USDT", new BigDecimal("25.00")),
+                AS_OF);
+        ExchangeAdapterDescriptor descriptor = descriptorWithAccount(account);
         when(repository.findAdapter(EXCHANGE)).thenReturn(Optional.of(descriptor));
 
-        UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class,
-                () -> useCase.queryBalances(EXCHANGE));
-        assertTrue(ex.getMessage().contains("not implemented yet"));
+        ExchangeBalanceSnapshot snapshot = useCase.queryBalances(EXCHANGE);
+
+        assertEquals(EXCHANGE, snapshot.exchangeName());
+        assertEquals(AS_OF, snapshot.retrievedAt());
+        assertEquals(2, snapshot.balances().size());
+
+        BalanceDto usdt = snapshot.balanceOf("usdt").orElseThrow();
+        assertEquals(new BigDecimal("100.50"), usdt.free());
+        assertEquals(new BigDecimal("25.00"), usdt.locked());
+        assertEquals(new BigDecimal("125.50"), usdt.total());
+    }
+
+    @Test
+    void queryBalances_reportsAssetPresentOnlyInLockedWithZeroFree() {
+        AccountDataDto account = new AccountDataDto(
+                "acc-1",
+                Map.of("USDT", new BigDecimal("100")),
+                Map.of("BTC", new BigDecimal("0.01")),
+                AS_OF);
+        ExchangeAdapterDescriptor descriptor = descriptorWithAccount(account);
+        when(repository.findAdapter(EXCHANGE)).thenReturn(Optional.of(descriptor));
+
+        ExchangeBalanceSnapshot snapshot = useCase.queryBalances(EXCHANGE);
+
+        BalanceDto btc = snapshot.balanceOf("BTC").orElseThrow();
+        assertEquals(BigDecimal.ZERO, btc.free());
+        assertEquals(new BigDecimal("0.01"), btc.locked());
+        assertEquals(new BigDecimal("0.01"), btc.total());
+    }
+
+    private static ExchangeAdapterDescriptor descriptorWithAccount(AccountDataDto account) {
+        ExchangeAdapterDescriptor descriptor = mock(ExchangeAdapterDescriptor.class);
+        ExchangeAccountQueryPort accountQuery = mock(ExchangeAccountQueryPort.class);
+        when(descriptor.exchangeName()).thenReturn(EXCHANGE);
+        when(descriptor.hasAccountQuery()).thenReturn(true);
+        when(descriptor.accountQuery()).thenReturn(accountQuery);
+        when(accountQuery.queryAccountSnapshot()).thenReturn(account);
+        return descriptor;
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/ExchangeQueryConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/ExchangeQueryConfig.java
@@ -1,0 +1,23 @@
+package com.marmitt.application.spring.config.core;
+
+import com.marmitt.core.application.usecase.exchange.QueryExchangeBalanceUseCase;
+import com.marmitt.core.ports.inbound.exchange.QueryExchangeBalancePort;
+import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wiring dos casos de uso agnósticos de consulta na exchange (saldo e histórico).
+ *
+ * <p>Despacham por {@code exchangeName} em runtime via {@link ExchangeAdapterRepositoryPort},
+ * portanto não dependem de credenciais de nenhum provider específico.
+ */
+@Configuration
+public class ExchangeQueryConfig {
+
+    @Bean
+    public QueryExchangeBalancePort queryExchangeBalanceUseCase(
+            ExchangeAdapterRepositoryPort exchangeAdapterRepository) {
+        return new QueryExchangeBalanceUseCase(exchangeAdapterRepository);
+    }
+}


### PR DESCRIPTION
## Summary
- Implementa a consulta de **saldo** real através do caminho agnóstico criado no T28 (PR #120, já mergeado), retornando dados via `adapter-binance` sem rota REST duplicada.
- `QueryExchangeBalanceUseCase` resolve o `ExchangeAdapterDescriptor` e traduz o snapshot de conta existente (`accountQuery().queryAccountSnapshot()`) para o contrato dedicado `ExchangeBalanceSnapshot`/`BalanceDto`, **sem vazar `AccountDataDto`**. Faz a união de `balances`/`lockedBalances` (asset presente só num lado é reportado com o outro zerado; `total = free + locked`).
- `ExchangeQueryConfig` registra o `QueryExchangeBalancePort` como bean, despachando por `exchangeName` em runtime (sem condição por credenciais de provider).

## Validation
- `./scripts/gradle-run.ps1 :core:test --tests "com.marmitt.core.application.usecase.exchange.*"`: passed
- `./scripts/gradle-run.ps1 :spring-application:compileJava`: passed
- Cobertura nova: mapeamento snapshot→saldo, asset só em locked (free zerado), filtro `balanceOf` case-insensitive, exchange não registrada e capacidade ausente.

## Documentation
- Sem impacto em `docs/` de negócio. Atualização de `/.ai` (Ports/Use Cases Reference) fica para quando a consulta virar fluxo exposto (endpoint). Sem comportamento externo novo neste PR.

## Scope notes
- **Endpoint HTTP deferido**: é opcional na spec do T29 e deve seguir o padrão de retorno das controllers definido no **T27** (pendente). Acoplar um controller agora nasceria fora do padrão; por isso a entrega é o caminho de use case completo e já wired no contexto.
- Sem mudança em `adapter-binance` (já implementava `ExchangeAccountQueryPort`); boot/recovery intactos.

## Notes
- Critérios do T29 atendidos: 1 (dados reais reusando o snapshot), 2 (DTO dedicado), 3 (lista completa + filtro opcional), 4 (capacidade ausente → `UnsupportedOperationException`), 6 (boot/recovery intactos). Critério 5 (endpoint) deferido conforme acima.