### PR TITLE
feat(T27): padronizar retorno das controllers (ApiError + handler global)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ POST /api/websocket/exchange/market-data/unsubscribe
 # Order Management  
 POST /api/websocket/exchange/orders/create
 POST /api/websocket/exchange/orders/cancel
+
+# Exchange Queries
+GET  /api/exchanges/{exchange}/balances          # ?asset=USDT filtra um ativo
+GET  /api/exchanges/{exchange}/trades            # ?symbol=BTCUSDT&from=...&to=...
 ```
 
 ### Documentação

--- a/README.md
+++ b/README.md
@@ -163,17 +163,17 @@ Grafana disponível em `http://localhost:3000` (admin / ctrade123).
 
 ```bash
 # WebSocket Management
-POST /websocket/connect
-POST /websocket/disconnect
-GET  /websocket/stats
+POST /api/websocket/connect
+POST /api/websocket/disconnect
+GET  /api/websocket/stats
 
 # Market Data
-POST /websocket/exchange/market-data/subscribe
-POST /websocket/exchange/market-data/unsubscribe
+POST /api/websocket/exchange/market-data/subscribe
+POST /api/websocket/exchange/market-data/unsubscribe
 
 # Order Management  
-POST /websocket/exchange/orders/create
-POST /websocket/exchange/orders/cancel
+POST /api/websocket/exchange/orders/create
+POST /api/websocket/exchange/orders/cancel
 ```
 
 ### Documentação

--- a/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
@@ -6,6 +6,7 @@ import com.marmitt.binance.rest.BinanceRestRequestBuilder;
 import com.marmitt.binance.rest.HttpClientPort;
 import com.marmitt.binance.rest.RestRequest;
 import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.exceptions.ExchangeQueryException;
 import com.marmitt.core.ports.outbound.exchange.TradeHistoryQueryPort;
 import lombok.extern.slf4j.Slf4j;
 
@@ -83,11 +84,12 @@ public class BinanceTradeHistoryAdapter implements TradeHistoryQueryPort {
         try {
             response = httpClient.get(req.url(), req.headers());
         } catch (IOException e) {
-            throw new RuntimeException("Failed to fetch myTrades from Binance: " + e.getMessage(), e);
+            throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.TEMPORARY,
+                    "Failed to fetch myTrades from Binance: " + e.getMessage(), e);
         }
 
         if (!response.isSuccessful()) {
-            throw new RuntimeException(
+            throw new ExchangeQueryException("BINANCE", errorTypeFor(response.statusCode()),
                     "Binance myTrades returned HTTP " + response.statusCode() + ": " + response.body());
         }
 
@@ -99,8 +101,18 @@ public class BinanceTradeHistoryAdapter implements TradeHistoryQueryPort {
             }
             return trades;
         } catch (IOException e) {
-            throw new RuntimeException("Failed to parse myTrades response: " + e.getMessage(), e);
+            throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.UNKNOWN,
+                    "Failed to parse myTrades response: " + e.getMessage(), e);
         }
+    }
+
+    private static ExchangeQueryException.ErrorType errorTypeFor(int statusCode) {
+        return switch (statusCode) {
+            case 400 -> ExchangeQueryException.ErrorType.INVALID_REQUEST;
+            case 401, 403 -> ExchangeQueryException.ErrorType.AUTH;
+            case 429 -> ExchangeQueryException.ErrorType.RATE_LIMIT;
+            default -> ExchangeQueryException.ErrorType.TEMPORARY;
+        };
     }
 
     private TradeExecutionDto parseTrade(JsonNode node) {

--- a/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
@@ -68,7 +68,7 @@ public class BinanceTradeHistoryAdapter implements TradeHistoryQueryPort {
 
         // Paginate: if full page returned, advance using fromId of last trade
         while (page.size() == PAGE_LIMIT) {
-            long lastId = Long.parseLong(page.getLast().exchangeTradeId());
+            long lastId = parseTradeId(page.getLast().exchangeTradeId());
             page = fetchPage(requestBuilder.buildMyTradesFromId(symbol, lastId + 1));
             // Filter client-side to stay within this window's end (fromId ignores time range)
             page = page.stream()
@@ -107,6 +107,20 @@ public class BinanceTradeHistoryAdapter implements TradeHistoryQueryPort {
             // Both are exchange-side failures (502), never client errors (400).
             throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.UNKNOWN,
                     "Failed to parse myTrades response: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Converte o {@code id} do último trade da página para o cursor {@code fromId} da paginação.
+     * Um {@code id} ausente/não-numérico em HTTP 200 é payload inválido do provider (502), não
+     * erro do cliente — espelha o tratamento de {@code parseTrade} em {@link #fetchPage}.
+     */
+    private static long parseTradeId(String rawId) {
+        try {
+            return Long.parseLong(rawId);
+        } catch (RuntimeException e) {
+            throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.UNKNOWN,
+                    "Failed to parse trade id for pagination cursor: " + rawId, e);
         }
     }
 

--- a/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
+++ b/adapter-binance/src/main/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapter.java
@@ -100,7 +100,11 @@ public class BinanceTradeHistoryAdapter implements TradeHistoryQueryPort {
                 trades.add(parseTrade(node));
             }
             return trades;
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
+            // IOException: body is not valid JSON.
+            // RuntimeException (e.g. NumberFormatException from a missing/non-numeric
+            // price/qty/quoteQty): provider returned HTTP 200 with a malformed payload.
+            // Both are exchange-side failures (502), never client errors (400).
             throw new ExchangeQueryException("BINANCE", ExchangeQueryException.ErrorType.UNKNOWN,
                     "Failed to parse myTrades response: " + e.getMessage(), e);
         }

--- a/adapter-binance/src/test/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapterTest.java
+++ b/adapter-binance/src/test/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapterTest.java
@@ -146,6 +146,19 @@ class BinanceTradeHistoryAdapterTest {
     }
 
     @Test
+    void fetchTrades_throwsExchangeQueryExceptionWhenPaginationCursorIdIsNotNumeric() throws IOException {
+        // Full page (1000) triggers pagination, but the last trade's id is non-numeric.
+        // The Long.parseLong cursor conversion must surface as ExchangeQueryException (502),
+        // not leak as IllegalArgumentException (400) — same provider-payload contract as parseTrade.
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        String fullPageWithBadLastId = buildTradeJsonArrayWithLastId(1000, 0L, "not-a-number");
+        when(httpClient.get(any(), any()))
+                .thenReturn(new HttpClientPort.HttpResponse(200, fullPageWithBadLastId));
+
+        assertThrows(ExchangeQueryException.class, () -> adapter.fetchTrades(SYMBOL, FROM, TO));
+    }
+
+    @Test
     void fetchTrades_issuesSingleRequestWhenWindowIsWithin24Hours() throws IOException {
         // FROM → TO is exactly 24h; should produce 1 buildMyTrades call, not 2
         when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
@@ -183,6 +196,21 @@ class BinanceTradeHistoryAdapterTest {
                     "\"price\":\"50000\",\"qty\":\"0.01\",\"quoteQty\":\"500\",\"commission\":\"0.0001\"," +
                     "\"commissionAsset\":\"BNB\",\"time\":1699865549590,\"isBuyer\":true}",
                     startId + i, i));
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static String buildTradeJsonArrayWithLastId(int count, long startId, String lastId) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) sb.append(",");
+            String id = (i == count - 1) ? "\"" + lastId + "\"" : "\"" + (startId + i) + "\"";
+            sb.append(String.format(
+                    "{\"id\":%s,\"orderId\":100234,\"clientOrderId\":\"client-%d\",\"symbol\":\"BTCUSDT\"," +
+                    "\"price\":\"50000\",\"qty\":\"0.01\",\"quoteQty\":\"500\",\"commission\":\"0.0001\"," +
+                    "\"commissionAsset\":\"BNB\",\"time\":1699865549590,\"isBuyer\":true}",
+                    id, i));
         }
         sb.append("]");
         return sb.toString();

--- a/adapter-binance/src/test/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapterTest.java
+++ b/adapter-binance/src/test/java/com/marmitt/binance/trade/BinanceTradeHistoryAdapterTest.java
@@ -5,6 +5,7 @@ import com.marmitt.binance.rest.BinanceRestRequestBuilder;
 import com.marmitt.binance.rest.HttpClientPort;
 import com.marmitt.binance.rest.RestRequest;
 import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.exceptions.ExchangeQueryException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -126,6 +127,22 @@ class BinanceTradeHistoryAdapterTest {
                 .thenReturn(new HttpClientPort.HttpResponse(200, "not-json"));
 
         assertThrows(RuntimeException.class, () -> adapter.fetchTrades(SYMBOL, FROM, TO));
+    }
+
+    @Test
+    void fetchTrades_throwsExchangeQueryExceptionWhenNumericFieldIsNotNumeric() throws IOException {
+        // HTTP 200 with a non-numeric price → NumberFormatException inside parseTrade.
+        // Must surface as a provider-side ExchangeQueryException (502), never leak as
+        // IllegalArgumentException (which the global handler maps to a 400 client error).
+        when(requestBuilder.buildMyTrades(anyString(), anyLong(), anyLong())).thenReturn(DUMMY_REQ);
+        String json = """
+                [{"id":"28457","orderId":100234,"clientOrderId":"client-1","symbol":"BTCUSDT",
+                  "price":"not-a-number","qty":"0.01","quoteQty":"500.00","commission":"0.0001",
+                  "commissionAsset":"BNB","time":1699865549590,"isBuyer":true}]
+                """;
+        when(httpClient.get(any(), any())).thenReturn(new HttpClientPort.HttpResponse(200, json));
+
+        assertThrows(ExchangeQueryException.class, () -> adapter.fetchTrades(SYMBOL, FROM, TO));
     }
 
     @Test

--- a/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCase.java
@@ -5,6 +5,7 @@ import com.marmitt.core.ports.inbound.exchange.QueryTradeHistoryPort;
 import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
@@ -14,11 +15,16 @@ import java.util.List;
  * <p>Resolve o {@link ExchangeAdapterDescriptor} da exchange pedida e despacha pela
  * capacidade de histórico, sem conhecer nenhum adapter concreto.
  *
- * <p>Valida o intervalo na borda ({@code symbol}, {@code from <= to}, ambos presentes)
- * antes de delegar. A paginação/limite de janela da exchange é tratada no adapter
- * (ex.: {@code BinanceTradeHistoryAdapter} fatia janelas de 24h internamente).
+ * <p>Valida o intervalo na borda ({@code symbol}, {@code from <= to}, ambos presentes e
+ * janela &le; {@value #MAX_WINDOW_DAYS} dias) antes de delegar. O limite de janela protege
+ * contra fan-out: o adapter da exchange fatia o intervalo em janelas de 24h e pagina
+ * (ex.: {@code BinanceTradeHistoryAdapter}), então um intervalo longo viraria muitas
+ * chamadas assinadas numa única requisição.
  */
 public class QueryTradeHistoryUseCase implements QueryTradeHistoryPort {
+
+    static final int MAX_WINDOW_DAYS = 31;
+    private static final Duration MAX_WINDOW = Duration.ofDays(MAX_WINDOW_DAYS);
 
     private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
 
@@ -49,6 +55,10 @@ public class QueryTradeHistoryUseCase implements QueryTradeHistoryPort {
         }
         if (from.isAfter(to)) {
             throw new IllegalArgumentException("from must not be after to (from=" + from + ", to=" + to + ")");
+        }
+        if (Duration.between(from, to).compareTo(MAX_WINDOW) > 0) {
+            throw new IllegalArgumentException(
+                    "query window must not exceed " + MAX_WINDOW_DAYS + " days (from=" + from + ", to=" + to + ")");
         }
     }
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCase.java
@@ -5,6 +5,8 @@ import com.marmitt.core.dto.portfolio.response.DeadLetterEntryDto;
 import com.marmitt.core.dto.portfolio.DeadLetterReprocessingResult;
 import com.marmitt.core.dto.portfolio.response.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
+import com.marmitt.core.exceptions.DeadLetterConflictException;
+import com.marmitt.core.exceptions.DeadLetterNotFoundException;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
@@ -45,13 +47,11 @@ public class ManageDeadLetterUseCase implements ManageDeadLetterPort {
             throw new IllegalArgumentException("resolvedBy cannot be blank");
         }
 
-        DeadLetterEntry entry = deadLetterEntryRepository.findById(deadLetterId).orElse(null);
-        if (entry == null) {
-            return ResolveDeadLetterResponse.failure(deadLetterId, "Dead letter entry not found");
-        }
+        DeadLetterEntry entry = deadLetterEntryRepository.findById(deadLetterId)
+                .orElseThrow(() -> new DeadLetterNotFoundException(deadLetterId));
 
         if (entry.isResolved()) {
-            return ResolveDeadLetterResponse.failure(deadLetterId, "Dead letter entry is already resolved");
+            throw new DeadLetterConflictException(deadLetterId, "Dead letter entry is already resolved");
         }
 
         entry.resolve(resolvedBy);
@@ -72,25 +72,21 @@ public class ManageDeadLetterUseCase implements ManageDeadLetterPort {
             throw new IllegalArgumentException("requestedBy cannot be blank");
         }
 
-        DeadLetterEntry entry = deadLetterEntryRepository.findById(deadLetterId).orElse(null);
-        if (entry == null) {
-            return ReprocessDeadLetterResponse.failure(deadLetterId, "Dead letter entry not found");
-        }
+        DeadLetterEntry entry = deadLetterEntryRepository.findById(deadLetterId)
+                .orElseThrow(() -> new DeadLetterNotFoundException(deadLetterId));
 
         if (entry.isResolved()) {
-            return ReprocessDeadLetterResponse.failure(deadLetterId, "Dead letter entry is already resolved");
+            throw new DeadLetterConflictException(deadLetterId, "Dead letter entry is already resolved");
         }
 
         if (!deadLetterReprocessingPort.supports(entry)) {
-            return ReprocessDeadLetterResponse.failure(
-                    deadLetterId,
-                    "Dead letter entry cannot be reprocessed automatically"
-            );
+            throw new DeadLetterConflictException(
+                    deadLetterId, "Dead letter entry cannot be reprocessed automatically");
         }
 
         DeadLetterReprocessingResult reprocessingResult = deadLetterReprocessingPort.reprocess(entry);
         if (!reprocessingResult.applied()) {
-            return ReprocessDeadLetterResponse.failure(deadLetterId, reprocessingResult.message());
+            throw new DeadLetterConflictException(deadLetterId, reprocessingResult.message());
         }
 
         entry.resolve(requestedBy);

--- a/core/src/main/java/com/marmitt/core/exceptions/DeadLetterConflictException.java
+++ b/core/src/main/java/com/marmitt/core/exceptions/DeadLetterConflictException.java
@@ -1,0 +1,21 @@
+package com.marmitt.core.exceptions;
+
+import java.util.UUID;
+
+/**
+ * Sinaliza conflito de estado ao operar uma dead letter (ex.: já resolvida, não
+ * reprocessável automaticamente, ou replay sem efeito).
+ *
+ * <p>Tipo explícito de domínio para o caso "conflito" (HTTP 409), substituindo a antiga
+ * decisão baseada em {@code message().contains("not found")} na borda HTTP.
+ */
+public class DeadLetterConflictException extends RuntimeException {
+
+    public DeadLetterConflictException(UUID deadLetterId, String reason) {
+        super(reason);
+    }
+
+    public DeadLetterConflictException(String reason) {
+        super(reason);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/exceptions/DeadLetterNotFoundException.java
+++ b/core/src/main/java/com/marmitt/core/exceptions/DeadLetterNotFoundException.java
@@ -1,0 +1,16 @@
+package com.marmitt.core.exceptions;
+
+import java.util.UUID;
+
+/**
+ * Sinaliza que a dead letter solicitada não existe.
+ *
+ * <p>Tipo explícito de domínio para o caso "não encontrado", substituindo a antiga
+ * decisão baseada em {@code message().contains("not found")} na borda HTTP.
+ */
+public class DeadLetterNotFoundException extends RuntimeException {
+
+    public DeadLetterNotFoundException(UUID deadLetterId) {
+        super("Dead letter entry not found: " + deadLetterId);
+    }
+}

--- a/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCaseTest.java
@@ -7,6 +7,7 @@ import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -80,6 +81,13 @@ class QueryTradeHistoryUseCaseTest {
     void queryTrades_throwsWhenSymbolIsBlank() {
         assertThrows(IllegalArgumentException.class,
                 () -> useCase.queryTrades(EXCHANGE, "  ", FROM, TO));
+    }
+
+    @Test
+    void queryTrades_throwsWhenWindowExceedsMax() {
+        Instant tooFar = FROM.plus(Duration.ofDays(32));
+        assertThrows(IllegalArgumentException.class,
+                () -> useCase.queryTrades(EXCHANGE, SYMBOL, FROM, tooFar));
     }
 
     private static TradeExecutionDto fill() {

--- a/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/portfolio/ManageDeadLetterUseCaseTest.java
@@ -6,6 +6,8 @@ import com.marmitt.core.dto.portfolio.DeadLetterReprocessingResult;
 import com.marmitt.core.dto.portfolio.response.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
 import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.exceptions.DeadLetterConflictException;
+import com.marmitt.core.exceptions.DeadLetterNotFoundException;
 import com.marmitt.core.ports.outbound.repository.DeadLetterReprocessingPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import org.junit.jupiter.api.Test;
@@ -16,9 +18,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -99,7 +99,7 @@ class ManageDeadLetterUseCaseTest {
     }
 
     @Test
-    void resolveShouldReturnFailureWhenEntryDoesNotExist() {
+    void resolveShouldThrowNotFoundWhenEntryDoesNotExist() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
         DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         UUID deadLetterId = UUID.randomUUID();
@@ -107,15 +107,12 @@ class ManageDeadLetterUseCaseTest {
 
         ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
-        ResolveDeadLetterResponse response = useCase.resolve(deadLetterId, "operator@test", "manual review");
-
-        assertFalse(response.resolved());
-        assertEquals("Dead letter entry not found", response.message());
-        assertNull(response.entry());
+        assertThrows(DeadLetterNotFoundException.class,
+                () -> useCase.resolve(deadLetterId, "operator@test", "manual review"));
     }
 
     @Test
-    void resolveShouldReturnFailureWhenEntryIsAlreadyResolved() {
+    void resolveShouldThrowConflictWhenEntryIsAlreadyResolved() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
         DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         DeadLetterEntry entry = newEntry(UUID.randomUUID(), UUID.randomUUID(), "client-3");
@@ -124,11 +121,9 @@ class ManageDeadLetterUseCaseTest {
 
         ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
-        ResolveDeadLetterResponse response = useCase.resolve(entry.getId(), "another@test", "manual review");
-
-        assertFalse(response.resolved());
-        assertEquals("Dead letter entry is already resolved", response.message());
-        assertNull(response.entry());
+        DeadLetterConflictException error = assertThrows(DeadLetterConflictException.class,
+                () -> useCase.resolve(entry.getId(), "another@test", "manual review"));
+        assertEquals("Dead letter entry is already resolved", error.getMessage());
     }
 
     @Test
@@ -152,7 +147,7 @@ class ManageDeadLetterUseCaseTest {
     }
 
     @Test
-    void reprocessShouldReturnFailureWhenEntryDoesNotExist() {
+    void reprocessShouldThrowNotFoundWhenEntryDoesNotExist() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
         DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         UUID deadLetterId = UUID.randomUUID();
@@ -160,15 +155,12 @@ class ManageDeadLetterUseCaseTest {
 
         ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
-        ReprocessDeadLetterResponse response = useCase.reprocess(deadLetterId, "operator@test", "retry capital flow");
-
-        assertFalse(response.reprocessed());
-        assertEquals("Dead letter entry not found", response.message());
-        assertNull(response.entry());
+        assertThrows(DeadLetterNotFoundException.class,
+                () -> useCase.reprocess(deadLetterId, "operator@test", "retry capital flow"));
     }
 
     @Test
-    void reprocessShouldReturnFailureWhenEntryIsAlreadyResolved() {
+    void reprocessShouldThrowConflictWhenEntryIsAlreadyResolved() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
         DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         DeadLetterEntry entry = newRetryExhaustedEntry(UUID.randomUUID(), UUID.randomUUID(), "client-5");
@@ -177,15 +169,14 @@ class ManageDeadLetterUseCaseTest {
 
         ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
-        ReprocessDeadLetterResponse response = useCase.reprocess(entry.getId(), "operator@test", "retry capital flow");
-
-        assertFalse(response.reprocessed());
-        assertEquals("Dead letter entry is already resolved", response.message());
+        DeadLetterConflictException error = assertThrows(DeadLetterConflictException.class,
+                () -> useCase.reprocess(entry.getId(), "operator@test", "retry capital flow"));
+        assertEquals("Dead letter entry is already resolved", error.getMessage());
         verify(reprocessingPort, never()).reprocess(entry);
     }
 
     @Test
-    void reprocessShouldReturnFailureWhenEntryIsNotSupported() {
+    void reprocessShouldThrowConflictWhenEntryIsNotSupported() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
         DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         DeadLetterEntry entry = newEntry(UUID.randomUUID(), UUID.randomUUID(), "client-6");
@@ -194,15 +185,14 @@ class ManageDeadLetterUseCaseTest {
 
         ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
-        ReprocessDeadLetterResponse response = useCase.reprocess(entry.getId(), "operator@test", "retry capital flow");
-
-        assertFalse(response.reprocessed());
-        assertEquals("Dead letter entry cannot be reprocessed automatically", response.message());
+        DeadLetterConflictException error = assertThrows(DeadLetterConflictException.class,
+                () -> useCase.reprocess(entry.getId(), "operator@test", "retry capital flow"));
+        assertEquals("Dead letter entry cannot be reprocessed automatically", error.getMessage());
         verify(reprocessingPort, never()).reprocess(entry);
     }
 
     @Test
-    void reprocessShouldReturnFailureWhenReplayProducesNoStateChange() {
+    void reprocessShouldThrowConflictWhenReplayProducesNoStateChange() {
         DeadLetterEntryRepositoryPort repository = mock(DeadLetterEntryRepositoryPort.class);
         DeadLetterReprocessingPort reprocessingPort = mock(DeadLetterReprocessingPort.class);
         DeadLetterEntry entry = newRetryExhaustedEntry(UUID.randomUUID(), UUID.randomUUID(), "client-7");
@@ -214,10 +204,9 @@ class ManageDeadLetterUseCaseTest {
 
         ManageDeadLetterUseCase useCase = new ManageDeadLetterUseCase(repository, reprocessingPort);
 
-        ReprocessDeadLetterResponse response = useCase.reprocess(entry.getId(), "operator@test", "retry capital flow");
-
-        assertFalse(response.reprocessed());
-        assertEquals("Dead letter replay produced no state change and requires manual review", response.message());
+        DeadLetterConflictException error = assertThrows(DeadLetterConflictException.class,
+                () -> useCase.reprocess(entry.getId(), "operator@test", "retry capital flow"));
+        assertEquals("Dead letter replay produced no state change and requires manual review", error.getMessage());
         verify(repository, never()).save(entry);
     }
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/AdminApiKeyInterceptor.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/AdminApiKeyInterceptor.java
@@ -1,18 +1,26 @@
 package com.marmitt.application.spring.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.application.spring.web.ApiError;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.time.Instant;
 
 @Component
 public class AdminApiKeyInterceptor implements HandlerInterceptor {
 
     private final String adminApiKey;
+    private final ObjectMapper objectMapper;
 
-    public AdminApiKeyInterceptor(@Value("${admin.api.key:}") String adminApiKey) {
+    public AdminApiKeyInterceptor(@Value("${admin.api.key:}") String adminApiKey, ObjectMapper objectMapper) {
         this.adminApiKey = adminApiKey;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -20,7 +28,23 @@ public class AdminApiKeyInterceptor implements HandlerInterceptor {
         if (!adminApiKey.isBlank() && adminApiKey.equals(request.getHeader("X-Admin-Key"))) {
             return true;
         }
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        writeUnauthorized(request, response);
         return false;
+    }
+
+    /**
+     * Escreve o mesmo envelope {@link ApiError} usado pelo {@code GlobalExceptionHandler},
+     * já que o interceptor barra a requisição antes de qualquer controller/advice rodar.
+     */
+    private void writeUnauthorized(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        ApiError body = new ApiError(
+                Instant.now(),
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                "Missing or invalid X-Admin-Key header",
+                request.getRequestURI());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/AdminWebMvcConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/AdminWebMvcConfig.java
@@ -15,6 +15,9 @@ public class AdminWebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(adminApiKeyInterceptor).addPathPatterns("/api/admin/**");
+        // /api/exchanges/** expõe saldo e fills da conta na exchange — operações sensíveis
+        // que devem exigir a mesma chave de admin que /api/admin/**.
+        registry.addInterceptor(adminApiKeyInterceptor)
+                .addPathPatterns("/api/admin/**", "/api/exchanges/**");
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/ExchangeQueryConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/ExchangeQueryConfig.java
@@ -1,7 +1,9 @@
 package com.marmitt.application.spring.config.core;
 
 import com.marmitt.core.application.usecase.exchange.QueryExchangeBalanceUseCase;
+import com.marmitt.core.application.usecase.exchange.QueryTradeHistoryUseCase;
 import com.marmitt.core.ports.inbound.exchange.QueryExchangeBalancePort;
+import com.marmitt.core.ports.inbound.exchange.QueryTradeHistoryPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,5 +21,11 @@ public class ExchangeQueryConfig {
     public QueryExchangeBalancePort queryExchangeBalanceUseCase(
             ExchangeAdapterRepositoryPort exchangeAdapterRepository) {
         return new QueryExchangeBalanceUseCase(exchangeAdapterRepository);
+    }
+
+    @Bean
+    public QueryTradeHistoryPort queryTradeHistoryUseCase(
+            ExchangeAdapterRepositoryPort exchangeAdapterRepository) {
+        return new QueryTradeHistoryUseCase(exchangeAdapterRepository);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/AdminController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/AdminController.java
@@ -3,7 +3,6 @@ package com.marmitt.application.spring.controller;
 import com.marmitt.binance.filters.SymbolFilterCache;
 import com.marmitt.core.dto.runner.response.RunnerDto;
 import com.marmitt.core.dto.runner.response.RunnerHaltResult;
-import com.marmitt.core.exceptions.RunnerNotFoundException;
 import com.marmitt.core.ports.inbound.runner.HaltRunnerPort;
 import com.marmitt.core.ports.inbound.runner.QueryRunnerPort;
 import org.springframework.http.ResponseEntity;
@@ -45,11 +44,7 @@ public class AdminController {
 
     @PostMapping("/runners/{id}/halt")
     public ResponseEntity<RunnerHaltResult> haltById(@PathVariable UUID id) {
-        try {
-            return ResponseEntity.ok(haltRunner.haltById(id));
-        } catch (RunnerNotFoundException e) {
-            return ResponseEntity.notFound().build();
-        }
+        return ResponseEntity.ok(haltRunner.haltById(id));
     }
 
     @GetMapping("/runners/status")

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/DeadLetterController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/DeadLetterController.java
@@ -7,8 +7,6 @@ import com.marmitt.core.dto.portfolio.request.ResolveDeadLetterRequest;
 import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
 import jakarta.validation.Valid;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.UUID;
 
-@Slf4j
 @RestController
 @RequestMapping("/api/dead-letters")
 public class DeadLetterController {
@@ -47,29 +44,9 @@ public class DeadLetterController {
             @PathVariable UUID id,
             @Valid @RequestBody ResolveDeadLetterRequest request
     ) {
-        try {
-            ResolveDeadLetterResponse response = manageDeadLetter.resolve(
-                    id,
-                    request.resolvedBy(),
-                    request.resolutionNote()
-            );
-
-            if (response.resolved()) {
-                return ResponseEntity.ok(response);
-            }
-            if (response.message() != null && response.message().toLowerCase().contains("not found")) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
-            }
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
-        } catch (IllegalArgumentException e) {
-            log.warn("deadLetter: invalid resolve request id={} reason={}", id, e.getMessage());
-            return ResponseEntity.badRequest()
-                    .body(ResolveDeadLetterResponse.failure(id, "Invalid request: " + e.getMessage()));
-        } catch (Exception e) {
-            log.error("deadLetter: unexpected error resolving id={}", id, e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ResolveDeadLetterResponse.failure(id, "Internal server error: " + e.getMessage()));
-        }
+        ResolveDeadLetterResponse response = manageDeadLetter.resolve(
+                id, request.resolvedBy(), request.resolutionNote());
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/{id}/reprocess")
@@ -77,29 +54,9 @@ public class DeadLetterController {
             @PathVariable UUID id,
             @Valid @RequestBody ReprocessDeadLetterRequest request
     ) {
-        try {
-            ReprocessDeadLetterResponse response = manageDeadLetter.reprocess(
-                    id,
-                    request.requestedBy(),
-                    request.resolutionNote()
-            );
-
-            if (response.reprocessed()) {
-                return ResponseEntity.ok(response);
-            }
-            if (response.message() != null && response.message().toLowerCase().contains("not found")) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
-            }
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
-        } catch (IllegalArgumentException e) {
-            log.warn("deadLetter: invalid reprocess request id={} reason={}", id, e.getMessage());
-            return ResponseEntity.badRequest()
-                    .body(ReprocessDeadLetterResponse.failure(id, "Invalid request: " + e.getMessage()));
-        } catch (Exception e) {
-            log.error("deadLetter: unexpected error reprocessing id={}", id, e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ReprocessDeadLetterResponse.failure(id, "Internal server error: " + e.getMessage()));
-        }
+        ReprocessDeadLetterResponse response = manageDeadLetter.reprocess(
+                id, request.requestedBy(), request.resolutionNote());
+        return ResponseEntity.ok(response);
     }
 }
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/ExchangeQueryController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/ExchangeQueryController.java
@@ -1,0 +1,76 @@
+package com.marmitt.application.spring.controller;
+
+import com.marmitt.core.dto.exchange.BalanceDto;
+import com.marmitt.core.dto.exchange.ExchangeBalanceSnapshot;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.ports.inbound.exchange.QueryExchangeBalancePort;
+import com.marmitt.core.ports.inbound.exchange.QueryTradeHistoryPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Consulta de leitura na exchange: saldo e histórico de trades.
+ *
+ * <p>Controllers finos — delegam aos ports inbound e deixam o tratamento de erro para o
+ * {@code GlobalExceptionHandler} (exchange não registrada → 400; capacidade não suportada
+ * pela exchange → 501; falha de comunicação → 502).
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/exchanges")
+public class ExchangeQueryController {
+
+    private final QueryExchangeBalancePort queryExchangeBalance;
+    private final QueryTradeHistoryPort queryTradeHistory;
+
+    public ExchangeQueryController(QueryExchangeBalancePort queryExchangeBalance,
+                                   QueryTradeHistoryPort queryTradeHistory) {
+        this.queryExchangeBalance = queryExchangeBalance;
+        this.queryTradeHistory = queryTradeHistory;
+    }
+
+    /**
+     * GET /api/exchanges/{exchangeName}/balances[?asset=USDT]
+     *
+     * <p>Retorna o snapshot completo de saldos. Com {@code asset}, filtra na borda para o
+     * ativo informado (snapshot com 0 ou 1 saldo), mantendo o mesmo contrato de resposta.
+     */
+    @GetMapping("/{exchangeName}/balances")
+    public ResponseEntity<ExchangeBalanceSnapshot> getBalances(
+            @PathVariable String exchangeName,
+            @RequestParam(required = false) String asset) {
+
+        log.debug("exchange balances: exchange={} asset={}", exchangeName, asset);
+        ExchangeBalanceSnapshot snapshot = queryExchangeBalance.queryBalances(exchangeName);
+
+        if (asset != null && !asset.isBlank()) {
+            List<BalanceDto> filtered = snapshot.balanceOf(asset).map(List::of).orElse(List.of());
+            snapshot = new ExchangeBalanceSnapshot(snapshot.exchangeName(), filtered, snapshot.retrievedAt());
+        }
+        return ResponseEntity.ok(snapshot);
+    }
+
+    /**
+     * GET /api/exchanges/{exchangeName}/trades?symbol=BTCUSDT&from=...&to=...
+     */
+    @GetMapping("/{exchangeName}/trades")
+    public ResponseEntity<List<TradeExecutionDto>> getTrades(
+            @PathVariable String exchangeName,
+            @RequestParam String symbol,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
+
+        log.debug("exchange trades: exchange={} symbol={} from={} to={}", exchangeName, symbol, from, to);
+        List<TradeExecutionDto> trades = queryTradeHistory.queryTrades(exchangeName, symbol, from, to);
+        return ResponseEntity.ok(trades);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/PortfolioController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/PortfolioController.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 @Slf4j
 @RestController
-@RequestMapping("/portfolios")
+@RequestMapping("/api/portfolios")
 public class PortfolioController {
 
     private final CreatePortfolioPort createPortfolio;
@@ -50,29 +50,12 @@ public class PortfolioController {
         log.info("Received request to create portfolio - Name: {}, InitialCapital: {}, Currency: {}",
                 request.name(), request.initialCapitalAmount(), request.currency());
 
-        try {
-            CreatePortfolioResponse response = createPortfolio.execute(request);
+        CreatePortfolioResponse response = createPortfolio.execute(request);
 
-            if (response.portfolioId() != null) {
-                return ResponseEntity.status(HttpStatus.CREATED).body(response);
-            } else {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-            }
-
-        } catch (IllegalArgumentException e) {
-            log.error("Invalid argument in create portfolio request: {}", e.getMessage());
-            CreatePortfolioResponse errorResponse = CreatePortfolioResponse.failure(
-                    "Invalid argument: " + e.getMessage()
-            );
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
-
-        } catch (Exception e) {
-            log.error("Unexpected error creating portfolio", e);
-            CreatePortfolioResponse errorResponse = CreatePortfolioResponse.failure(
-                    "Internal server error: " + e.getMessage()
-            );
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+        if (response.portfolioId() == null) {
+            throw new IllegalArgumentException(response.message());
         }
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     /**

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/PortfolioRunnerController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/PortfolioRunnerController.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 
 @Slf4j
 @RestController
-@RequestMapping("/portfolios")
+@RequestMapping("/api/portfolios")
 public class PortfolioRunnerController {
 
     private final CreateRunnerPort createRunner;
@@ -53,36 +53,20 @@ public class PortfolioRunnerController {
         log.info("Received request to create runner - PortfolioId: {}, StrategyId: {}, Symbol: {}, Exchange: {}",
                 id, dto.strategyId(), dto.symbol(), dto.exchangeName());
 
-        try {
-            CreateRunnerRequest request = CreateRunnerRequest.builder()
-                    .portfolioId(id)
-                    .strategyId(dto.strategyId())
-                    .symbol(dto.symbol())
-                    .exchangeName(dto.exchangeName())
-                    .allowedMarketDataSources(dto.allowedMarketDataSources())
-                    .build();
+        CreateRunnerRequest request = CreateRunnerRequest.builder()
+                .portfolioId(id)
+                .strategyId(dto.strategyId())
+                .symbol(dto.symbol())
+                .exchangeName(dto.exchangeName())
+                .allowedMarketDataSources(dto.allowedMarketDataSources())
+                .build();
 
-            CreateRunnerResponse response = createRunner.execute(request);
+        CreateRunnerResponse response = createRunner.execute(request);
 
-            if (response.runnerId() != null) {
-                return ResponseEntity.status(HttpStatus.CREATED).body(response);
-            }
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-
-        } catch (IllegalArgumentException e) {
-            log.error("Invalid argument in create runner request: {}", e.getMessage());
-            CreateRunnerResponse errorResponse = CreateRunnerResponse.failure(
-                    "Invalid argument: " + e.getMessage()
-            );
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
-
-        } catch (Exception e) {
-            log.error("Unexpected error creating runner", e);
-            CreateRunnerResponse errorResponse = CreateRunnerResponse.failure(
-                    "Internal server error: " + e.getMessage()
-            );
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+        if (response.runnerId() == null) {
+            throw new IllegalArgumentException(response.message());
         }
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     /**

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/ReconciliationController.java
@@ -33,7 +33,7 @@ public class ReconciliationController {
      *                       but still counted in summary.matched
      */
     @GetMapping
-    public ResponseEntity<?> reconcile(
+    public ResponseEntity<ReconciliationReportDto> reconcile(
             @RequestParam String symbol,
             @RequestParam(defaultValue = "BINANCE") String exchangeId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
@@ -41,29 +41,22 @@ public class ReconciliationController {
             @RequestParam(defaultValue = "false") boolean includeMatched) {
 
         if (from.isAfter(to)) {
-            return ResponseEntity.badRequest().body("'from' must be before 'to'");
+            throw new IllegalArgumentException("'from' must be before 'to'");
         }
 
         log.info("reconciliation: symbol={} exchangeId={} from={} to={} includeMatched={}",
                 symbol, exchangeId, from, to, includeMatched);
 
-        try {
-            ReconciliationReportDto report = reconcileTradesPort.reconcile(
-                    new ReconciliationRequest(symbol, exchangeId, from, to, includeMatched));
-            log.info("reconciliation: done symbol={} total={} matched={} divergent={} exchangeOnly={} localOnly={}",
-                    symbol,
-                    report.summary().total(),
-                    report.summary().matched(),
-                    report.summary().divergent(),
-                    report.summary().exchangeOnly(),
-                    report.summary().localOnly());
-            return ResponseEntity.ok(report);
-        } catch (IllegalArgumentException e) {
-            log.warn("reconciliation: bad request symbol={} error={}", symbol, e.getMessage());
-            return ResponseEntity.badRequest().body(e.getMessage());
-        } catch (RuntimeException e) {
-            log.error("reconciliation: failed symbol={} error={}", symbol, e.getMessage(), e);
-            return ResponseEntity.status(502).body("Exchange query failed: " + e.getMessage());
-        }
+        ReconciliationReportDto report = reconcileTradesPort.reconcile(
+                new ReconciliationRequest(symbol, exchangeId, from, to, includeMatched));
+
+        log.info("reconciliation: done symbol={} total={} matched={} divergent={} exchangeOnly={} localOnly={}",
+                symbol,
+                report.summary().total(),
+                report.summary().matched(),
+                report.summary().divergent(),
+                report.summary().exchangeOnly(),
+                report.summary().localOnly());
+        return ResponseEntity.ok(report);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/RunnerController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/RunnerController.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 
 @Slf4j
 @RestController
-@RequestMapping("/runners")
+@RequestMapping("/api/runners")
 public class RunnerController {
 
     private final QueryRunnerPort queryRunner;
@@ -25,7 +25,7 @@ public class RunnerController {
 
     /**
      * Lista transacoes de um runner
-     * GET /runners/{id}/transactions
+     * GET /api/runners/{id}/transactions
      */
     @GetMapping("/{id}/transactions")
     public ResponseEntity<List<TransactionDto>> getTransactionsByRunnerId(@PathVariable UUID id) {

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/WebsocketController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/WebsocketController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/websocket")
+@RequestMapping("/api/websocket")
 public class WebsocketController {
 
     private final ExchangeConnectService exchangeConnectionService;

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/WebsocketExchangeController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/WebsocketExchangeController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/websocket/exchange")
+@RequestMapping("/api/websocket/exchange")
 public class WebsocketExchangeController {
 
     private final MarketDataService marketDataService;

--- a/spring-application/src/main/java/com/marmitt/application/spring/web/ApiError.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/web/ApiError.java
@@ -1,0 +1,24 @@
+package com.marmitt.application.spring.web;
+
+import java.time.Instant;
+
+/**
+ * Envelope único de erro HTTP da aplicação.
+ *
+ * <p>Toda resposta de erro retorna {@code ApiError} — nunca {@code String} crua nem o DTO
+ * de resultado de um caso de uso. Não expõe stacktrace nem detalhe interno.
+ *
+ * @param timestamp momento da resposta
+ * @param status    código HTTP
+ * @param error     reason phrase (ex.: "Bad Request")
+ * @param message   mensagem amigável
+ * @param path      caminho da requisição que originou o erro
+ */
+public record ApiError(
+        Instant timestamp,
+        int status,
+        String error,
+        String message,
+        String path
+) {
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
@@ -1,0 +1,75 @@
+package com.marmitt.application.spring.web;
+
+import com.marmitt.core.exceptions.DeadLetterConflictException;
+import com.marmitt.core.exceptions.DeadLetterNotFoundException;
+import com.marmitt.core.exceptions.ExchangeQueryException;
+import com.marmitt.core.exceptions.RunnerNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+
+/**
+ * Handler global de exceções: centraliza o mapeamento exceção→status e monta o
+ * {@link ApiError}. Controllers não decidem status de erro nem montam corpo de erro.
+ *
+ * <table>
+ *   <tr><td>IllegalArgumentException / validação</td><td>400</td></tr>
+ *   <tr><td>RunnerNotFoundException / DeadLetterNotFoundException</td><td>404</td></tr>
+ *   <tr><td>DeadLetterConflictException</td><td>409</td></tr>
+ *   <tr><td>ExchangeQueryException</td><td>502</td></tr>
+ *   <tr><td>Exception (fallback)</td><td>500</td></tr>
+ * </table>
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, ConstraintViolationException.class})
+    public ResponseEntity<ApiError> handleValidation(Exception ex, HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler({RunnerNotFoundException.class, DeadLetterNotFoundException.class})
+    public ResponseEntity<ApiError> handleNotFound(RuntimeException ex, HttpServletRequest request) {
+        return build(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(DeadLetterConflictException.class)
+    public ResponseEntity<ApiError> handleConflict(DeadLetterConflictException ex, HttpServletRequest request) {
+        return build(HttpStatus.CONFLICT, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(ExchangeQueryException.class)
+    public ResponseEntity<ApiError> handleExchangeQuery(ExchangeQueryException ex, HttpServletRequest request) {
+        log.warn("exchange query failed path={} reason={}", request.getRequestURI(), ex.getMessage());
+        return build(HttpStatus.BAD_GATEWAY, "Exchange query failed: " + ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleUnexpected(Exception ex, HttpServletRequest request) {
+        log.error("unexpected error path={}", request.getRequestURI(), ex);
+        return build(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error", request);
+    }
+
+    private static ResponseEntity<ApiError> build(HttpStatus status, String message, HttpServletRequest request) {
+        ApiError body = new ApiError(
+                Instant.now(),
+                status.value(),
+                status.getReasonPhrase(),
+                message,
+                request.getRequestURI());
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import java.time.Instant;
  *   <tr><td>IllegalArgumentException / validação</td><td>400</td></tr>
  *   <tr><td>RunnerNotFoundException / DeadLetterNotFoundException</td><td>404</td></tr>
  *   <tr><td>DeadLetterConflictException</td><td>409</td></tr>
+ *   <tr><td>UnsupportedOperationException (capacidade não suportada pela exchange)</td><td>501</td></tr>
  *   <tr><td>ExchangeQueryException</td><td>502</td></tr>
  *   <tr><td>Exception (fallback)</td><td>500</td></tr>
  * </table>
@@ -49,6 +50,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DeadLetterConflictException.class)
     public ResponseEntity<ApiError> handleConflict(DeadLetterConflictException ex, HttpServletRequest request) {
         return build(HttpStatus.CONFLICT, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(UnsupportedOperationException.class)
+    public ResponseEntity<ApiError> handleUnsupported(UnsupportedOperationException ex, HttpServletRequest request) {
+        return build(HttpStatus.NOT_IMPLEMENTED, ex.getMessage(), request);
     }
 
     @ExceptionHandler(ExchangeQueryException.class)

--- a/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -54,6 +55,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiError> handleTypeMismatch(MethodArgumentTypeMismatchException ex,
                                                        HttpServletRequest request) {
         return build(HttpStatus.BAD_REQUEST, "Invalid value for parameter '" + ex.getName() + "'", request);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiError> handleUnreadableBody(HttpMessageNotReadableException ex,
+                                                         HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, "Malformed or unreadable request body", request);
     }
 
     @ExceptionHandler({RunnerNotFoundException.class, DeadLetterNotFoundException.class})

--- a/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
@@ -10,8 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.Instant;
 
@@ -20,7 +22,7 @@ import java.time.Instant;
  * {@link ApiError}. Controllers não decidem status de erro nem montam corpo de erro.
  *
  * <table>
- *   <tr><td>IllegalArgumentException / validação</td><td>400</td></tr>
+ *   <tr><td>IllegalArgumentException / validação / parâmetro ausente ou inválido</td><td>400</td></tr>
  *   <tr><td>RunnerNotFoundException / DeadLetterNotFoundException</td><td>404</td></tr>
  *   <tr><td>DeadLetterConflictException</td><td>409</td></tr>
  *   <tr><td>UnsupportedOperationException (capacidade não suportada pela exchange)</td><td>501</td></tr>
@@ -40,6 +42,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({MethodArgumentNotValidException.class, ConstraintViolationException.class})
     public ResponseEntity<ApiError> handleValidation(Exception ex, HttpServletRequest request) {
         return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiError> handleMissingParam(MissingServletRequestParameterException ex,
+                                                       HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiError> handleTypeMismatch(MethodArgumentTypeMismatchException ex,
+                                                       HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, "Invalid value for parameter '" + ex.getName() + "'", request);
     }
 
     @ExceptionHandler({RunnerNotFoundException.class, DeadLetterNotFoundException.class})

--- a/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
@@ -8,8 +8,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -28,6 +30,7 @@ import java.time.Instant;
  *   <tr><td>DeadLetterConflictException</td><td>409</td></tr>
  *   <tr><td>UnsupportedOperationException (capacidade não suportada pela exchange)</td><td>501</td></tr>
  *   <tr><td>ExchangeQueryException</td><td>502</td></tr>
+ *   <tr><td>ErrorResponse (exceções MVC do Spring: 404/405/415...)</td><td>status original</td></tr>
  *   <tr><td>Exception (fallback)</td><td>500</td></tr>
  * </table>
  */
@@ -86,15 +89,25 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiError> handleUnexpected(Exception ex, HttpServletRequest request) {
+        // Exceções padrão do Spring MVC (ex.: HttpRequestMethodNotSupportedException → 405,
+        // NoResourceFoundException → 404, HttpMediaTypeNotSupportedException → 415) implementam
+        // ErrorResponse e já carregam o status HTTP correto. Preserva esse status em vez de
+        // tratá-las como falha interna 500.
+        if (ex instanceof ErrorResponse errorResponse) {
+            String detail = errorResponse.getBody().getDetail();
+            String message = detail != null ? detail : errorResponse.getBody().getTitle();
+            return build(errorResponse.getStatusCode(), message, request);
+        }
         log.error("unexpected error path={}", request.getRequestURI(), ex);
         return build(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error", request);
     }
 
-    private static ResponseEntity<ApiError> build(HttpStatus status, String message, HttpServletRequest request) {
+    private static ResponseEntity<ApiError> build(HttpStatusCode status, String message, HttpServletRequest request) {
+        String reason = (status instanceof HttpStatus httpStatus) ? httpStatus.getReasonPhrase() : "";
         ApiError body = new ApiError(
                 Instant.now(),
                 status.value(),
-                status.getReasonPhrase(),
+                reason,
                 message,
                 request.getRequestURI());
         return ResponseEntity.status(status).body(body);

--- a/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/CapitalDeadLetterReplayIntegrationTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/bootstrap/CapitalDeadLetterReplayIntegrationTest.java
@@ -209,7 +209,7 @@ class CapitalDeadLetterReplayIntegrationTest extends AbstractIntegrationTest {
                                 }
                                 """))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.reprocessed").value(false))
+                .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message").value(
                         "Dead letter replay produced no state change and requires manual review"
                 ));

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/DeadLetterControllerTest.java
@@ -1,9 +1,12 @@
 package com.marmitt.application.spring.controller;
 
+import com.marmitt.application.spring.web.GlobalExceptionHandler;
 import com.marmitt.core.dto.portfolio.response.DeadLetterEntryDto;
 import com.marmitt.core.dto.portfolio.response.ReprocessDeadLetterResponse;
 import com.marmitt.core.dto.portfolio.response.ResolveDeadLetterResponse;
 import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.exceptions.DeadLetterConflictException;
+import com.marmitt.core.exceptions.DeadLetterNotFoundException;
 import com.marmitt.core.ports.inbound.portfolio.ManageDeadLetterPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +33,9 @@ class DeadLetterControllerTest {
 
     @BeforeEach
     void setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(new DeadLetterController(manageDeadLetter)).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(new DeadLetterController(manageDeadLetter))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
     }
 
     @Test
@@ -106,7 +111,7 @@ class DeadLetterControllerTest {
     void resolveShouldReturnNotFoundWhenEntryDoesNotExist() throws Exception {
         UUID deadLetterId = UUID.randomUUID();
         when(manageDeadLetter.resolve(deadLetterId, "operator@test", "manual review"))
-                .thenReturn(ResolveDeadLetterResponse.failure(deadLetterId, "Dead letter entry not found"));
+                .thenThrow(new DeadLetterNotFoundException(deadLetterId));
 
         mockMvc.perform(post("/api/dead-letters/{id}/resolve", deadLetterId)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -117,15 +122,16 @@ class DeadLetterControllerTest {
                                 }
                                 """))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.resolved").value(false))
-                .andExpect(jsonPath("$.message").value("Dead letter entry not found"));
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Not Found"))
+                .andExpect(jsonPath("$.path").value("/api/dead-letters/" + deadLetterId + "/resolve"));
     }
 
     @Test
     void resolveShouldReturnConflictWhenEntryIsAlreadyResolved() throws Exception {
         UUID deadLetterId = UUID.randomUUID();
         when(manageDeadLetter.resolve(deadLetterId, "operator@test", "manual review"))
-                .thenReturn(ResolveDeadLetterResponse.failure(deadLetterId, "Dead letter entry is already resolved"));
+                .thenThrow(new DeadLetterConflictException(deadLetterId, "Dead letter entry is already resolved"));
 
         mockMvc.perform(post("/api/dead-letters/{id}/resolve", deadLetterId)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -136,7 +142,7 @@ class DeadLetterControllerTest {
                                 }
                                 """))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.resolved").value(false))
+                .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message").value("Dead letter entry is already resolved"));
     }
 
@@ -155,8 +161,8 @@ class DeadLetterControllerTest {
                                 }
                                 """))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.resolved").value(false))
-                .andExpect(jsonPath("$.message").value("Invalid request: resolvedBy cannot be blank"));
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("resolvedBy cannot be blank"));
     }
 
     @Test
@@ -186,10 +192,8 @@ class DeadLetterControllerTest {
     void reprocessShouldReturnConflictWhenEntryCannotBeReprocessedAutomatically() throws Exception {
         UUID deadLetterId = UUID.randomUUID();
         when(manageDeadLetter.reprocess(deadLetterId, "operator@test", "retry capital flow"))
-                .thenReturn(ReprocessDeadLetterResponse.failure(
-                        deadLetterId,
-                        "Dead letter entry cannot be reprocessed automatically"
-                ));
+                .thenThrow(new DeadLetterConflictException(
+                        deadLetterId, "Dead letter entry cannot be reprocessed automatically"));
 
         mockMvc.perform(post("/api/dead-letters/{id}/reprocess", deadLetterId)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -200,7 +204,7 @@ class DeadLetterControllerTest {
                                 }
                                 """))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.reprocessed").value(false))
+                .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message").value("Dead letter entry cannot be reprocessed automatically"));
     }
 
@@ -219,8 +223,8 @@ class DeadLetterControllerTest {
                                 }
                                 """))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.reprocessed").value(false))
-                .andExpect(jsonPath("$.message").value("Invalid request: requestedBy cannot be blank"));
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("requestedBy cannot be blank"));
     }
 
     private static DeadLetterEntryDto newEntry(UUID deadLetterId,

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/ExchangeQueryControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/ExchangeQueryControllerTest.java
@@ -125,6 +125,26 @@ class ExchangeQueryControllerTest {
     }
 
     @Test
+    void getTrades_returns400WhenRequiredParamMissing() throws Exception {
+        // symbol omitted → Spring binding fails before the use case runs
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", EXCHANGE)
+                        .param("from", FROM.toString())
+                        .param("to", TO.toString()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void getTrades_returns400WhenTimestampMalformed() throws Exception {
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", EXCHANGE)
+                        .param("symbol", "BTCUSDT")
+                        .param("from", "not-a-timestamp")
+                        .param("to", TO.toString()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
     void getTrades_returns501WhenCapabilityUnsupported() throws Exception {
         when(queryTrades.queryTrades("COINBASE", "BTCUSDT", FROM, TO))
                 .thenThrow(new UnsupportedOperationException("Trade history query capability is not available"));

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/ExchangeQueryControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/ExchangeQueryControllerTest.java
@@ -1,0 +1,151 @@
+package com.marmitt.application.spring.controller;
+
+import com.marmitt.application.spring.web.GlobalExceptionHandler;
+import com.marmitt.core.dto.exchange.BalanceDto;
+import com.marmitt.core.dto.exchange.ExchangeBalanceSnapshot;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.ports.inbound.exchange.QueryExchangeBalancePort;
+import com.marmitt.core.ports.inbound.exchange.QueryTradeHistoryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ExchangeQueryControllerTest {
+
+    private static final String EXCHANGE = "BINANCE";
+    private static final Instant AS_OF = Instant.parse("2026-01-01T10:00:00Z");
+    private static final Instant FROM = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant TO = Instant.parse("2026-01-02T00:00:00Z");
+
+    private final QueryExchangeBalancePort queryBalance = mock(QueryExchangeBalancePort.class);
+    private final QueryTradeHistoryPort queryTrades = mock(QueryTradeHistoryPort.class);
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ExchangeQueryController(queryBalance, queryTrades))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void getBalances_returnsFullSnapshot() throws Exception {
+        when(queryBalance.queryBalances(EXCHANGE)).thenReturn(snapshot(
+                BalanceDto.of("USDT", new BigDecimal("100"), new BigDecimal("25")),
+                BalanceDto.of("BTC", new BigDecimal("0.20"), BigDecimal.ZERO)));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", EXCHANGE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.exchangeName").value(EXCHANGE))
+                .andExpect(jsonPath("$.balances.length()").value(2));
+    }
+
+    @Test
+    void getBalances_filtersByAssetAtTheEdge() throws Exception {
+        when(queryBalance.queryBalances(EXCHANGE)).thenReturn(snapshot(
+                BalanceDto.of("USDT", new BigDecimal("100"), new BigDecimal("25")),
+                BalanceDto.of("BTC", new BigDecimal("0.20"), BigDecimal.ZERO)));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", EXCHANGE).param("asset", "usdt"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.balances.length()").value(1))
+                .andExpect(jsonPath("$.balances[0].asset").value("USDT"))
+                .andExpect(jsonPath("$.balances[0].total").value(125));
+    }
+
+    @Test
+    void getBalances_returnsEmptyWhenAssetAbsent() throws Exception {
+        when(queryBalance.queryBalances(EXCHANGE)).thenReturn(snapshot(
+                BalanceDto.of("USDT", new BigDecimal("100"), BigDecimal.ZERO)));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", EXCHANGE).param("asset", "ETH"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.balances.length()").value(0));
+    }
+
+    @Test
+    void getBalances_returns400WhenExchangeUnknown() throws Exception {
+        when(queryBalance.queryBalances("NOPE"))
+                .thenThrow(new IllegalArgumentException("Exchange 'NOPE' is not registered"));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", "NOPE"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void getBalances_returns501WhenCapabilityUnsupported() throws Exception {
+        when(queryBalance.queryBalances("COINBASE"))
+                .thenThrow(new UnsupportedOperationException("Balance query capability is not available"));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", "COINBASE"))
+                .andExpect(status().isNotImplemented())
+                .andExpect(jsonPath("$.status").value(501));
+    }
+
+    @Test
+    void getTrades_returnsFills() throws Exception {
+        when(queryTrades.queryTrades(EXCHANGE, "BTCUSDT", FROM, TO)).thenReturn(List.of(fill()));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", EXCHANGE)
+                        .param("symbol", "BTCUSDT")
+                        .param("from", FROM.toString())
+                        .param("to", TO.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].symbol").value("BTCUSDT"));
+
+        verify(queryTrades).queryTrades(eq(EXCHANGE), eq("BTCUSDT"), eq(FROM), eq(TO));
+    }
+
+    @Test
+    void getTrades_returns400WhenIntervalInvalid() throws Exception {
+        when(queryTrades.queryTrades(EXCHANGE, "BTCUSDT", TO, FROM))
+                .thenThrow(new IllegalArgumentException("from must not be after to"));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", EXCHANGE)
+                        .param("symbol", "BTCUSDT")
+                        .param("from", TO.toString())
+                        .param("to", FROM.toString()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void getTrades_returns501WhenCapabilityUnsupported() throws Exception {
+        when(queryTrades.queryTrades("COINBASE", "BTCUSDT", FROM, TO))
+                .thenThrow(new UnsupportedOperationException("Trade history query capability is not available"));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", "COINBASE")
+                        .param("symbol", "BTCUSDT")
+                        .param("from", FROM.toString())
+                        .param("to", TO.toString()))
+                .andExpect(status().isNotImplemented())
+                .andExpect(jsonPath("$.status").value(501));
+    }
+
+    private static ExchangeBalanceSnapshot snapshot(BalanceDto... balances) {
+        return new ExchangeBalanceSnapshot(EXCHANGE, List.of(balances), AS_OF);
+    }
+
+    private static TradeExecutionDto fill() {
+        return new TradeExecutionDto(
+                "trade-1", 100234L, null, "BTCUSDT",
+                new BigDecimal("50000"), new BigDecimal("0.01"),
+                new BigDecimal("500"), new BigDecimal("0.0001"), "BNB",
+                Instant.parse("2026-01-01T10:00:00Z"), true);
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/ReconciliationControllerTest.java
@@ -1,8 +1,10 @@
 package com.marmitt.application.spring.controller;
 
+import com.marmitt.application.spring.web.GlobalExceptionHandler;
 import com.marmitt.core.dto.reconciliation.ReconciliationReportDto;
 import com.marmitt.core.dto.reconciliation.ReconciliationRequest;
 import com.marmitt.core.dto.reconciliation.ReconciliationSummaryDto;
+import com.marmitt.core.exceptions.ExchangeQueryException;
 import com.marmitt.core.ports.inbound.reconciliation.ReconcileTradesPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +29,9 @@ class ReconciliationControllerTest {
 
     @BeforeEach
     void setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(new ReconciliationController(reconcileTradesPort)).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(new ReconciliationController(reconcileTradesPort))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
     }
 
     @Test
@@ -77,16 +81,19 @@ class ReconciliationControllerTest {
     }
 
     @Test
-    void reconcile_returns502WhenExchangeThrows() throws Exception {
+    void reconcile_returns502WhenExchangeQueryFails() throws Exception {
         when(reconcileTradesPort.reconcile(any(ReconciliationRequest.class)))
-                .thenThrow(new RuntimeException("Binance timeout"));
+                .thenThrow(new ExchangeQueryException("BINANCE",
+                        ExchangeQueryException.ErrorType.TEMPORARY, "Binance timeout"));
 
         mockMvc.perform(get("/api/reconciliation")
                         .param("symbol", "BTCUSDT")
                         .param("exchangeId", "BINANCE")
                         .param("from", "2026-01-01T00:00:00Z")
                         .param("to", "2026-01-02T00:00:00Z"))
-                .andExpect(status().isBadGateway());
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.status").value(502))
+                .andExpect(jsonPath("$.path").value("/api/reconciliation"));
     }
 
     @Test

--- a/spring-application/src/test/java/com/marmitt/application/spring/web/GlobalExceptionHandlerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/web/GlobalExceptionHandlerTest.java
@@ -1,0 +1,71 @@
+package com.marmitt.application.spring.web;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ProbeController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void methodNotSupported_preservesOriginalStatus() throws Exception {
+        // HttpRequestMethodNotSupportedException implements ErrorResponse (405) — must NOT become 500.
+        mockMvc.perform(post("/probe/get-only"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.path").value("/probe/get-only"));
+    }
+
+    @Test
+    void illegalArgument_mapsToBadRequest() throws Exception {
+        mockMvc.perform(get("/probe/illegal"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("bad input"));
+    }
+
+    @Test
+    void unexpectedException_mapsToInternalServerError() throws Exception {
+        mockMvc.perform(get("/probe/boom"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.message").value("Internal server error"));
+    }
+
+    @RestController
+    @RequestMapping("/probe")
+    static class ProbeController {
+
+        @GetMapping("/get-only")
+        public String getOnly() {
+            return "ok";
+        }
+
+        @GetMapping("/illegal")
+        public String illegal() {
+            throw new IllegalArgumentException("bad input");
+        }
+
+        @GetMapping("/boom")
+        public String boom() {
+            throw new IllegalStateException("unexpected");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Introduz envelope de erro único **`ApiError`** e **`GlobalExceptionHandler`** (`@RestControllerAdvice`) que centraliza o mapeamento exceção→status: `IllegalArgumentException`/validação→400, `RunnerNotFoundException`/`DeadLetterNotFoundException`→404, `DeadLetterConflictException`→409, `ExchangeQueryException`→502, fallback→500.
- **DLQ:** `ManageDeadLetterUseCase` passa a lançar `DeadLetterNotFoundException`/`DeadLetterConflictException`; a borda HTTP deixa de decidir status por `message().contains("not found")` (critério 3).
- **Controllers finos:** removido try/catch de mapeamento de status e corpos de erro com `String` crua ou DTO de resultado (Reconciliation, DeadLetter, Portfolio, PortfolioRunner, Admin). Sucesso segue a convenção (200/201 com corpo, 204 sem).
- **Prefixo `/api/...` (breaking):** `runners`, `portfolios` (x2), `websocket`, `websocket/exchange` migrados; README atualizado. Cutover direto alinhado com o autor (sem testes/scripts dependentes das rotas antigas).
- `BinanceTradeHistoryAdapter` passa a lançar `ExchangeQueryException` (preserva o 502 da reconciliação sob o handler global, alinhando com os adapters irmãos).

## Validation
- `./scripts/gradle-run.ps1 :core:test --tests "...ManageDeadLetterUseCaseTest"`: passed
- `./scripts/gradle-run.ps1 :adapter-binance:test --tests "...BinanceTradeHistoryAdapterTest"`: passed
- `./scripts/gradle-run.ps1 :spring-application:test --tests "...DeadLetterControllerTest" --tests "...ReconciliationControllerTest"`: passed
- Compilação de todos os módulos + de todo o test source do spring-application: passed
- **Não** rodei a suíte de integração `@SpringBootTest` (Docker/infra) localmente; o handler é um advice padrão, risco de context-load baixo. Inventário confirmou que nenhum teste referencia as rotas antigas nem o contrato de falha do DLQ.

## Documentation
- README atualizado para as rotas `/api/websocket...`. Sem outro impacto em `docs/` (o `IMPLEMENTATION_GUIDE` já descreve um desenho `/api/...` idealizado).

## Scope notes
- **Modelo de erro dos use cases de create mantido**: `CreatePortfolioUseCase`/`CreateRunnerUseCase` continuam absorvendo erros em failure-response (refatorá-los para lançar é um redesign de core fora da padronização de controller). Os controllers traduzem a failure-response em `ApiError` 400 (sem retornar o DTO de resultado como corpo de erro), satisfazendo o critério 1 sem mexer no core.
- **404s vazios mantidos** (`Optional` ausente em Portfolio/Runner query): retornam 404 sem corpo, o que não viola o critério 1 (não é String crua nem DTO de resultado). Padronizá-los para `ApiError` exigiria novas exceções de domínio — deixado de fora para manter o escopo.
- **Endpoints de saldo/histórico (T29/T30) não adicionados aqui**: T27 padroniza o contrato; criar esses endpoints seguindo o novo padrão é follow-up.
- Sem testes de controller para Portfolio/Admin/Websocket (não existiam); essas mudanças são validadas por compilação.

## Notes
- Mudança de path é **breaking** para consumidores externos manuais. Registrado no README e neste PR.