### PR TITLE
feat(T30): implementar consulta de histórico de trades via caminho agnóstico

### DIFF
--- a/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCase.java
@@ -14,10 +14,9 @@ import java.util.List;
  * <p>Resolve o {@link ExchangeAdapterDescriptor} da exchange pedida e despacha pela
  * capacidade de histórico, sem conhecer nenhum adapter concreto.
  *
- * <p><b>Fundação (T28):</b> nenhuma exchange liga {@code tradeHistory()} ainda, então
- * {@code hasTradeHistory()} é {@code false} e o caso de uso sinaliza "não implementado"
- * via {@link UnsupportedOperationException}. T30 liga o {@code BinanceTradeHistoryAdapter}
- * existente ao accessor; o despacho aqui passa a retornar fills reais sem alteração.
+ * <p>Valida o intervalo na borda ({@code symbol}, {@code from <= to}, ambos presentes)
+ * antes de delegar. A paginação/limite de janela da exchange é tratada no adapter
+ * (ex.: {@code BinanceTradeHistoryAdapter} fatia janelas de 24h internamente).
  */
 public class QueryTradeHistoryUseCase implements QueryTradeHistoryPort {
 
@@ -29,6 +28,8 @@ public class QueryTradeHistoryUseCase implements QueryTradeHistoryPort {
 
     @Override
     public List<TradeExecutionDto> queryTrades(String exchangeName, String symbol, Instant from, Instant to) {
+        validateInterval(symbol, from, to);
+
         ExchangeAdapterDescriptor descriptor = resolveAdapter(exchangeName);
 
         if (!descriptor.hasTradeHistory()) {
@@ -37,6 +38,18 @@ public class QueryTradeHistoryUseCase implements QueryTradeHistoryPort {
         }
 
         return descriptor.tradeHistory().fetchTrades(symbol, from, to);
+    }
+
+    private static void validateInterval(String symbol, Instant from, Instant to) {
+        if (symbol == null || symbol.isBlank()) {
+            throw new IllegalArgumentException("symbol must not be blank");
+        }
+        if (from == null || to == null) {
+            throw new IllegalArgumentException("from and to must not be null");
+        }
+        if (from.isAfter(to)) {
+            throw new IllegalArgumentException("from must not be after to (from=" + from + ", to=" + to + ")");
+        }
     }
 
     private ExchangeAdapterDescriptor resolveAdapter(String exchangeName) {

--- a/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCaseTest.java
@@ -64,6 +64,24 @@ class QueryTradeHistoryUseCaseTest {
         verify(tradeHistory).fetchTrades(eq(SYMBOL), eq(FROM), eq(TO));
     }
 
+    @Test
+    void queryTrades_throwsWhenFromAfterTo() {
+        assertThrows(IllegalArgumentException.class,
+                () -> useCase.queryTrades(EXCHANGE, SYMBOL, TO, FROM));
+    }
+
+    @Test
+    void queryTrades_throwsWhenIntervalBoundIsNull() {
+        assertThrows(IllegalArgumentException.class,
+                () -> useCase.queryTrades(EXCHANGE, SYMBOL, null, TO));
+    }
+
+    @Test
+    void queryTrades_throwsWhenSymbolIsBlank() {
+        assertThrows(IllegalArgumentException.class,
+                () -> useCase.queryTrades(EXCHANGE, "  ", FROM, TO));
+    }
+
     private static TradeExecutionDto fill() {
         return new TradeExecutionDto(
                 "trade-1", 100234L, null, SYMBOL,

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfiguration.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/exchange/BinanceAdapterConfiguration.java
@@ -140,7 +140,8 @@ public class BinanceAdapterConfiguration {
     public ExchangeAdapterDescriptor binanceAdapterDescriptor(BinanceMarketStreamAdapter binanceMarketStreamAdapter,
                                                                BinanceUserStreamAdapter binanceUserStreamAdapter,
                                                                BinanceUserStreamSessionAdapter binanceUserStreamSessionAdapter,
-                                                               BinanceOrderAdapter binanceOrderAdapter) {
+                                                               BinanceOrderAdapter binanceOrderAdapter,
+                                                               BinanceTradeHistoryAdapter binanceTradeHistoryAdapter) {
         return DefaultExchangeAdapterDescriptor.builder("BINANCE")
                 .streaming(binanceMarketStreamAdapter)
                 .orderPort(binanceOrderAdapter)
@@ -149,6 +150,7 @@ public class BinanceAdapterConfiguration {
                 .orderExecution(binanceMarketStreamAdapter)
                 .orderQuery(binanceMarketStreamAdapter)
                 .accountQuery(binanceMarketStreamAdapter)
+                .tradeHistory(binanceTradeHistoryAdapter)
                 .bootReadiness(binanceMarketStreamAdapter)
                 .build();
     }


### PR DESCRIPTION
## Summary
- Implementa a consulta de **histórico de trades** real através do caminho agnóstico criado no T28 (PR #120, mergeado), retornando fills via `adapter-binance` sem rota REST duplicada.
- `BinanceAdapterConfiguration`: o descriptor passa a expor `tradeHistory()` apontando para o **mesmo** `binanceTradeHistoryAdapter` já usado pela reconciliação → `hasTradeHistory()` true para BINANCE; o `QueryTradeHistoryUseCase` (já em develop pelo T28) passa a despachar fills reais sem alteração na lógica de dispatch.
- `QueryTradeHistoryUseCase`: valida o intervalo na borda (`symbol` não vazio, `from`/`to` presentes, `from <= to`) antes de delegar. Paginação/janela máxima permanece no adapter (Binance fatia janelas de 24h).

## Validation
- `./scripts/gradle-run.ps1 :core:test --tests "com.marmitt.core.application.usecase.exchange.*"`: passed
- `./scripts/gradle-run.ps1 :spring-application:compileJava`: passed
- Cobertura nova: validação de intervalo (`from>to`, bound null, `symbol` vazio), além de dispatch para a capacidade e capacidade ausente.

## Documentation
- Sem impacto em `docs/` de negócio. Atualização de `/.ai` (Ports/Use Cases Reference) e do flow de reconciliação fica para quando a consulta virar fluxo exposto (endpoint).

## Scope notes
- **Sem regressão na reconciliação**: `ReconcileTradesUseCase` continua consumindo o `TradeHistoryQueryPort` standalone (mesmo bean `binanceTradeHistoryAdapter`). Avaliado e mantido o acesso atual para não alterar comportamento do relatório.
- **Endpoint HTTP deferido**: opcional na spec, deve seguir o padrão de retorno do **T27** (pendente).
- **Bean `QueryTradeHistoryPort` deferido**: o registro natural é no `ExchangeQueryConfig` introduzido pelo **T29 (PR #121, em revisão)**. Para não duplicar/conflitar esse arquivo, o bean será adicionado junto ao do saldo quando o T29 entrar em `develop` (ou com o endpoint do T27).

## Notes
- Critérios do T30 atendidos: 1 (fills reais reusando o adapter), 2 (dispatch via descriptor, agnóstico), 3 (reconciliação sem regressão), 4 (validação de intervalo na borda), 5 (capacidade ausente → `UnsupportedOperationException`). Critério 6 (endpoint) deferido conforme acima.
- A montagem do descriptor Binance é `@ConditionalOnExpression` nas credenciais, então o wiring real é exercido com credenciais presentes; aqui validado por compilação + testes unitários do use case.