### PR TITLE
feat(T21): notificação ativa de erro terminal via Discord (Camada 1)

### DIFF
--- a/.ai/tasks/T21-active-error-reporting-discord.md
+++ b/.ai/tasks/T21-active-error-reporting-discord.md
@@ -3,13 +3,20 @@
 **Complexidade:** Média  
 **Responsável:** Claude  
 **Dependências:** T17 (Loki + Grafana já no stack)  
-**Status:** Em andamento — Camada 1 (código) entregue; Camadas 2 e 3 (Grafana/logs) pendentes
+**Status:** Concluído
 
-> **Progresso Camada 1:** `ErrorNotificationPort` no core + `DiscordWebhookNotificationAdapter`
+> **Camada 1 (código):** `ErrorNotificationPort` no core + `DiscordWebhookNotificationAdapter`
 > (no-op quando `DISCORD_WEBHOOK_URL` vazio, envio assíncrono e tolerante a falha), com disparo
-> em `CapitalEventListener` (DLQ persistido) e `BootAlertListener` (boot fail-fast). Atende os
-> critérios de aceitação 1-4. Critérios 5-6 (alert rules Grafana e link Loki provisionado)
-> dependem das Camadas 2/3.
+> em `CapitalEventListener` (DLQ persistido) e `BootAlertListener` (boot fail-fast). Critérios 1-4.
+>
+> **Camada 2 (Grafana):** provisioning em `docker/grafana/provisioning/alerting/` — contact point
+> Discord (`$__env{DISCORD_WEBHOOK_URL}`), notification policy roteando por `channel=alerts-behavior`
+> e 6 alert rules sobre o Loki. `DISCORD_WEBHOOK_URL` passado ao container do Grafana no compose.
+> Validado subindo o stack: `finished to provision alerting` sem erros e rules avaliando contra o Loki.
+>
+> **Camada 3 (logs):** enriquecimento dos logs sentinel de baixa qualidade em `RunBootSequenceUseCase`
+> (`runId` + contagens) e `ProcessMessageEventListener` (`correlationId`); alert rules de ausência
+> (`no-fills-confirmed`, `no-orders-submitted`, `boot-recovery-errors`) incluídas na Camada 2.
 
 ---
 

--- a/.ai/tasks/T21-active-error-reporting-discord.md
+++ b/.ai/tasks/T21-active-error-reporting-discord.md
@@ -3,7 +3,13 @@
 **Complexidade:** Média  
 **Responsável:** Claude  
 **Dependências:** T17 (Loki + Grafana já no stack)  
-**Status:** Pendente
+**Status:** Em andamento — Camada 1 (código) entregue; Camadas 2 e 3 (Grafana/logs) pendentes
+
+> **Progresso Camada 1:** `ErrorNotificationPort` no core + `DiscordWebhookNotificationAdapter`
+> (no-op quando `DISCORD_WEBHOOK_URL` vazio, envio assíncrono e tolerante a falha), com disparo
+> em `CapitalEventListener` (DLQ persistido) e `BootAlertListener` (boot fail-fast). Atende os
+> critérios de aceitação 1-4. Critérios 5-6 (alert rules Grafana e link Loki provisionado)
+> dependem das Camadas 2/3.
 
 ---
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/boot/RunBootSequenceUseCase.java
@@ -141,7 +141,7 @@ public class RunBootSequenceUseCase implements RunBootSequencePort {
                     exchange, readiness.code(), readiness.message());
         }
 
-        log.info("bootSequence.phase1: completed exchanges={}", exchanges.size());
+        log.info("bootSequence.phase1: completed runId={} exchanges={}", runId, exchanges.size());
     }
 
     private void runPhase2PortfolioSanity(String runId,
@@ -200,7 +200,7 @@ public class RunBootSequenceUseCase implements RunBootSequencePort {
             }
         }
 
-        log.info("bootSequence.phase2.sanity: completed");
+        log.info("bootSequence.phase2.sanity: completed runId={} portfolios={}", runId, portfolios.size());
     }
 
     private void runPhase2ZombieDetection(String runId,
@@ -212,6 +212,7 @@ public class RunBootSequenceUseCase implements RunBootSequencePort {
         log.info("bootSequence.phase2.zombie: start portfolios={} mode={} cutoffEnabled={}",
                 portfolios.size(), mode, command.cutoffEnabled());
 
+        int zombiesTotal = 0;
         for (Portfolio portfolio : portfolios) {
             Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
             if (exchanges.isEmpty()) {
@@ -223,6 +224,7 @@ public class RunBootSequenceUseCase implements RunBootSequencePort {
                 PortfolioZombieDetectionResult result =
                         portfolioZombieDetectionUseCase.execute(portfolio.getId(), exchange, command.cutoffEnabled());
                 long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+                zombiesTotal += result.zombieCount();
                 observer.onPortfolioPhaseEvaluated("phase2.zombie", result.status().name(), exchange, mode.name(), durationMs);
 
                 switch (result.status()) {
@@ -264,7 +266,7 @@ public class RunBootSequenceUseCase implements RunBootSequencePort {
             }
         }
 
-        log.info("bootSequence.phase2.zombie: completed");
+        log.info("bootSequence.phase2.zombie: completed runId={} zombies={}", runId, zombiesTotal);
     }
 
     private void runPhase2ReservationTtl(String runId,
@@ -276,6 +278,7 @@ public class RunBootSequenceUseCase implements RunBootSequencePort {
         BootFailureMode mode = command.failureMode();
         log.info("bootSequence.phase2.ttl: start portfolios={} mode={} ttlMs={}", portfolios.size(), mode, ttlMs);
 
+        int expiredTotal = 0;
         for (Portfolio portfolio : portfolios) {
             Set<String> exchanges = resolvePortfolioExchanges(portfolio, eligibleRunners);
             if (exchanges.isEmpty()) {
@@ -292,6 +295,7 @@ public class RunBootSequenceUseCase implements RunBootSequencePort {
                 PortfolioReservationTtlResult result =
                         portfolioReservationTtlUseCase.execute(portfolio.getId(), exchange, ttlMs, scopedRunners);
                 long durationMs = (System.nanoTime() - startedNs) / 1_000_000L;
+                expiredTotal += result.expiredCount();
                 observer.onPortfolioPhaseEvaluated("phase2.reservation_ttl", result.status().name(), exchange, mode.name(), durationMs);
 
                 switch (result.status()) {
@@ -332,7 +336,7 @@ public class RunBootSequenceUseCase implements RunBootSequencePort {
             }
         }
 
-        log.info("bootSequence.phase2.ttl: completed");
+        log.info("bootSequence.phase2.ttl: completed runId={} expired={}", runId, expiredTotal);
     }
 
     private void executePhase(String phase, boolean enabled, Runnable action, BootExecutionObserverPort observer) {

--- a/core/src/main/java/com/marmitt/core/dto/notification/ErrorNotificationEvent.java
+++ b/core/src/main/java/com/marmitt/core/dto/notification/ErrorNotificationEvent.java
@@ -1,0 +1,43 @@
+package com.marmitt.core.dto.notification;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Evento de erro terminal a ser notificado ativamente ao operador (ex.: Discord).
+ *
+ * <p>Contrato agnóstico de canal: descreve o que aconteceu e o contexto mínimo para o
+ * operador agir, sem conhecer detalhes de transporte (webhook, embed, etc.). Os campos
+ * de contexto são anuláveis porque nem todo disparo dispõe de todos eles.
+ *
+ * @param type          categoria do erro
+ * @param title         título curto e legível
+ * @param description   detalhe do erro (causa, fase, etc.)
+ * @param correlationId id de correlação para rastrear nos logs (nullable)
+ * @param runnerId      runner associado, quando aplicável (nullable)
+ * @param dlqId         id da dead letter entry, quando aplicável (nullable)
+ * @param occurredAt    momento da ocorrência
+ */
+public record ErrorNotificationEvent(
+        ErrorNotificationType type,
+        String title,
+        String description,
+        String correlationId,
+        UUID runnerId,
+        UUID dlqId,
+        Instant occurredAt
+) {
+
+    public static ErrorNotificationEvent dlqPersisted(String title, String description,
+                                                      String correlationId, UUID runnerId, UUID dlqId,
+                                                      Instant occurredAt) {
+        return new ErrorNotificationEvent(ErrorNotificationType.DLQ_PERSISTED, title, description,
+                correlationId, runnerId, dlqId, occurredAt);
+    }
+
+    public static ErrorNotificationEvent bootFailFast(String title, String description,
+                                                      String correlationId, Instant occurredAt) {
+        return new ErrorNotificationEvent(ErrorNotificationType.BOOT_FAIL_FAST, title, description,
+                correlationId, null, null, occurredAt);
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/notification/ErrorNotificationType.java
+++ b/core/src/main/java/com/marmitt/core/dto/notification/ErrorNotificationType.java
@@ -1,0 +1,14 @@
+package com.marmitt.core.dto.notification;
+
+/**
+ * Categoria de um erro terminal reportado ativamente ao operador.
+ *
+ * <ul>
+ *   <li>{@link #DLQ_PERSISTED} — um evento esgotou os retries e foi persistido na dead letter queue.</li>
+ *   <li>{@link #BOOT_FAIL_FAST} — o boot abortou em modo fail-fast.</li>
+ * </ul>
+ */
+public enum ErrorNotificationType {
+    DLQ_PERSISTED,
+    BOOT_FAIL_FAST
+}

--- a/core/src/main/java/com/marmitt/core/ports/outbound/notification/ErrorNotificationPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/notification/ErrorNotificationPort.java
@@ -1,0 +1,15 @@
+package com.marmitt.core.ports.outbound.notification;
+
+import com.marmitt.core.dto.notification.ErrorNotificationEvent;
+
+/**
+ * Porta de saída para reportar ativamente erros terminais ao operador.
+ *
+ * <p>Implementações (ex.: webhook Discord) devem ser <b>tolerantes a falha</b>: nunca
+ * propagar exceção nem bloquear o fluxo principal — a notificação é colateral ao
+ * tratamento do erro, não parte dele.
+ */
+public interface ErrorNotificationPort {
+
+    void notifyError(ErrorNotificationEvent event);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: ctrade123
       GF_USERS_ALLOW_SIGN_UP: "false"
+      # Usado pelo contact point Discord provisionado (docker/grafana/provisioning/alerting).
+      # Sem a env var os alertas comportamentais disparam mas não entregam no Discord.
+      DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL:-}
     volumes:
       - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro
       - grafana_data:/var/lib/grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,10 @@ services:
       BINANCE_API_KEY: ${BINANCE_API_KEY:-}
       BINANCE_API_SECRET: ${BINANCE_API_SECRET:-}
       ADMIN_API_KEY: ${ADMIN_API_KEY:-}
+      # Compose só injeta variáveis explicitamente listadas; sem isto o adapter Discord
+      # ficaria em no-op dentro do container mesmo com DISCORD_WEBHOOK_URL setado no host.
+      DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL:-}
+      GRAFANA_EXPLORE_URL_TEMPLATE: ${GRAFANA_EXPLORE_URL_TEMPLATE:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/grafana/provisioning/alerting/contactpoints.yml
+++ b/docker/grafana/provisioning/alerting/contactpoints.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+# Contact point Discord para alertas comportamentais (T21 — Camada 2).
+# A URL vem da env var DISCORD_WEBHOOK_URL passada ao container do Grafana.
+# Sem a env var o contact point fica sem destino — os alertas disparam mas não entregam.
+contactPoints:
+  - orgId: 1
+    name: discord
+    receivers:
+      - uid: discord-behavior
+        type: discord
+        settings:
+          url: $__env{DISCORD_WEBHOOK_URL}
+        disableResolveMessage: false

--- a/docker/grafana/provisioning/alerting/contactpoints.yml
+++ b/docker/grafana/provisioning/alerting/contactpoints.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 # Contact point Discord para alertas comportamentais (T21 — Camada 2).
 # A URL vem da env var DISCORD_WEBHOOK_URL passada ao container do Grafana.
+# Provisioning de alerting expande ${VAR}; a forma $__env{} é do provider grafana.ini.
 # Sem a env var o contact point fica sem destino — os alertas disparam mas não entregam.
 contactPoints:
   - orgId: 1
@@ -10,5 +11,5 @@ contactPoints:
       - uid: discord-behavior
         type: discord
         settings:
-          url: $__env{DISCORD_WEBHOOK_URL}
+          url: ${DISCORD_WEBHOOK_URL}
         disableResolveMessage: false

--- a/docker/grafana/provisioning/alerting/policies.yml
+++ b/docker/grafana/provisioning/alerting/policies.yml
@@ -1,0 +1,20 @@
+apiVersion: 1
+
+# Árvore de notificação: por padrão tudo vai para o contact point 'discord'.
+# Alertas com label channel=alerts-behavior são agrupados de forma independente
+# para facilitar a triagem (separados dos alertas de erro terminal).
+policies:
+  - orgId: 1
+    receiver: discord
+    group_by:
+      - grafana_folder
+      - alertname
+    routes:
+      - receiver: discord
+        object_matchers:
+          - ['channel', '=', 'alerts-behavior']
+        group_by:
+          - alertname
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h

--- a/docker/grafana/provisioning/alerting/rules.yml
+++ b/docker/grafana/provisioning/alerting/rules.yml
@@ -1,0 +1,191 @@
+apiVersion: 1
+
+# Alert rules comportamentais sobre os logs no Loki (T21 — Camadas 2 e 3).
+# Todas roteiam para o Discord via label channel=alerts-behavior.
+groups:
+  - orgId: 1
+    name: ctrade-behavior
+    folder: ctrade-alerts
+    interval: 1m
+    rules:
+      # --- Camada 2: anomalias por taxa ---
+      - uid: ctrade-warn-rate-high
+        title: Alta taxa de WARN
+        condition: C
+        for: 2m
+        labels:
+          channel: alerts-behavior
+          severity: warning
+        annotations:
+          summary: 'Taxa de logs WARN elevada nos últimos 5 min'
+        noDataState: OK
+        execErrState: OK
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: loki
+            model:
+              datasource: { type: loki, uid: loki }
+              expr: 'sum(count_over_time({app="ctrade", level="WARN"} [5m]))'
+              queryType: instant
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [150] }
+              refId: C
+
+      - uid: ctrade-error-spike
+        title: Spike de ERROR
+        condition: C
+        for: 0m
+        labels:
+          channel: alerts-behavior
+          severity: critical
+        annotations:
+          summary: 'Spike de logs ERROR no último minuto'
+        noDataState: OK
+        execErrState: OK
+        data:
+          - refId: A
+            relativeTimeRange: { from: 60, to: 0 }
+            datasourceUid: loki
+            model:
+              datasource: { type: loki, uid: loki }
+              expr: 'sum(count_over_time({app="ctrade", level="ERROR"} [1m]))'
+              queryType: instant
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [6] }
+              refId: C
+
+      - uid: ctrade-reconnect-frequent
+        title: Reconexões frequentes
+        condition: C
+        for: 1m
+        labels:
+          channel: alerts-behavior
+          severity: warning
+        annotations:
+          summary: 'Frequência de reconexão acima do esperado (> 3/min em 5 min)'
+        noDataState: OK
+        execErrState: OK
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: loki
+            model:
+              datasource: { type: loki, uid: loki }
+              expr: 'sum(count_over_time({app="ctrade"} |= `reconnect` [5m]))'
+              queryType: instant
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [15] }
+              refId: C
+
+      # --- Camada 3: ausência de sinais de fluxo (logs sentinel) ---
+      - uid: ctrade-no-fills-confirmed
+        title: Nenhum fill confirmado
+        condition: C
+        for: 0m
+        labels:
+          channel: alerts-behavior
+          severity: warning
+        annotations:
+          summary: 'Nenhum executionConfirmedReaction final nos últimos 10 min'
+        noDataState: Alerting
+        execErrState: OK
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: loki
+            model:
+              datasource: { type: loki, uid: loki }
+              expr: 'sum(count_over_time({app="ctrade"} |= `executionConfirmedReaction:` |~ `isFinal=true` [10m]))'
+              queryType: instant
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+              refId: C
+
+      - uid: ctrade-no-orders-submitted
+        title: Nenhuma ordem submetida
+        condition: C
+        for: 0m
+        labels:
+          channel: alerts-behavior
+          severity: warning
+        annotations:
+          summary: 'Nenhuma transição PENDING->SUBMITTED nos últimos 30 min'
+        noDataState: Alerting
+        execErrState: OK
+        data:
+          - refId: A
+            relativeTimeRange: { from: 1800, to: 0 }
+            datasourceUid: loki
+            model:
+              datasource: { type: loki, uid: loki }
+              expr: 'sum(count_over_time({app="ctrade"} |= `PENDING->SUBMITTED` [30m]))'
+              queryType: instant
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+              refId: C
+
+      - uid: ctrade-boot-recovery-errors
+        title: Boot recovery com erros
+        condition: C
+        for: 0m
+        labels:
+          channel: alerts-behavior
+          severity: critical
+        annotations:
+          summary: 'bootRecovery: completed com hasErrors=true'
+        noDataState: OK
+        execErrState: OK
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: loki
+            model:
+              datasource: { type: loki, uid: loki }
+              expr: 'sum(count_over_time({app="ctrade"} |= `bootRecovery: completed` |~ `hasErrors=true` [10m]))'
+              queryType: instant
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+              refId: C

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -26,7 +26,7 @@ Trilha de tarefas para habilitar operação com a API da Binance (testnet), pré
 | T18 | Trade Reconciliation Report                                      | Média | Claude | Concluído |
 | T19 | Serializar conciliação por clientOrderId via striped lock        | Baixa | Codex  | Concluído |
 | T20 | Preencher `executed_at` com timestamp da exchange no boot recovery | Baixa | Codex | Concluído |
-| T21 | Active Error Reporting via Discord                               | Média | Claude | Pendente  |
+| T21 | Active Error Reporting via Discord                               | Média | Claude | Concluído |
 | T22 | Estudo e Desenho do Sistema de Monitoramento                    | Média | Claude | Concluído |
 | T23 | Instrumentação: Gaps Críticos de Observabilidade                | Média | Claude | Pendente  |
 | T24 | Circuit Breaker nas Chamadas REST à Exchange                    | Média | Claude | Pendente  |

--- a/spring-application/src/main/java/com/marmitt/application/spring/adapter/notification/DiscordWebhookNotificationAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/adapter/notification/DiscordWebhookNotificationAdapter.java
@@ -1,0 +1,118 @@
+package com.marmitt.application.spring.adapter.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marmitt.core.dto.notification.ErrorNotificationEvent;
+import com.marmitt.core.ports.outbound.notification.ErrorNotificationPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.UUID;
+
+/**
+ * Reporta erros terminais para um webhook Discord como embed.
+ *
+ * <p><b>Tolerante a falha:</b> se {@code webhookUrl} for vazio o adapter é no-op; o envio é
+ * assíncrono (fire-and-forget) e qualquer falha de rede/HTTP é apenas logada — nunca propaga
+ * exceção nem bloqueia o caller (boot/DLQ).
+ */
+@Slf4j
+public class DiscordWebhookNotificationAdapter implements ErrorNotificationPort {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    private final String webhookUrl;
+    private final String grafanaExploreTemplate;
+    private final ObjectMapper objectMapper;
+    private final HttpClient httpClient;
+
+    public DiscordWebhookNotificationAdapter(String webhookUrl, String grafanaExploreTemplate,
+                                             ObjectMapper objectMapper, HttpClient httpClient) {
+        this.webhookUrl = webhookUrl;
+        this.grafanaExploreTemplate = grafanaExploreTemplate;
+        this.objectMapper = objectMapper;
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public void notifyError(ErrorNotificationEvent event) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            return; // Discord não configurado — no-op
+        }
+        try {
+            String payload = buildPayload(event);
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(webhookUrl))
+                    .timeout(TIMEOUT)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payload))
+                    .build();
+
+            httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .whenComplete((response, error) -> {
+                        if (error != null) {
+                            log.error("discord notification failed type={} title={} reason={}",
+                                    event.type(), event.title(), error.getMessage());
+                        } else if (response.statusCode() >= 300) {
+                            log.error("discord notification rejected type={} status={} body={}",
+                                    event.type(), response.statusCode(), response.body());
+                        }
+                    });
+        } catch (Exception e) {
+            // Montagem do payload não deve derrubar o fluxo de erro principal.
+            log.error("discord notification error type={} title={} reason={}",
+                    event.type(), event.title(), e.getMessage());
+        }
+    }
+
+    private String buildPayload(ErrorNotificationEvent event) throws Exception {
+        ObjectNode embed = objectMapper.createObjectNode();
+        embed.put("title", "[" + event.type() + "] " + event.title());
+        if (event.description() != null) {
+            embed.put("description", event.description());
+        }
+        String lokiLink = lokiLink(event.correlationId());
+        if (lokiLink != null) {
+            embed.put("url", lokiLink);
+        }
+        if (event.occurredAt() != null) {
+            embed.put("timestamp", event.occurredAt().toString());
+        }
+
+        ArrayNode fields = embed.putArray("fields");
+        addField(fields, "Reason", event.type().name());
+        addField(fields, "Runner", asText(event.runnerId()));
+        addField(fields, "DLQ ID", asText(event.dlqId()));
+        addField(fields, "CorrelationId", event.correlationId());
+
+        ObjectNode root = objectMapper.createObjectNode();
+        root.putArray("embeds").add(embed);
+        return objectMapper.writeValueAsString(root);
+    }
+
+    private void addField(ArrayNode fields, String name, String value) {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        ObjectNode field = fields.addObject();
+        field.put("name", name);
+        field.put("value", value);
+        field.put("inline", true);
+    }
+
+    private String lokiLink(String correlationId) {
+        if (grafanaExploreTemplate == null || grafanaExploreTemplate.isBlank() || correlationId == null) {
+            return null;
+        }
+        return grafanaExploreTemplate.replace("{correlationId}", correlationId);
+    }
+
+    private static String asText(UUID value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/adapter/notification/DiscordWebhookNotificationAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/adapter/notification/DiscordWebhookNotificationAdapter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marmitt.core.dto.notification.ErrorNotificationEvent;
+import com.marmitt.core.dto.notification.ErrorNotificationType;
 import com.marmitt.core.ports.outbound.notification.ErrorNotificationPort;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,6 +14,10 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Reporta erros terminais para um webhook Discord como embed.
@@ -20,11 +25,16 @@ import java.util.UUID;
  * <p><b>Tolerante a falha:</b> se {@code webhookUrl} for vazio o adapter é no-op; o envio é
  * assíncrono (fire-and-forget) e qualquer falha de rede/HTTP é apenas logada — nunca propaga
  * exceção nem bloqueia o caller (boot/DLQ).
+ *
+ * <p><b>Boot fail-fast:</b> para {@link ErrorNotificationType#BOOT_FAIL_FAST} o caller relança
+ * a exceção e o processo encerra logo em seguida; nesse caso esperamos a entrega de forma
+ * limitada (flush) para que o alerta saia antes do shutdown, ainda engolindo qualquer falha.
  */
 @Slf4j
 public class DiscordWebhookNotificationAdapter implements ErrorNotificationPort {
 
     private static final Duration TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration FLUSH_TIMEOUT = Duration.ofSeconds(6);
 
     private final String webhookUrl;
     private final String grafanaExploreTemplate;
@@ -53,20 +63,40 @@ public class DiscordWebhookNotificationAdapter implements ErrorNotificationPort 
                     .POST(HttpRequest.BodyPublishers.ofString(payload))
                     .build();
 
-            httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
-                    .whenComplete((response, error) -> {
-                        if (error != null) {
-                            log.error("discord notification failed type={} title={} reason={}",
-                                    event.type(), event.title(), error.getMessage());
-                        } else if (response.statusCode() >= 300) {
-                            log.error("discord notification rejected type={} status={} body={}",
-                                    event.type(), response.statusCode(), response.body());
-                        }
-                    });
+            CompletableFuture<HttpResponse<String>> future =
+                    httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                            .whenComplete((response, error) -> {
+                                if (error != null) {
+                                    log.error("discord notification failed type={} title={} reason={}",
+                                            event.type(), event.title(), error.getMessage());
+                                } else if (response.statusCode() >= 300) {
+                                    log.error("discord notification rejected type={} status={} body={}",
+                                            event.type(), response.statusCode(), response.body());
+                                }
+                            });
+
+            if (event.type() == ErrorNotificationType.BOOT_FAIL_FAST) {
+                awaitFlush(future);
+            }
         } catch (Exception e) {
             // Montagem do payload não deve derrubar o fluxo de erro principal.
             log.error("discord notification error type={} title={} reason={}",
                     event.type(), event.title(), e.getMessage());
+        }
+    }
+
+    /**
+     * Espera (limitada) a conclusão do envio para o caminho fail-fast, sem propagar falha.
+     * Erro/timeout já são logados pelo {@code whenComplete}; aqui apenas garantimos que o
+     * processo não aborte antes de tentar entregar, nem bloqueie além de {@link #FLUSH_TIMEOUT}.
+     */
+    private void awaitFlush(CompletableFuture<?> future) {
+        try {
+            future.get(FLUSH_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException | ExecutionException e) {
+            // já tratado/logado no whenComplete — não propagar
         }
     }
 

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/notification/NotificationConfig.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/notification/NotificationConfig.java
@@ -1,0 +1,40 @@
+package com.marmitt.application.spring.config.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.application.spring.adapter.notification.DiscordWebhookNotificationAdapter;
+import com.marmitt.core.ports.outbound.notification.ErrorNotificationPort;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+/**
+ * Wiring das notificações ativas de erro (T21 — Camada 1).
+ *
+ * <p>Registra sempre um {@link ErrorNotificationPort}; quando o webhook não está configurado,
+ * o adapter opera em modo no-op, então os listeners podem depender do port incondicionalmente.
+ */
+@Configuration
+@EnableConfigurationProperties(NotificationProperties.class)
+public class NotificationConfig {
+
+    @Bean
+    public HttpClient notificationHttpClient() {
+        return HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @Bean
+    public ErrorNotificationPort errorNotificationPort(NotificationProperties properties,
+                                                       ObjectMapper objectMapper,
+                                                       HttpClient notificationHttpClient) {
+        return new DiscordWebhookNotificationAdapter(
+                properties.getDiscord().getWebhookUrl(),
+                properties.getGrafana().getExploreUrlTemplate(),
+                objectMapper,
+                notificationHttpClient);
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/config/notification/NotificationProperties.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/config/notification/NotificationProperties.java
@@ -1,0 +1,51 @@
+package com.marmitt.application.spring.config.notification;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuração das notificações ativas de erro.
+ *
+ * <p>{@code discord.webhook-url} vazio mantém o adapter como no-op — a aplicação sobe
+ * normalmente sem Discord configurado. {@code grafana.explore-url-template} é opcional e,
+ * quando presente, gera o link "ver logs" usando {@code {correlationId}} como placeholder.
+ */
+@ConfigurationProperties(prefix = "notification")
+public class NotificationProperties {
+
+    private final Discord discord = new Discord();
+    private final Grafana grafana = new Grafana();
+
+    public Discord getDiscord() {
+        return discord;
+    }
+
+    public Grafana getGrafana() {
+        return grafana;
+    }
+
+    public static class Discord {
+        /** URL do webhook Discord. Vazio ⇒ adapter no-op. */
+        private String webhookUrl = "";
+
+        public String getWebhookUrl() {
+            return webhookUrl;
+        }
+
+        public void setWebhookUrl(String webhookUrl) {
+            this.webhookUrl = webhookUrl;
+        }
+    }
+
+    public static class Grafana {
+        /** Template de URL do Grafana Explore; {@code {correlationId}} é substituído. Vazio ⇒ sem link. */
+        private String exploreUrlTemplate = "";
+
+        public String getExploreUrlTemplate() {
+            return exploreUrlTemplate;
+        }
+
+        public void setExploreUrlTemplate(String exploreUrlTemplate) {
+            this.exploreUrlTemplate = exploreUrlTemplate;
+        }
+    }
+}

--- a/spring-application/src/main/java/com/marmitt/application/spring/handler/BootAlertListener.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/handler/BootAlertListener.java
@@ -1,6 +1,8 @@
 package com.marmitt.application.spring.handler;
 
 import com.marmitt.application.spring.bootstrap.BootFailFastEvent;
+import com.marmitt.core.dto.notification.ErrorNotificationEvent;
+import com.marmitt.core.ports.outbound.notification.ErrorNotificationPort;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -9,9 +11,21 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class BootAlertListener {
 
+    private final ErrorNotificationPort errorNotification;
+
+    public BootAlertListener(ErrorNotificationPort errorNotification) {
+        this.errorNotification = errorNotification;
+    }
+
     @EventListener
     public void onBootFailFast(BootFailFastEvent event) {
         log.error("BOOT_FAILFAST_ALERT: runId={} phase={} code={} message={} at={}",
                 event.runId(), event.phase(), event.code(), event.message(), event.timestamp());
+
+        errorNotification.notifyError(ErrorNotificationEvent.bootFailFast(
+                "Boot fail-fast: " + event.phase(),
+                "code=" + event.code() + " message=" + event.message(),
+                event.runId(),
+                event.timestamp()));
     }
 }

--- a/spring-application/src/main/java/com/marmitt/application/spring/handler/CapitalEventListener.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/handler/CapitalEventListener.java
@@ -6,10 +6,13 @@ import com.marmitt.core.application.reaction.MarginReleasedReaction;
 import com.marmitt.core.domain.portfolio.DeadLetterEntry;
 import com.marmitt.core.dto.events.ExecutionConfirmedEvent;
 import com.marmitt.core.dto.events.MarginReleaseEvent;
+import com.marmitt.core.dto.notification.ErrorNotificationEvent;
 import com.marmitt.core.enums.DlqReason;
+import com.marmitt.core.ports.outbound.notification.ErrorNotificationPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.dao.PessimisticLockingFailureException;
@@ -23,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -40,19 +44,22 @@ public class CapitalEventListener {
     private final StrategyRunnerRepositoryPort strategyRunnerRepository;
     private final DeadLetterEntryRepositoryPort deadLetterEntryRepository;
     private final CapitalDeadLetterPayloadCodec payloadCodec;
+    private final ErrorNotificationPort errorNotification;
 
     public CapitalEventListener(
             ExecutionConfirmedReaction handleExecutionConfirmed,
             MarginReleasedReaction handleMarginRelease,
             StrategyRunnerRepositoryPort strategyRunnerRepository,
             DeadLetterEntryRepositoryPort deadLetterEntryRepository,
-            CapitalDeadLetterPayloadCodec payloadCodec
+            CapitalDeadLetterPayloadCodec payloadCodec,
+            ErrorNotificationPort errorNotification
     ) {
         this.handleExecutionConfirmed = handleExecutionConfirmed;
         this.handleMarginRelease = handleMarginRelease;
         this.strategyRunnerRepository = strategyRunnerRepository;
         this.deadLetterEntryRepository = deadLetterEntryRepository;
         this.payloadCodec = payloadCodec;
+        this.errorNotification = errorNotification;
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -151,6 +158,8 @@ public class CapitalEventListener {
                     safeMessage(originalFailure),
                     originalFailure
             );
+
+            notifyDlqPersisted(eventType, runnerId, entry.getId(), originalFailure);
         } catch (Exception persistFailure) {
             log.error(
                     "CAPITAL_DLQ: failed to persist dead letter entry - eventType={} portfolioId={} runnerId={} persistCause={} originalCause={}",
@@ -162,6 +171,16 @@ public class CapitalEventListener {
                     persistFailure
             );
         }
+    }
+
+    private void notifyDlqPersisted(String eventType, UUID runnerId, UUID dlqId, Exception originalFailure) {
+        errorNotification.notifyError(ErrorNotificationEvent.dlqPersisted(
+                "Capital event sent to DLQ",
+                eventType + " esgotou os retries: " + safeMessage(originalFailure),
+                MDC.get("correlationId"),
+                runnerId,
+                dlqId,
+                Instant.now()));
     }
 
     private static String safeMessage(Throwable throwable) {

--- a/spring-application/src/main/java/com/marmitt/application/spring/handler/ProcessMessageEventListener.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/handler/ProcessMessageEventListener.java
@@ -30,7 +30,9 @@ public class ProcessMessageEventListener {
             ProcessingResult<?> result = processMessagePort.execute(event.getRawMessage(), event.getContext());
 
             if (result.isSuccess() && result.getData().isPresent()) {
-                log.info("Processing SUCCESS - type={}", result.getData().get().getClass().getSimpleName());
+                log.info("Processing SUCCESS - type={} correlationId={}",
+                        result.getData().get().getClass().getSimpleName(),
+                        event.getContext().correlationId());
             } else if (result.isWarning() && result.getData().isPresent()) {
                 log.warn("Processing WARNING - type={} warning={} rawMessage={}",
                         result.getData().get().getClass().getSimpleName(),

--- a/spring-application/src/main/resources/application.yml
+++ b/spring-application/src/main/resources/application.yml
@@ -106,3 +106,11 @@ runner:
 admin:
   api:
     key: ${ADMIN_API_KEY:}
+
+notification:
+  discord:
+    # Vazio ⇒ notificações Discord desativadas (adapter no-op); a aplicação sobe normalmente.
+    webhook-url: ${DISCORD_WEBHOOK_URL:}
+  grafana:
+    # Opcional: template do link "ver logs" no Discord; {correlationId} é substituído em runtime.
+    explore-url-template: ${GRAFANA_EXPLORE_URL_TEMPLATE:}

--- a/spring-application/src/test/java/com/marmitt/application/spring/adapter/notification/DiscordWebhookNotificationAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/adapter/notification/DiscordWebhookNotificationAdapterTest.java
@@ -1,0 +1,106 @@
+package com.marmitt.application.spring.adapter.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marmitt.core.dto.notification.ErrorNotificationEvent;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class DiscordWebhookNotificationAdapterTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private MockWebServer server;
+    private HttpClient httpClient;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    void notifyError_isNoOpWhenWebhookBlank() {
+        DiscordWebhookNotificationAdapter adapter =
+                new DiscordWebhookNotificationAdapter("", "", MAPPER, httpClient);
+
+        adapter.notifyError(dlqEvent(UUID.randomUUID(), "abc-correlation"));
+
+        assertThat(server.getRequestCount()).isZero();
+    }
+
+    @Test
+    void notifyError_postsDiscordEmbedWhenConfigured() throws InterruptedException {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        UUID dlqId = UUID.randomUUID();
+        DiscordWebhookNotificationAdapter adapter = new DiscordWebhookNotificationAdapter(
+                server.url("/webhook").toString(),
+                "https://grafana.local/explore?cid={correlationId}",
+                MAPPER, httpClient);
+
+        adapter.notifyError(dlqEvent(dlqId, "corr-123"));
+
+        RecordedRequest request = server.takeRequest(2, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getHeader("Content-Type")).contains("application/json");
+        String body = request.getBody().readUtf8();
+        assertThat(body).contains("[DLQ_PERSISTED]");
+        assertThat(body).contains(dlqId.toString());
+        assertThat(body).contains("corr-123");
+        assertThat(body).contains("https://grafana.local/explore?cid=corr-123");
+    }
+
+    @Test
+    void notifyError_swallowsHttpErrorResponse() throws InterruptedException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+        DiscordWebhookNotificationAdapter adapter = new DiscordWebhookNotificationAdapter(
+                server.url("/webhook").toString(), "", MAPPER, httpClient);
+
+        assertThatCode(() -> adapter.notifyError(dlqEvent(UUID.randomUUID(), null)))
+                .doesNotThrowAnyException();
+
+        // request foi enviada (falha tratada no callback async, sem propagar)
+        assertThat(server.takeRequest(2, TimeUnit.SECONDS)).isNotNull();
+    }
+
+    @Test
+    void notifyError_swallowsConnectionFailure() throws IOException {
+        String deadUrl = server.url("/webhook").toString();
+        server.shutdown(); // ninguém escutando → falha de conexão
+
+        DiscordWebhookNotificationAdapter adapter =
+                new DiscordWebhookNotificationAdapter(deadUrl, "", MAPPER, httpClient);
+
+        assertThatCode(() -> adapter.notifyError(dlqEvent(UUID.randomUUID(), null)))
+                .doesNotThrowAnyException();
+    }
+
+    private static ErrorNotificationEvent dlqEvent(UUID dlqId, String correlationId) {
+        return ErrorNotificationEvent.dlqPersisted(
+                "Capital event sent to DLQ",
+                "MARGIN_RELEASE esgotou os retries: boom",
+                correlationId,
+                UUID.randomUUID(),
+                dlqId,
+                Instant.parse("2026-06-20T10:00:00Z"));
+    }
+}

--- a/spring-application/src/test/java/com/marmitt/application/spring/adapter/notification/DiscordWebhookNotificationAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/adapter/notification/DiscordWebhookNotificationAdapterTest.java
@@ -94,6 +94,32 @@ class DiscordWebhookNotificationAdapterTest {
                 .doesNotThrowAnyException();
     }
 
+    @Test
+    void notifyError_blocksUntilDeliveryForBootFailFast() {
+        // Boot fail-fast aborta o processo logo após publicar o evento: a entrega precisa
+        // ocorrer de forma síncrona (flush) para que o alerta saia antes do shutdown.
+        server.enqueue(new MockResponse().setResponseCode(204));
+        DiscordWebhookNotificationAdapter adapter = new DiscordWebhookNotificationAdapter(
+                server.url("/webhook").toString(), "", MAPPER, httpClient);
+
+        adapter.notifyError(bootFailFastEvent());
+
+        // Sem aguardar: a request já foi recebida ao retornar, provando o flush síncrono.
+        assertThat(server.getRequestCount()).isEqualTo(1);
+    }
+
+    @Test
+    void notifyError_swallowsConnectionFailureOnBootFailFast() throws IOException {
+        String deadUrl = server.url("/webhook").toString();
+        server.shutdown(); // ninguém escutando → falha de conexão durante o flush
+
+        DiscordWebhookNotificationAdapter adapter =
+                new DiscordWebhookNotificationAdapter(deadUrl, "", MAPPER, httpClient);
+
+        assertThatCode(() -> adapter.notifyError(bootFailFastEvent()))
+                .doesNotThrowAnyException();
+    }
+
     private static ErrorNotificationEvent dlqEvent(UUID dlqId, String correlationId) {
         return ErrorNotificationEvent.dlqPersisted(
                 "Capital event sent to DLQ",
@@ -101,6 +127,14 @@ class DiscordWebhookNotificationAdapterTest {
                 correlationId,
                 UUID.randomUUID(),
                 dlqId,
+                Instant.parse("2026-06-20T10:00:00Z"));
+    }
+
+    private static ErrorNotificationEvent bootFailFastEvent() {
+        return ErrorNotificationEvent.bootFailFast(
+                "Boot fail-fast: phase1.infrastructure",
+                "code=READINESS_FAILED message=exchange unavailable",
+                "boot-run-1",
                 Instant.parse("2026-06-20T10:00:00Z"));
     }
 }

--- a/spring-application/src/test/java/com/marmitt/application/spring/handler/CapitalEventListenerTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/handler/CapitalEventListenerTest.java
@@ -11,11 +11,14 @@ import com.marmitt.core.dto.capital.ExecutionConfirmation;
 import com.marmitt.core.dto.capital.MarginRelease;
 import com.marmitt.core.dto.events.ExecutionConfirmedEvent;
 import com.marmitt.core.dto.events.MarginReleaseEvent;
+import com.marmitt.core.dto.notification.ErrorNotificationEvent;
+import com.marmitt.core.dto.notification.ErrorNotificationType;
 import com.marmitt.core.enums.AccountingPolicyType;
 import com.marmitt.core.enums.DlqReason;
 import com.marmitt.core.enums.ExecutionPolicy;
 import com.marmitt.core.enums.ReleaseReason;
 import com.marmitt.core.enums.RunnerStatus;
+import com.marmitt.core.ports.outbound.notification.ErrorNotificationPort;
 import com.marmitt.core.ports.outbound.repository.DeadLetterEntryRepositoryPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import org.junit.jupiter.api.Test;
@@ -45,12 +48,14 @@ class CapitalEventListenerTest {
         MarginReleasedReaction marginReaction = mock(MarginReleasedReaction.class);
         StrategyRunnerRepositoryPort runnerRepository = mock(StrategyRunnerRepositoryPort.class);
         DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
+        ErrorNotificationPort notification = mock(ErrorNotificationPort.class);
         CapitalEventListener listener = new CapitalEventListener(
                 executionReaction,
                 marginReaction,
                 runnerRepository,
                 deadLetterRepository,
-                payloadCodec()
+                payloadCodec(),
+                notification
         );
         ExecutionConfirmedEvent event = executionConfirmedEvent(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
 
@@ -66,12 +71,14 @@ class CapitalEventListenerTest {
         MarginReleasedReaction marginReaction = mock(MarginReleasedReaction.class);
         StrategyRunnerRepositoryPort runnerRepository = mock(StrategyRunnerRepositoryPort.class);
         DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
+        ErrorNotificationPort notification = mock(ErrorNotificationPort.class);
         CapitalEventListener listener = new CapitalEventListener(
                 executionReaction,
                 marginReaction,
                 runnerRepository,
                 deadLetterRepository,
-                payloadCodec()
+                payloadCodec(),
+                notification
         );
         MarginReleaseEvent event = marginReleaseEvent(UUID.randomUUID(), UUID.randomUUID());
 
@@ -90,12 +97,14 @@ class CapitalEventListenerTest {
         UUID portfolioId = UUID.randomUUID();
         UUID runnerId = UUID.randomUUID();
         when(runnerRepository.findById(runnerId)).thenReturn(Optional.of(activeRunner(portfolioId, runnerId)));
+        ErrorNotificationPort notification = mock(ErrorNotificationPort.class);
         CapitalEventListener listener = new CapitalEventListener(
                 executionReaction,
                 marginReaction,
                 runnerRepository,
                 deadLetterRepository,
-                payloadCodec()
+                payloadCodec(),
+                notification
         );
         ExecutionConfirmedEvent event = executionConfirmedEvent(UUID.randomUUID(), runnerId, UUID.randomUUID());
         RuntimeException failure = new RuntimeException("temporary failure");
@@ -112,6 +121,13 @@ class CapitalEventListenerTest {
         assertTrue(entry.getRawPayload().contains("\"transactionId\":\"" + event.confirmation().transactionId() + "\""));
         assertTrue(entry.getRawPayload().contains("\"matchId\":\"" + event.confirmation().matchId() + "\""));
         assertTrue(entry.getRawPayload().contains("\"failureMessage\":\"temporary failure\""));
+
+        ArgumentCaptor<ErrorNotificationEvent> notificationCaptor = ArgumentCaptor.forClass(ErrorNotificationEvent.class);
+        verify(notification).notifyError(notificationCaptor.capture());
+        ErrorNotificationEvent notified = notificationCaptor.getValue();
+        assertEquals(ErrorNotificationType.DLQ_PERSISTED, notified.type());
+        assertEquals(entry.getId(), notified.dlqId());
+        assertEquals(runnerId, notified.runnerId());
     }
 
     @Test
@@ -123,12 +139,14 @@ class CapitalEventListenerTest {
         UUID portfolioId = UUID.randomUUID();
         UUID runnerId = UUID.randomUUID();
         when(runnerRepository.findById(runnerId)).thenReturn(Optional.of(activeRunner(portfolioId, runnerId)));
+        ErrorNotificationPort notification = mock(ErrorNotificationPort.class);
         CapitalEventListener listener = new CapitalEventListener(
                 executionReaction,
                 marginReaction,
                 runnerRepository,
                 deadLetterRepository,
-                payloadCodec()
+                payloadCodec(),
+                notification
         );
         MarginReleaseEvent event = marginReleaseEvent(UUID.randomUUID(), runnerId);
         RuntimeException failure = new RuntimeException("temporary failure");
@@ -145,6 +163,13 @@ class CapitalEventListenerTest {
         assertTrue(entry.getRawPayload().contains("\"transactionId\":\"" + event.release().transactionId() + "\""));
         assertTrue(entry.getRawPayload().contains("\"reason\":\"" + event.release().reason() + "\""));
         assertTrue(entry.getRawPayload().contains("\"failureMessage\":\"temporary failure\""));
+
+        ArgumentCaptor<ErrorNotificationEvent> notificationCaptor = ArgumentCaptor.forClass(ErrorNotificationEvent.class);
+        verify(notification).notifyError(notificationCaptor.capture());
+        ErrorNotificationEvent notified = notificationCaptor.getValue();
+        assertEquals(ErrorNotificationType.DLQ_PERSISTED, notified.type());
+        assertEquals(entry.getId(), notified.dlqId());
+        assertEquals(runnerId, notified.runnerId());
     }
 
     @Test
@@ -155,18 +180,21 @@ class CapitalEventListenerTest {
         DeadLetterEntryRepositoryPort deadLetterRepository = mock(DeadLetterEntryRepositoryPort.class);
         UUID runnerId = UUID.randomUUID();
         when(runnerRepository.findById(runnerId)).thenReturn(Optional.empty());
+        ErrorNotificationPort notification = mock(ErrorNotificationPort.class);
         CapitalEventListener listener = new CapitalEventListener(
                 executionReaction,
                 marginReaction,
                 runnerRepository,
                 deadLetterRepository,
-                payloadCodec()
+                payloadCodec(),
+                notification
         );
         ExecutionConfirmedEvent event = executionConfirmedEvent(UUID.randomUUID(), runnerId, UUID.randomUUID());
 
         listener.recoverExecutionConfirmed(new RuntimeException("temporary failure"), event);
 
         verify(deadLetterRepository, never()).save(any(DeadLetterEntry.class));
+        verify(notification, never()).notifyError(any(ErrorNotificationEvent.class));
     }
 
     @Test
@@ -179,12 +207,14 @@ class CapitalEventListenerTest {
         UUID runnerId = UUID.randomUUID();
         when(runnerRepository.findById(runnerId)).thenReturn(Optional.of(activeRunner(portfolioId, runnerId)));
         doThrow(new RuntimeException("db down")).when(deadLetterRepository).save(any(DeadLetterEntry.class));
+        ErrorNotificationPort notification = mock(ErrorNotificationPort.class);
         CapitalEventListener listener = new CapitalEventListener(
                 executionReaction,
                 marginReaction,
                 runnerRepository,
                 deadLetterRepository,
-                payloadCodec()
+                payloadCodec(),
+                notification
         );
         MarginReleaseEvent event = marginReleaseEvent(UUID.randomUUID(), runnerId);
 
@@ -192,6 +222,7 @@ class CapitalEventListenerTest {
                 listener.recoverMarginRelease(new RuntimeException("temporary failure"), event));
 
         verify(deadLetterRepository).save(any(DeadLetterEntry.class));
+        verify(notification, never()).notifyError(any(ErrorNotificationEvent.class));
     }
 
     private static CapitalDeadLetterPayloadCodec payloadCodec() {


### PR DESCRIPTION
## Objetivo

T21 — **Camada 1 (código)**: notificar o operador ativamente quando um erro terminal ocorre (DLQ persistido, boot fail-fast), sem precisar abrir o Grafana. Camadas 2 (alert rules Grafana) e 3 (enriquecimento de logs) ficam para follow-up.

## Mudanças

**core**
- `ErrorNotificationPort` (outbound) — contrato agnóstico de canal, tolerante a falha.
- `ErrorNotificationEvent` + `ErrorNotificationType` (DLQ_PERSISTED, BOOT_FAIL_FAST).

**spring-application**
- `DiscordWebhookNotificationAdapter` — POST de embed JSON; **no-op** quando `DISCORD_WEBHOOK_URL` vazio; envio **assíncrono** (fire-and-forget); falha de rede/HTTP só é logada, **nunca propaga**. Link "ver logs" via template Grafana opcional (`{correlationId}`).
- `NotificationConfig` + `NotificationProperties` (`notification.discord.webhook-url`, `notification.grafana.explore-url-template`).
- Disparo: `CapitalEventListener` notifica `DLQ_PERSISTED` após persistir a dead letter; `BootAlertListener` notifica `BOOT_FAIL_FAST` após o alerta de boot.

## Critérios de aceitação
1. ✅ Esgotado retry de capital event → mensagem no Discord com dlqId e correlationId.
2. ✅ `BootFailFastEvent` → mensagem no Discord.
3. ✅ Sem `DISCORD_WEBHOOK_URL` → app sobe normalmente (adapter no-op).
4. ✅ Falha no webhook não propaga nem interrompe o fluxo.
5. ⏳ Grafana contact point + alert rule — **Camada 2 (follow-up)**.
6. ⏳ Link Loki provisionado no Grafana — depende de Camada 2/3 (o adapter já monta o link via template configurável).

## Validação
- `./scripts/gradle-run.ps1 :spring-application:test` — verde (inclui Testcontainers e o contexto Spring com o novo bean).
- Novos testes: `DiscordWebhookNotificationAdapterTest` (no-op, POST de embed, swallow de erro HTTP/conexão); `CapitalEventListenerTest` estendido (verifica notificação no persist e ausência quando não persiste).

## Docs
- `/.ai/tasks/T21` atualizado com o progresso da Camada 1 (status geral segue "Em andamento").
- Sem novo flow map nesta fatia; quando Camadas 2/3 entrarem, avaliar um mapa de notificação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)