### PR TITLE
feat: endpoints de consulta de saldo e histórico na exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ POST /api/websocket/exchange/market-data/unsubscribe
 # Order Management  
 POST /api/websocket/exchange/orders/create
 POST /api/websocket/exchange/orders/cancel
+
+# Exchange Queries
+GET  /api/exchanges/{exchange}/balances          # ?asset=USDT filtra um ativo
+GET  /api/exchanges/{exchange}/trades            # ?symbol=BTCUSDT&from=...&to=...
 ```
 
 ### Documentação

--- a/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCase.java
@@ -5,6 +5,7 @@ import com.marmitt.core.ports.inbound.exchange.QueryTradeHistoryPort;
 import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
@@ -14,11 +15,16 @@ import java.util.List;
  * <p>Resolve o {@link ExchangeAdapterDescriptor} da exchange pedida e despacha pela
  * capacidade de histórico, sem conhecer nenhum adapter concreto.
  *
- * <p>Valida o intervalo na borda ({@code symbol}, {@code from <= to}, ambos presentes)
- * antes de delegar. A paginação/limite de janela da exchange é tratada no adapter
- * (ex.: {@code BinanceTradeHistoryAdapter} fatia janelas de 24h internamente).
+ * <p>Valida o intervalo na borda ({@code symbol}, {@code from <= to}, ambos presentes e
+ * janela &le; {@value #MAX_WINDOW_DAYS} dias) antes de delegar. O limite de janela protege
+ * contra fan-out: o adapter da exchange fatia o intervalo em janelas de 24h e pagina
+ * (ex.: {@code BinanceTradeHistoryAdapter}), então um intervalo longo viraria muitas
+ * chamadas assinadas numa única requisição.
  */
 public class QueryTradeHistoryUseCase implements QueryTradeHistoryPort {
+
+    static final int MAX_WINDOW_DAYS = 31;
+    private static final Duration MAX_WINDOW = Duration.ofDays(MAX_WINDOW_DAYS);
 
     private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
 
@@ -49,6 +55,10 @@ public class QueryTradeHistoryUseCase implements QueryTradeHistoryPort {
         }
         if (from.isAfter(to)) {
             throw new IllegalArgumentException("from must not be after to (from=" + from + ", to=" + to + ")");
+        }
+        if (Duration.between(from, to).compareTo(MAX_WINDOW) > 0) {
+            throw new IllegalArgumentException(
+                    "query window must not exceed " + MAX_WINDOW_DAYS + " days (from=" + from + ", to=" + to + ")");
         }
     }
 

--- a/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCaseTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/exchange/QueryTradeHistoryUseCaseTest.java
@@ -7,6 +7,7 @@ import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -80,6 +81,13 @@ class QueryTradeHistoryUseCaseTest {
     void queryTrades_throwsWhenSymbolIsBlank() {
         assertThrows(IllegalArgumentException.class,
                 () -> useCase.queryTrades(EXCHANGE, "  ", FROM, TO));
+    }
+
+    @Test
+    void queryTrades_throwsWhenWindowExceedsMax() {
+        Instant tooFar = FROM.plus(Duration.ofDays(32));
+        assertThrows(IllegalArgumentException.class,
+                () -> useCase.queryTrades(EXCHANGE, SYMBOL, FROM, tooFar));
     }
 
     private static TradeExecutionDto fill() {

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/AdminWebMvcConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/AdminWebMvcConfig.java
@@ -15,6 +15,9 @@ public class AdminWebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(adminApiKeyInterceptor).addPathPatterns("/api/admin/**");
+        // /api/exchanges/** expõe saldo e fills da conta na exchange — operações sensíveis
+        // que devem exigir a mesma chave de admin que /api/admin/**.
+        registry.addInterceptor(adminApiKeyInterceptor)
+                .addPathPatterns("/api/admin/**", "/api/exchanges/**");
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/core/ExchangeQueryConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/core/ExchangeQueryConfig.java
@@ -1,7 +1,9 @@
 package com.marmitt.application.spring.config.core;
 
 import com.marmitt.core.application.usecase.exchange.QueryExchangeBalanceUseCase;
+import com.marmitt.core.application.usecase.exchange.QueryTradeHistoryUseCase;
 import com.marmitt.core.ports.inbound.exchange.QueryExchangeBalancePort;
+import com.marmitt.core.ports.inbound.exchange.QueryTradeHistoryPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,5 +21,11 @@ public class ExchangeQueryConfig {
     public QueryExchangeBalancePort queryExchangeBalanceUseCase(
             ExchangeAdapterRepositoryPort exchangeAdapterRepository) {
         return new QueryExchangeBalanceUseCase(exchangeAdapterRepository);
+    }
+
+    @Bean
+    public QueryTradeHistoryPort queryTradeHistoryUseCase(
+            ExchangeAdapterRepositoryPort exchangeAdapterRepository) {
+        return new QueryTradeHistoryUseCase(exchangeAdapterRepository);
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/controller/ExchangeQueryController.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/controller/ExchangeQueryController.java
@@ -1,0 +1,76 @@
+package com.marmitt.application.spring.controller;
+
+import com.marmitt.core.dto.exchange.BalanceDto;
+import com.marmitt.core.dto.exchange.ExchangeBalanceSnapshot;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.ports.inbound.exchange.QueryExchangeBalancePort;
+import com.marmitt.core.ports.inbound.exchange.QueryTradeHistoryPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Consulta de leitura na exchange: saldo e histórico de trades.
+ *
+ * <p>Controllers finos — delegam aos ports inbound e deixam o tratamento de erro para o
+ * {@code GlobalExceptionHandler} (exchange não registrada → 400; capacidade não suportada
+ * pela exchange → 501; falha de comunicação → 502).
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/exchanges")
+public class ExchangeQueryController {
+
+    private final QueryExchangeBalancePort queryExchangeBalance;
+    private final QueryTradeHistoryPort queryTradeHistory;
+
+    public ExchangeQueryController(QueryExchangeBalancePort queryExchangeBalance,
+                                   QueryTradeHistoryPort queryTradeHistory) {
+        this.queryExchangeBalance = queryExchangeBalance;
+        this.queryTradeHistory = queryTradeHistory;
+    }
+
+    /**
+     * GET /api/exchanges/{exchangeName}/balances[?asset=USDT]
+     *
+     * <p>Retorna o snapshot completo de saldos. Com {@code asset}, filtra na borda para o
+     * ativo informado (snapshot com 0 ou 1 saldo), mantendo o mesmo contrato de resposta.
+     */
+    @GetMapping("/{exchangeName}/balances")
+    public ResponseEntity<ExchangeBalanceSnapshot> getBalances(
+            @PathVariable String exchangeName,
+            @RequestParam(required = false) String asset) {
+
+        log.debug("exchange balances: exchange={} asset={}", exchangeName, asset);
+        ExchangeBalanceSnapshot snapshot = queryExchangeBalance.queryBalances(exchangeName);
+
+        if (asset != null && !asset.isBlank()) {
+            List<BalanceDto> filtered = snapshot.balanceOf(asset).map(List::of).orElse(List.of());
+            snapshot = new ExchangeBalanceSnapshot(snapshot.exchangeName(), filtered, snapshot.retrievedAt());
+        }
+        return ResponseEntity.ok(snapshot);
+    }
+
+    /**
+     * GET /api/exchanges/{exchangeName}/trades?symbol=BTCUSDT&from=...&to=...
+     */
+    @GetMapping("/{exchangeName}/trades")
+    public ResponseEntity<List<TradeExecutionDto>> getTrades(
+            @PathVariable String exchangeName,
+            @RequestParam String symbol,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
+
+        log.debug("exchange trades: exchange={} symbol={} from={} to={}", exchangeName, symbol, from, to);
+        List<TradeExecutionDto> trades = queryTradeHistory.queryTrades(exchangeName, symbol, from, to);
+        return ResponseEntity.ok(trades);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import java.time.Instant;
  *   <tr><td>IllegalArgumentException / validação</td><td>400</td></tr>
  *   <tr><td>RunnerNotFoundException / DeadLetterNotFoundException</td><td>404</td></tr>
  *   <tr><td>DeadLetterConflictException</td><td>409</td></tr>
+ *   <tr><td>UnsupportedOperationException (capacidade não suportada pela exchange)</td><td>501</td></tr>
  *   <tr><td>ExchangeQueryException</td><td>502</td></tr>
  *   <tr><td>Exception (fallback)</td><td>500</td></tr>
  * </table>
@@ -49,6 +50,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DeadLetterConflictException.class)
     public ResponseEntity<ApiError> handleConflict(DeadLetterConflictException ex, HttpServletRequest request) {
         return build(HttpStatus.CONFLICT, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(UnsupportedOperationException.class)
+    public ResponseEntity<ApiError> handleUnsupported(UnsupportedOperationException ex, HttpServletRequest request) {
+        return build(HttpStatus.NOT_IMPLEMENTED, ex.getMessage(), request);
     }
 
     @ExceptionHandler(ExchangeQueryException.class)

--- a/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/web/GlobalExceptionHandler.java
@@ -10,8 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.Instant;
 
@@ -20,7 +22,7 @@ import java.time.Instant;
  * {@link ApiError}. Controllers não decidem status de erro nem montam corpo de erro.
  *
  * <table>
- *   <tr><td>IllegalArgumentException / validação</td><td>400</td></tr>
+ *   <tr><td>IllegalArgumentException / validação / parâmetro ausente ou inválido</td><td>400</td></tr>
  *   <tr><td>RunnerNotFoundException / DeadLetterNotFoundException</td><td>404</td></tr>
  *   <tr><td>DeadLetterConflictException</td><td>409</td></tr>
  *   <tr><td>UnsupportedOperationException (capacidade não suportada pela exchange)</td><td>501</td></tr>
@@ -40,6 +42,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({MethodArgumentNotValidException.class, ConstraintViolationException.class})
     public ResponseEntity<ApiError> handleValidation(Exception ex, HttpServletRequest request) {
         return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiError> handleMissingParam(MissingServletRequestParameterException ex,
+                                                       HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiError> handleTypeMismatch(MethodArgumentTypeMismatchException ex,
+                                                       HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, "Invalid value for parameter '" + ex.getName() + "'", request);
     }
 
     @ExceptionHandler({RunnerNotFoundException.class, DeadLetterNotFoundException.class})

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/ExchangeQueryControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/ExchangeQueryControllerTest.java
@@ -125,6 +125,26 @@ class ExchangeQueryControllerTest {
     }
 
     @Test
+    void getTrades_returns400WhenRequiredParamMissing() throws Exception {
+        // symbol omitted → Spring binding fails before the use case runs
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", EXCHANGE)
+                        .param("from", FROM.toString())
+                        .param("to", TO.toString()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void getTrades_returns400WhenTimestampMalformed() throws Exception {
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", EXCHANGE)
+                        .param("symbol", "BTCUSDT")
+                        .param("from", "not-a-timestamp")
+                        .param("to", TO.toString()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
     void getTrades_returns501WhenCapabilityUnsupported() throws Exception {
         when(queryTrades.queryTrades("COINBASE", "BTCUSDT", FROM, TO))
                 .thenThrow(new UnsupportedOperationException("Trade history query capability is not available"));

--- a/spring-application/src/test/java/com/marmitt/application/spring/controller/ExchangeQueryControllerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/controller/ExchangeQueryControllerTest.java
@@ -1,0 +1,151 @@
+package com.marmitt.application.spring.controller;
+
+import com.marmitt.application.spring.web.GlobalExceptionHandler;
+import com.marmitt.core.dto.exchange.BalanceDto;
+import com.marmitt.core.dto.exchange.ExchangeBalanceSnapshot;
+import com.marmitt.core.dto.reconciliation.TradeExecutionDto;
+import com.marmitt.core.ports.inbound.exchange.QueryExchangeBalancePort;
+import com.marmitt.core.ports.inbound.exchange.QueryTradeHistoryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ExchangeQueryControllerTest {
+
+    private static final String EXCHANGE = "BINANCE";
+    private static final Instant AS_OF = Instant.parse("2026-01-01T10:00:00Z");
+    private static final Instant FROM = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant TO = Instant.parse("2026-01-02T00:00:00Z");
+
+    private final QueryExchangeBalancePort queryBalance = mock(QueryExchangeBalancePort.class);
+    private final QueryTradeHistoryPort queryTrades = mock(QueryTradeHistoryPort.class);
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ExchangeQueryController(queryBalance, queryTrades))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void getBalances_returnsFullSnapshot() throws Exception {
+        when(queryBalance.queryBalances(EXCHANGE)).thenReturn(snapshot(
+                BalanceDto.of("USDT", new BigDecimal("100"), new BigDecimal("25")),
+                BalanceDto.of("BTC", new BigDecimal("0.20"), BigDecimal.ZERO)));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", EXCHANGE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.exchangeName").value(EXCHANGE))
+                .andExpect(jsonPath("$.balances.length()").value(2));
+    }
+
+    @Test
+    void getBalances_filtersByAssetAtTheEdge() throws Exception {
+        when(queryBalance.queryBalances(EXCHANGE)).thenReturn(snapshot(
+                BalanceDto.of("USDT", new BigDecimal("100"), new BigDecimal("25")),
+                BalanceDto.of("BTC", new BigDecimal("0.20"), BigDecimal.ZERO)));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", EXCHANGE).param("asset", "usdt"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.balances.length()").value(1))
+                .andExpect(jsonPath("$.balances[0].asset").value("USDT"))
+                .andExpect(jsonPath("$.balances[0].total").value(125));
+    }
+
+    @Test
+    void getBalances_returnsEmptyWhenAssetAbsent() throws Exception {
+        when(queryBalance.queryBalances(EXCHANGE)).thenReturn(snapshot(
+                BalanceDto.of("USDT", new BigDecimal("100"), BigDecimal.ZERO)));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", EXCHANGE).param("asset", "ETH"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.balances.length()").value(0));
+    }
+
+    @Test
+    void getBalances_returns400WhenExchangeUnknown() throws Exception {
+        when(queryBalance.queryBalances("NOPE"))
+                .thenThrow(new IllegalArgumentException("Exchange 'NOPE' is not registered"));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", "NOPE"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void getBalances_returns501WhenCapabilityUnsupported() throws Exception {
+        when(queryBalance.queryBalances("COINBASE"))
+                .thenThrow(new UnsupportedOperationException("Balance query capability is not available"));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/balances", "COINBASE"))
+                .andExpect(status().isNotImplemented())
+                .andExpect(jsonPath("$.status").value(501));
+    }
+
+    @Test
+    void getTrades_returnsFills() throws Exception {
+        when(queryTrades.queryTrades(EXCHANGE, "BTCUSDT", FROM, TO)).thenReturn(List.of(fill()));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", EXCHANGE)
+                        .param("symbol", "BTCUSDT")
+                        .param("from", FROM.toString())
+                        .param("to", TO.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].symbol").value("BTCUSDT"));
+
+        verify(queryTrades).queryTrades(eq(EXCHANGE), eq("BTCUSDT"), eq(FROM), eq(TO));
+    }
+
+    @Test
+    void getTrades_returns400WhenIntervalInvalid() throws Exception {
+        when(queryTrades.queryTrades(EXCHANGE, "BTCUSDT", TO, FROM))
+                .thenThrow(new IllegalArgumentException("from must not be after to"));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", EXCHANGE)
+                        .param("symbol", "BTCUSDT")
+                        .param("from", TO.toString())
+                        .param("to", FROM.toString()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void getTrades_returns501WhenCapabilityUnsupported() throws Exception {
+        when(queryTrades.queryTrades("COINBASE", "BTCUSDT", FROM, TO))
+                .thenThrow(new UnsupportedOperationException("Trade history query capability is not available"));
+
+        mockMvc.perform(get("/api/exchanges/{exchange}/trades", "COINBASE")
+                        .param("symbol", "BTCUSDT")
+                        .param("from", FROM.toString())
+                        .param("to", TO.toString()))
+                .andExpect(status().isNotImplemented())
+                .andExpect(jsonPath("$.status").value(501));
+    }
+
+    private static ExchangeBalanceSnapshot snapshot(BalanceDto... balances) {
+        return new ExchangeBalanceSnapshot(EXCHANGE, List.of(balances), AS_OF);
+    }
+
+    private static TradeExecutionDto fill() {
+        return new TradeExecutionDto(
+                "trade-1", 100234L, null, "BTCUSDT",
+                new BigDecimal("50000"), new BigDecimal("0.01"),
+                new BigDecimal("500"), new BigDecimal("0.0001"), "BNB",
+                Instant.parse("2026-01-01T10:00:00Z"), true);
+    }
+}


### PR DESCRIPTION
> **PR empilhado sobre o T27 (#123).** A base é `feature/controller-response-standardization`, não `develop`, porque estes endpoints usam o `ApiError`/`GlobalExceptionHandler` que ainda não estão em `develop`. Rebasear para `develop` quando o #123 for mergeado.

## Summary
- Expõe via HTTP os caminhos agnósticos de **saldo** (T29) e **histórico de trades** (T30), seguindo o padrão de retorno do T27.
- **`ExchangeQueryController`** (`/api/exchanges`): `GET /{exchange}/balances` (com filtro opcional `?asset=` aplicado na borda via `ExchangeBalanceSnapshot#balanceOf`) e `GET /{exchange}/trades` (`?symbol&from&to`). Controllers finos — erros sobem para o handler global.
- **`ExchangeQueryConfig`**: registra o bean `QueryTradeHistoryPort` (deferido no T30), ao lado do de saldo.
- **`GlobalExceptionHandler`**: novo mapeamento `UnsupportedOperationException` → **501 Not Implemented** (exchange não suporta a capacidade consultada). `IllegalArgumentException` (exchange não registrada / intervalo inválido) → 400; `ExchangeQueryException` → 502 já existentes.

## Validation
- `./scripts/gradle-run.ps1 :spring-application:test --tests "...ExchangeQueryControllerTest"`: passed (8 casos: snapshot completo, filtro por asset, asset ausente, exchange desconhecida→400, capacidade ausente→501, fills, intervalo inválido→400, histórico não suportado→501)
- Compilação de `:spring-application` (main + test): passed

## Documentation
- README atualizado com os dois endpoints. Sem impacto em `docs/` de negócio.

## Scope notes
- Reusa os DTOs/contratos já mergeados (`ExchangeBalanceSnapshot`/`BalanceDto` do T29, `TradeExecutionDto` do T30); nenhum core novo.
- O endpoint de saldo retorna `ExchangeBalanceSnapshot` sempre; com `?asset=`, devolve um snapshot com 0 ou 1 saldo (mantém um só contrato de resposta).