### PR TITLE
feat(T33+T32): strategy SHOULD_CANCEL action + OrderDispatchPort.cancel

### DIFF
--- a/.ai/tasks/T32-strategy-cancel-action.md
+++ b/.ai/tasks/T32-strategy-cancel-action.md
@@ -3,7 +3,7 @@
 **Complexidade:** Alta  
 **Responsável:** Claude  
 **Dependências:** T33 (caminho outbound de cancelamento — `OrderDispatchPort.cancel`)  
-**Status:** Pendente
+**Status:** Concluído — `TradingAction.SHOULD_CANCEL` + `StrategyOutputDto.cancel/targetTransactionId/shouldCancel`, `CancelSignalHandler` (ownership + estado cancelável) e roteamento em `ProcessTradeSignalUseCase` (antes do pipeline de trade). Coberto por unit tests (contrato + handler). **Follow-up:** estratégia de referência emitindo `SHOULD_CANCEL` + teste de integração end-to-end (cancel → CANCELED via stream → conciliação libera capital).
 
 ---
 

--- a/.ai/tasks/T33-order-cancel-dispatch-foundation.md
+++ b/.ai/tasks/T33-order-cancel-dispatch-foundation.md
@@ -3,7 +3,7 @@
 **Complexidade:** Baixa  
 **Responsável:** Claude  
 **Dependências:** Nenhuma  
-**Status:** Pendente
+**Status:** Concluído — verbo `OrderDispatchPort.cancel(OrderCancelCommand)` + impl no adapter (via `orderExecution().cancelOrder`, fire-and-forget). Primeiro consumidor: T32.
 
 ---
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandler.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandler.java
@@ -9,8 +9,12 @@ import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Executa o ramo {@code SHOULD_CANCEL} do pipeline de sinais: valida o alvo e despacha o
@@ -33,8 +37,17 @@ class CancelSignalHandler {
             TransactionStatus.PARTIAL
     );
 
+    /**
+     * Janela de de-dup: enquanto o {@code CANCELED} async nao chega, a ordem segue cancelavel em
+     * {@code pendingOrders} e uma estrategia deterministica reemitiria {@code SHOULD_CANCEL} a cada
+     * tick. Suprimimos reenvios para o mesmo {@code transactionId} dentro desta janela (evita
+     * rate-limit de cancel). Apos a janela, um reenvio e permitido (caso o cancel anterior se perca).
+     */
+    private static final Duration CANCEL_COOLDOWN = Duration.ofSeconds(30);
+
     private final StrategyRunnerRepositoryPort strategyRunnerRepository;
     private final OrderDispatchPort orderDispatch;
+    private final Map<UUID, Instant> recentCancelByTransaction = new ConcurrentHashMap<>();
 
     CancelSignalHandler(StrategyRunnerRepositoryPort strategyRunnerRepository, OrderDispatchPort orderDispatch) {
         this.strategyRunnerRepository = strategyRunnerRepository;
@@ -65,6 +78,16 @@ class CancelSignalHandler {
         if (!CANCELABLE_STATUSES.contains(transaction.getStatus())) {
             log.info("processCancelSignal: target not cancelable transactionId={} status={} runnerId={} - no-op",
                     targetTransactionId, transaction.getStatus(), runner.getId());
+            return;
+        }
+
+        // De-dup: nao reenvia cancel para a mesma transacao dentro da janela de cooldown.
+        Instant now = Instant.now();
+        recentCancelByTransaction.entrySet().removeIf(
+                e -> Duration.between(e.getValue(), now).compareTo(CANCEL_COOLDOWN) >= 0);
+        if (recentCancelByTransaction.putIfAbsent(targetTransactionId, now) != null) {
+            log.debug("processCancelSignal: cancel already in-flight for transactionId={} (cooldown) - skipping duplicate",
+                    targetTransactionId);
             return;
         }
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandler.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandler.java
@@ -1,0 +1,77 @@
+package com.marmitt.core.application.usecase.runner.processsignal;
+
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.runner.OrderCancelCommand;
+import com.marmitt.core.dto.strategy.StrategyOutputDto;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Executa o ramo {@code SHOULD_CANCEL} do pipeline de sinais: valida o alvo e despacha o
+ * cancelamento (fire-and-forget) via {@link OrderDispatchPort#cancel}.
+ *
+ * <p><b>Rejeicao silenciosa:</b> o contexto da estrategia e montado no inicio do tick e pode
+ * estar levemente defasado (a ordem pode ter enchido ou sumido nesse meio-tempo). Alvo
+ * inexistente, de outro runner ou ja terminal e tratado como no-op logado — nunca excecao que
+ * derrube o tick.
+ *
+ * <p><b>Sem marcacao terminal otimista:</b> o handler nao altera o estado local. O {@code CANCELED}
+ * real chega via stream e e conciliado pelo caminho idempotente, liberando capital quando aplicavel.
+ */
+@Slf4j
+class CancelSignalHandler {
+
+    private static final List<TransactionStatus> CANCELABLE_STATUSES = List.of(
+            TransactionStatus.PENDING,
+            TransactionStatus.SUBMITTED,
+            TransactionStatus.PARTIAL
+    );
+
+    private final StrategyRunnerRepositoryPort strategyRunnerRepository;
+    private final OrderDispatchPort orderDispatch;
+
+    CancelSignalHandler(StrategyRunnerRepositoryPort strategyRunnerRepository, OrderDispatchPort orderDispatch) {
+        this.strategyRunnerRepository = strategyRunnerRepository;
+        this.orderDispatch = orderDispatch;
+    }
+
+    void handle(StrategyRunner runner, StrategyOutputDto signal) {
+        UUID targetTransactionId = signal.targetTransactionId();
+        if (targetTransactionId == null) {
+            log.warn("processCancelSignal: SHOULD_CANCEL without targetTransactionId runnerId={} - ignored",
+                    runner.getId());
+            return;
+        }
+
+        Transaction transaction = strategyRunnerRepository.findTransactionById(targetTransactionId).orElse(null);
+        if (transaction == null) {
+            log.warn("processCancelSignal: target transaction not found transactionId={} runnerId={} - ignored",
+                    targetTransactionId, runner.getId());
+            return;
+        }
+
+        if (!transaction.getRunnerId().equals(runner.getId())) {
+            log.warn("processCancelSignal: target belongs to another runner transactionId={} owner={} requester={} - ignored",
+                    targetTransactionId, transaction.getRunnerId(), runner.getId());
+            return;
+        }
+
+        if (!CANCELABLE_STATUSES.contains(transaction.getStatus())) {
+            log.info("processCancelSignal: target not cancelable transactionId={} status={} runnerId={} - no-op",
+                    targetTransactionId, transaction.getStatus(), runner.getId());
+            return;
+        }
+
+        orderDispatch.cancel(new OrderCancelCommand(
+                transaction.getClientOrderId(), runner.getId(), runner.getSymbol(), runner.getExchangeId()));
+
+        log.info("processCancelSignal: cancel dispatched transactionId={} clientOrderId={} runnerId={} reason={}",
+                targetTransactionId, transaction.getClientOrderId(), runner.getId(), signal.reasoning());
+    }
+}

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandler.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandler.java
@@ -9,12 +9,8 @@ import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
 import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
 import lombok.extern.slf4j.Slf4j;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Executa o ramo {@code SHOULD_CANCEL} do pipeline de sinais: valida o alvo e despacha o
@@ -37,17 +33,8 @@ class CancelSignalHandler {
             TransactionStatus.PARTIAL
     );
 
-    /**
-     * Janela de de-dup: enquanto o {@code CANCELED} async nao chega, a ordem segue cancelavel em
-     * {@code pendingOrders} e uma estrategia deterministica reemitiria {@code SHOULD_CANCEL} a cada
-     * tick. Suprimimos reenvios para o mesmo {@code transactionId} dentro desta janela (evita
-     * rate-limit de cancel). Apos a janela, um reenvio e permitido (caso o cancel anterior se perca).
-     */
-    private static final Duration CANCEL_COOLDOWN = Duration.ofSeconds(30);
-
     private final StrategyRunnerRepositoryPort strategyRunnerRepository;
     private final OrderDispatchPort orderDispatch;
-    private final Map<UUID, Instant> recentCancelByTransaction = new ConcurrentHashMap<>();
 
     CancelSignalHandler(StrategyRunnerRepositoryPort strategyRunnerRepository, OrderDispatchPort orderDispatch) {
         this.strategyRunnerRepository = strategyRunnerRepository;
@@ -81,16 +68,9 @@ class CancelSignalHandler {
             return;
         }
 
-        // De-dup: nao reenvia cancel para a mesma transacao dentro da janela de cooldown.
-        Instant now = Instant.now();
-        recentCancelByTransaction.entrySet().removeIf(
-                e -> Duration.between(e.getValue(), now).compareTo(CANCEL_COOLDOWN) >= 0);
-        if (recentCancelByTransaction.putIfAbsent(targetTransactionId, now) != null) {
-            log.debug("processCancelSignal: cancel already in-flight for transactionId={} (cooldown) - skipping duplicate",
-                    targetTransactionId);
-            return;
-        }
-
+        // De-dup de reenvios (estrategia deterministica reemite SHOULD_CANCEL a cada tick enquanto o
+        // CANCELED async nao chega) e tratado no OrderDispatchAdapter, que marca o cooldown apenas
+        // apos um envio REAL (blocked/unsupported nao consomem a janela).
         orderDispatch.cancel(new OrderCancelCommand(
                 transaction.getClientOrderId(), runner.getId(), runner.getSymbol(), runner.getExchangeId()));
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
@@ -76,6 +76,7 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
     private final OrderNormalizer orderNormalizer;
     private final BuySignalHandler buySignalHandler;
     private final SellSignalHandler sellSignalHandler;
+    private final CancelSignalHandler cancelSignalHandler;
     private final RunnerExposureService runnerExposureService;
     private final CapitalReservationPolicy capitalReservationPolicy;
 
@@ -97,6 +98,7 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
         this.orderNormalizer = new OrderNormalizer(orderNormalizers);
         this.buySignalHandler = new BuySignalHandler(this.tradeIntentFactory, orderDispatch);
         this.sellSignalHandler = new SellSignalHandler(strategyRunnerRepository, this.tradeIntentFactory, orderDispatch);
+        this.cancelSignalHandler = new CancelSignalHandler(strategyRunnerRepository, orderDispatch);
         this.runnerExposureService = new RunnerExposureService(strategyRunnerRepository);
         this.capitalReservationPolicy = new CapitalReservationPolicy(
                 portfolioRepository, globalBalanceRepository, this.runnerExposureService);
@@ -260,6 +262,15 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
         StrategyOutputDto strategyOutput = signalEvaluator.evaluate(runner, activeStrategy.get(), input, context);
         if (signalEvaluator.isHold(strategyOutput)) {
             log.debug("priceUpdate: HOLD signal for runner={} - no action", runner.getId());
+            return;
+        }
+
+        // SHOULD_CANCEL e roteado ANTES do pipeline de trade: nao reserva capital, nao normaliza
+        // quantidade e nao passa pelas guardas BUY/SELL — apenas puxa uma ordem em transito.
+        if (strategyOutput.shouldCancel()) {
+            log.debug("priceUpdate: routing SHOULD_CANCEL runner={} target={}",
+                    runner.getId(), strategyOutput.targetTransactionId());
+            cancelSignalHandler.handle(runner, strategyOutput);
             return;
         }
 

--- a/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
+++ b/core/src/main/java/com/marmitt/core/application/usecase/runner/processsignal/ProcessTradeSignalUseCase.java
@@ -270,6 +270,10 @@ public abstract class ProcessTradeSignalUseCase implements ProcessTradeSignalPor
         if (strategyOutput.shouldCancel()) {
             log.debug("priceUpdate: routing SHOULD_CANCEL runner={} target={}",
                     runner.getId(), strategyOutput.targetTransactionId());
+            // Re-le o status do runner: o kill-switch/reconciliacao pode ter halted o runner entre
+            // canProcessRunner e o retorno da estrategia. Lanca RunnerHaltedException (capturada em
+            // execute) — mesma semantica de seguranca dos ramos BUY/SELL antes do dispatch.
+            checkRunnerNotHalted(runner.getId());
             cancelSignalHandler.handle(runner, strategyOutput);
             return;
         }

--- a/core/src/main/java/com/marmitt/core/dto/runner/OrderCancelCommand.java
+++ b/core/src/main/java/com/marmitt/core/dto/runner/OrderCancelCommand.java
@@ -1,0 +1,33 @@
+package com.marmitt.core.dto.runner;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Comando enviado ao {@code OrderDispatchPort} para cancelar uma ordem viva na exchange.
+ * <p>
+ * Espelha o {@link OrderDispatchCommand} (submit): carrega os dados mínimos para o adapter
+ * construir a requisição de cancelamento específica da exchange. Agnóstico — nenhum DTO de
+ * provider entra no core. O adapter não deve persistir nem acessar repositórios.
+ * <p>
+ * Fire-and-forget: o cancelamento é enviado e o {@code CANCELED} real chega de forma assíncrona
+ * via stream, sendo conciliado pelo caminho idempotente. Nenhuma marcação terminal otimista.
+ *
+ * @param clientOrderId chave de idempotência da ordem a cancelar
+ * @param runnerId      UUID do Runner dono da ordem
+ * @param symbol        par de trading (ex: "BTCUSDT")
+ * @param exchangeId    identificador da exchange destino
+ */
+public record OrderCancelCommand(
+        String clientOrderId,
+        UUID runnerId,
+        String symbol,
+        String exchangeId
+) {
+    public OrderCancelCommand {
+        Objects.requireNonNull(clientOrderId, "clientOrderId cannot be null");
+        Objects.requireNonNull(runnerId, "runnerId cannot be null");
+        Objects.requireNonNull(symbol, "symbol cannot be null");
+        Objects.requireNonNull(exchangeId, "exchangeId cannot be null");
+    }
+}

--- a/core/src/main/java/com/marmitt/core/dto/strategy/StrategyOutputDto.java
+++ b/core/src/main/java/com/marmitt/core/dto/strategy/StrategyOutputDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 @Builder
@@ -15,6 +16,7 @@ public record StrategyOutputDto(
         BigDecimal confidence,    // 0.0 - 1.0
         BigDecimal quantity,      // Quantidade absoluta a ser executada (ex: 0.05 BTC)
         UUID targetLotId,         // null = FIFO, UUID = lot especifico
+        UUID targetTransactionId, // ordem em transito a cancelar (somente SHOULD_CANCEL)
         String reasoning,
         Instant timestamp,
         Map<String, Object> metadata
@@ -22,7 +24,7 @@ public record StrategyOutputDto(
 
     public static StrategyOutputDto hold(String strategyName, String reasoning) {
         return new StrategyOutputDto(strategyName, TradingAction.SHOULD_HOLD,
-                                 BigDecimal.ZERO, BigDecimal.ZERO, null, reasoning,
+                                 BigDecimal.ZERO, BigDecimal.ZERO, null, null, reasoning,
                                  Instant.now(), Map.of());
     }
 
@@ -30,7 +32,7 @@ public record StrategyOutputDto(
                                         BigDecimal quantity, String reasoning) {
         validateTradeParams(confidence, quantity);
         return new StrategyOutputDto(strategyName, TradingAction.SHOULD_BUY,
-                                 confidence, quantity, null, reasoning,
+                                 confidence, quantity, null, null, reasoning,
                                  Instant.now(), Map.of());
     }
 
@@ -38,7 +40,7 @@ public record StrategyOutputDto(
                                          BigDecimal quantity, String reasoning) {
         validateTradeParams(confidence, quantity);
         return new StrategyOutputDto(strategyName, TradingAction.SHOULD_SELL,
-                                 confidence, quantity, null, reasoning,
+                                 confidence, quantity, null, null, reasoning,
                                  Instant.now(), Map.of());
     }
 
@@ -46,7 +48,18 @@ public record StrategyOutputDto(
                                             BigDecimal quantity, UUID targetLotId, String reasoning) {
         validateTradeParams(confidence, quantity);
         return new StrategyOutputDto(strategyName, TradingAction.SHOULD_SELL,
-                                 confidence, quantity, targetLotId, reasoning,
+                                 confidence, quantity, targetLotId, null, reasoning,
+                                 Instant.now(), Map.of());
+    }
+
+    /**
+     * Decisao de cancelar uma ordem em transito. Nao reserva capital nem normaliza quantidade —
+     * apenas identifica o alvo pelo {@code targetTransactionId} (de {@link PendingOrderDto#transactionId}).
+     */
+    public static StrategyOutputDto cancel(String strategyName, UUID targetTransactionId, String reasoning) {
+        Objects.requireNonNull(targetTransactionId, "targetTransactionId required for cancel");
+        return new StrategyOutputDto(strategyName, TradingAction.SHOULD_CANCEL,
+                                 BigDecimal.ZERO, BigDecimal.ZERO, null, targetTransactionId, reasoning,
                                  Instant.now(), Map.of());
     }
 
@@ -65,6 +78,10 @@ public record StrategyOutputDto(
 
     public boolean shouldHold() {
         return decision == TradingAction.SHOULD_HOLD;
+    }
+
+    public boolean shouldCancel() {
+        return decision == TradingAction.SHOULD_CANCEL;
     }
 
     public boolean isHighConfidence() {

--- a/core/src/main/java/com/marmitt/core/enums/TradingAction.java
+++ b/core/src/main/java/com/marmitt/core/enums/TradingAction.java
@@ -3,5 +3,7 @@ package com.marmitt.core.enums;
 public enum TradingAction {
     SHOULD_BUY,
     SHOULD_SELL,
-    SHOULD_HOLD
+    SHOULD_HOLD,
+    /** Pedido da estratégia para cancelar uma ordem em trânsito (alvo em StrategyOutputDto.targetTransactionId). */
+    SHOULD_CANCEL
 }

--- a/core/src/main/java/com/marmitt/core/ports/outbound/exchange/OrderDispatchPort.java
+++ b/core/src/main/java/com/marmitt/core/ports/outbound/exchange/OrderDispatchPort.java
@@ -1,5 +1,6 @@
 package com.marmitt.core.ports.outbound.exchange;
 
+import com.marmitt.core.dto.runner.OrderCancelCommand;
 import com.marmitt.core.dto.runner.OrderDispatchCommand;
 
 /**
@@ -25,4 +26,15 @@ public interface OrderDispatchPort {
      * @throws RuntimeException      se o envio falhar por razão técnica
      */
     void dispatch(OrderDispatchCommand command);
+
+    /**
+     * Cancela uma ordem viva na exchange via canal de saída.
+     * <p>
+     * Fire-and-forget, como {@link #dispatch}: envia o cancelamento e retorna. O {@code CANCELED}
+     * (e a eventual liberação de capital) chega de forma assíncrona via stream e é conciliado pelo
+     * caminho idempotente. Não marca a transação como terminal de forma otimista.
+     *
+     * @param command alvo do cancelamento (agnóstico de provider)
+     */
+    void cancel(OrderCancelCommand command);
 }

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandlerTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandlerTest.java
@@ -60,6 +60,19 @@ class CancelSignalHandlerTest {
     }
 
     @Test
+    void deDupesRepeatedCancelForSameTransactionWithinCooldown() {
+        Transaction tx = tx(runnerId, TransactionStatus.SUBMITTED);
+        when(repository.findTransactionById(tx.getId())).thenReturn(Optional.of(tx));
+        StrategyRunner runner = runner(runnerId);
+
+        StrategyOutputDto cancel = StrategyOutputDto.cancel("s", tx.getId(), "thesis changed");
+        handler.handle(runner, cancel);
+        handler.handle(runner, cancel); // mesmo alvo, dentro do cooldown
+
+        verify(orderDispatch, org.mockito.Mockito.times(1)).cancel(any());
+    }
+
+    @Test
     void ignoresWhenTargetNotFound() {
         UUID targetId = UUID.randomUUID();
         when(repository.findTransactionById(targetId)).thenReturn(Optional.empty());

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandlerTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandlerTest.java
@@ -60,19 +60,6 @@ class CancelSignalHandlerTest {
     }
 
     @Test
-    void deDupesRepeatedCancelForSameTransactionWithinCooldown() {
-        Transaction tx = tx(runnerId, TransactionStatus.SUBMITTED);
-        when(repository.findTransactionById(tx.getId())).thenReturn(Optional.of(tx));
-        StrategyRunner runner = runner(runnerId);
-
-        StrategyOutputDto cancel = StrategyOutputDto.cancel("s", tx.getId(), "thesis changed");
-        handler.handle(runner, cancel);
-        handler.handle(runner, cancel); // mesmo alvo, dentro do cooldown
-
-        verify(orderDispatch, org.mockito.Mockito.times(1)).cancel(any());
-    }
-
-    @Test
     void ignoresWhenTargetNotFound() {
         UUID targetId = UUID.randomUUID();
         when(repository.findTransactionById(targetId)).thenReturn(Optional.empty());

--- a/core/src/test/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandlerTest.java
+++ b/core/src/test/java/com/marmitt/core/application/usecase/runner/processsignal/CancelSignalHandlerTest.java
@@ -1,0 +1,116 @@
+package com.marmitt.core.application.usecase.runner.processsignal;
+
+import com.marmitt.core.domain.runner.StrategyRunner;
+import com.marmitt.core.domain.runner.Transaction;
+import com.marmitt.core.dto.runner.OrderCancelCommand;
+import com.marmitt.core.dto.strategy.StrategyOutputDto;
+import com.marmitt.core.enums.TransactionStatus;
+import com.marmitt.core.enums.TransactionType;
+import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
+import com.marmitt.core.ports.outbound.repository.StrategyRunnerRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CancelSignalHandlerTest {
+
+    private final StrategyRunnerRepositoryPort repository = mock(StrategyRunnerRepositoryPort.class);
+    private final OrderDispatchPort orderDispatch = mock(OrderDispatchPort.class);
+    private final CancelSignalHandler handler = new CancelSignalHandler(repository, orderDispatch);
+
+    private final UUID runnerId = UUID.randomUUID();
+
+    @Test
+    void dispatchesCancelForOwnedCancelableTransaction() {
+        Transaction tx = tx(runnerId, TransactionStatus.SUBMITTED);
+        when(repository.findTransactionById(tx.getId())).thenReturn(Optional.of(tx));
+
+        handler.handle(runner(runnerId), StrategyOutputDto.cancel("s", tx.getId(), "thesis changed"));
+
+        ArgumentCaptor<OrderCancelCommand> captor = ArgumentCaptor.forClass(OrderCancelCommand.class);
+        verify(orderDispatch).cancel(captor.capture());
+        assertEquals(tx.getClientOrderId(), captor.getValue().clientOrderId());
+        assertEquals(runnerId, captor.getValue().runnerId());
+        assertEquals("BTCUSDT", captor.getValue().symbol());
+        assertEquals("BINANCE", captor.getValue().exchangeId());
+    }
+
+    @Test
+    void dispatchesCancelForPendingAndPartial() {
+        Transaction pending = tx(runnerId, TransactionStatus.PENDING);
+        Transaction partial = tx(runnerId, TransactionStatus.PARTIAL);
+        when(repository.findTransactionById(pending.getId())).thenReturn(Optional.of(pending));
+        when(repository.findTransactionById(partial.getId())).thenReturn(Optional.of(partial));
+
+        handler.handle(runner(runnerId), StrategyOutputDto.cancel("s", pending.getId(), "x"));
+        handler.handle(runner(runnerId), StrategyOutputDto.cancel("s", partial.getId(), "x"));
+
+        verify(orderDispatch, org.mockito.Mockito.times(2)).cancel(any());
+    }
+
+    @Test
+    void ignoresWhenTargetNotFound() {
+        UUID targetId = UUID.randomUUID();
+        when(repository.findTransactionById(targetId)).thenReturn(Optional.empty());
+
+        handler.handle(runner(runnerId), StrategyOutputDto.cancel("s", targetId, "x"));
+
+        verify(orderDispatch, never()).cancel(any());
+    }
+
+    @Test
+    void ignoresWhenTargetBelongsToAnotherRunner() {
+        Transaction tx = tx(UUID.randomUUID(), TransactionStatus.SUBMITTED); // dono diferente
+        when(repository.findTransactionById(tx.getId())).thenReturn(Optional.of(tx));
+
+        handler.handle(runner(runnerId), StrategyOutputDto.cancel("s", tx.getId(), "x"));
+
+        verify(orderDispatch, never()).cancel(any());
+    }
+
+    @Test
+    void ignoresWhenTargetIsTerminal() {
+        Transaction tx = tx(runnerId, TransactionStatus.FILLED);
+        when(repository.findTransactionById(tx.getId())).thenReturn(Optional.of(tx));
+
+        handler.handle(runner(runnerId), StrategyOutputDto.cancel("s", tx.getId(), "x"));
+
+        verify(orderDispatch, never()).cancel(any());
+    }
+
+    private StrategyRunner runner(UUID id) {
+        StrategyRunner runner = mock(StrategyRunner.class);
+        when(runner.getId()).thenReturn(id);
+        when(runner.getSymbol()).thenReturn("BTCUSDT");
+        when(runner.getExchangeId()).thenReturn("BINANCE");
+        return runner;
+    }
+
+    private Transaction tx(UUID ownerRunnerId, TransactionStatus status) {
+        return Transaction.reconstitute()
+                .id(UUID.randomUUID())
+                .runnerId(ownerRunnerId)
+                .clientOrderId("client-order-id")
+                .exchangeOrderId(status == TransactionStatus.PENDING ? null : "EX_ORDER")
+                .status(status)
+                .type(TransactionType.BUY)
+                .symbol("BTCUSDT")
+                .quantity(new BigDecimal("0.0015"))
+                .price(new BigDecimal("60000"))
+                .total(new BigDecimal("90"))
+                .requestedAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+}

--- a/core/src/test/java/com/marmitt/core/dto/strategy/StrategyOutputDtoCancelTest.java
+++ b/core/src/test/java/com/marmitt/core/dto/strategy/StrategyOutputDtoCancelTest.java
@@ -1,0 +1,31 @@
+package com.marmitt.core.dto.strategy;
+
+import com.marmitt.core.enums.TradingAction;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StrategyOutputDtoCancelTest {
+
+    @Test
+    void cancelFactoryProducesCancelDecisionWithTarget() {
+        UUID target = UUID.randomUUID();
+        StrategyOutputDto out = StrategyOutputDto.cancel("sma", target, "thesis changed");
+
+        assertEquals(TradingAction.SHOULD_CANCEL, out.decision());
+        assertEquals(target, out.targetTransactionId());
+        assertTrue(out.shouldCancel());
+        assertFalse(out.shouldTrade(), "cancel is not a BUY/SELL trade");
+        assertFalse(out.shouldHold());
+    }
+
+    @Test
+    void cancelRequiresTargetTransactionId() {
+        assertThrows(NullPointerException.class, () -> StrategyOutputDto.cancel("sma", null, "x"));
+    }
+}

--- a/docs/tasks/BACKLOG.md
+++ b/docs/tasks/BACKLOG.md
@@ -37,8 +37,8 @@ Trilha de tarefas para habilitar operação com a API da Binance (testnet), pré
 | T29 | Implementar consulta de saldo na exchange                       | Média | Claude | Concluído |
 | T30 | Implementar consulta de histórico de trades na exchange         | Média | Claude | Concluído |
 | T31 | Unificação do recovery de runtime: cobertura de zombies (`PENDING`) | Baixa | Claude | Concluído |
-| T32 | Ação `SHOULD_CANCEL` no contrato da estratégia                  | Alta  | Claude | Pendente  |
-| T33 | Fundação de cancelamento outbound (`OrderDispatchPort.cancel`)  | Baixa | Claude | Pendente  |
+| T32 | Ação `SHOULD_CANCEL` no contrato da estratégia                  | Alta  | Claude | Concluído |
+| T33 | Fundação de cancelamento outbound (`OrderDispatchPort.cancel`)  | Baixa | Claude | Concluído |
 | TD1 | Telemetria do canal USER_DATA (débito técnico)                  | Baixa | —      | Concluído |
 
 ## Ordem de execução

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
@@ -66,6 +66,15 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
 
     @Override
     public void cancel(OrderCancelCommand command) {
+        if (exchangeAdapterRepository.isDispatchBlocked(command.exchangeId())) {
+            // Conexao perdida (MARKET/USER_DATA): nao envia o cancel. Com o USER_DATA fora, o
+            // CANCELED poderia nao chegar pelo stream e o estado local ficaria preso (capital/lock).
+            // A estrategia pode reemitir o cancel quando a conexao restabelecer.
+            log.warn("cancel: blocked — connection lost for exchange={} clientOrderId={} — skipping",
+                    command.exchangeId(), command.clientOrderId());
+            return;
+        }
+
         ExchangeAdapterDescriptor adapter = exchangeAdapterRepository
                 .findAdapter(command.exchangeId())
                 .orElseThrow(() -> new IllegalStateException(
@@ -79,8 +88,16 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
 
         // Fire-and-forget: envia o cancelamento; o CANCELED real (e a liberacao de capital) chega
         // pelo stream e e conciliado pelo caminho idempotente. Sem marcacao terminal otimista.
-        adapter.orderExecution().cancelOrder(
-                new SendCancelOrderRequest(command.exchangeId(), command.clientOrderId(), command.symbol()));
+        // A capability pode estar anunciada mas o verbo de cancel ser nao suportado (ex.: Coinbase):
+        // nesse caso, no-op logado em vez de propagar como erro de processamento do runner.
+        try {
+            adapter.orderExecution().cancelOrder(
+                    new SendCancelOrderRequest(command.exchangeId(), command.clientOrderId(), command.symbol()));
+        } catch (UnsupportedOperationException e) {
+            log.warn("cancel: not supported by exchange={} clientOrderId={} — skipping",
+                    command.exchangeId(), command.clientOrderId());
+            return;
+        }
 
         log.debug("cancel: cancel sent — clientOrderId={} exchange={} symbol={} — awaits CANCELED via stream",
                 command.clientOrderId(), command.exchangeId(), command.symbol());

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
@@ -98,12 +98,14 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
             return;
         }
 
-        // De-dup: nao reenvia o mesmo cancel dentro da janela de cooldown (marca gravada so apos envio real).
+        // De-dup ATOMICO: reserva a janela ANTES do envio (putIfAbsent), para que dois ticks
+        // concorrentes da mesma ordem nao enviem ambos. A reserva e LIBERADA se o envio nao
+        // ocorrer (unsupported/falha tecnica), para nao bloquear um retry legitimo apos um no-op.
         Instant now = Instant.now();
         recentCancelByClientOrderId.entrySet().removeIf(
                 e -> Duration.between(e.getValue(), now).compareTo(CANCEL_COOLDOWN) >= 0);
-        if (recentCancelByClientOrderId.containsKey(command.clientOrderId())) {
-            log.debug("cancel: already sent recently for clientOrderId={} (cooldown) — skipping duplicate",
+        if (recentCancelByClientOrderId.putIfAbsent(command.clientOrderId(), now) != null) {
+            log.debug("cancel: already in-flight for clientOrderId={} (cooldown) — skipping duplicate",
                     command.clientOrderId());
             return;
         }
@@ -111,18 +113,20 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
         // Fire-and-forget: envia o cancelamento; o CANCELED real (e a liberacao de capital) chega
         // pelo stream e e conciliado pelo caminho idempotente. Sem marcacao terminal otimista.
         // A capability pode estar anunciada mas o verbo de cancel ser nao suportado (ex.: Coinbase):
-        // nesse caso, no-op logado em vez de propagar como erro de processamento do runner.
+        // nesse caso, no-op logado e a reserva e liberada (sem propagar como erro de runner).
         try {
             adapter.orderExecution().cancelOrder(
                     new SendCancelOrderRequest(command.exchangeId(), command.clientOrderId(), command.symbol()));
         } catch (UnsupportedOperationException e) {
+            recentCancelByClientOrderId.remove(command.clientOrderId(), now);
             log.warn("cancel: not supported by exchange={} clientOrderId={} — skipping",
                     command.exchangeId(), command.clientOrderId());
             return;
+        } catch (RuntimeException e) {
+            recentCancelByClientOrderId.remove(command.clientOrderId(), now);
+            throw e;
         }
 
-        // Marca o cooldown APENAS apos o envio real bem-sucedido.
-        recentCancelByClientOrderId.put(command.clientOrderId(), now);
         log.debug("cancel: cancel sent — clientOrderId={} exchange={} symbol={} — awaits CANCELED via stream",
                 command.clientOrderId(), command.exchangeId(), command.symbol());
     }

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
@@ -2,13 +2,16 @@ package com.marmitt.application.spring.infrastructure.exchange;
 
 import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.dto.exchange.OrderSubmissionResult;
+import com.marmitt.core.dto.runner.OrderCancelCommand;
 import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.dto.websocket.request.SendCancelOrderRequest;
 import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.core.enums.OrderSide;
 import com.marmitt.core.enums.OrderType;
 import com.marmitt.core.enums.TransactionType;
 import com.marmitt.core.ports.inbound.runner.OrderConciliationPort;
+import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
 import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
 import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
@@ -59,6 +62,28 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
 
         log.debug("dispatch: order sent — clientOrderId={} exchange={} symbol={} type={}",
                 command.clientOrderId(), command.exchangeId(), command.symbol(), command.type());
+    }
+
+    @Override
+    public void cancel(OrderCancelCommand command) {
+        ExchangeAdapterDescriptor adapter = exchangeAdapterRepository
+                .findAdapter(command.exchangeId())
+                .orElseThrow(() -> new IllegalStateException(
+                        "No adapter registered for exchangeId: " + command.exchangeId()));
+
+        if (!adapter.hasOrderExecution()) {
+            log.warn("cancel: order execution capability not available exchange={} clientOrderId={} — skipping",
+                    command.exchangeId(), command.clientOrderId());
+            return;
+        }
+
+        // Fire-and-forget: envia o cancelamento; o CANCELED real (e a liberacao de capital) chega
+        // pelo stream e e conciliado pelo caminho idempotente. Sem marcacao terminal otimista.
+        adapter.orderExecution().cancelOrder(
+                new SendCancelOrderRequest(command.exchangeId(), command.clientOrderId(), command.symbol()));
+
+        log.debug("cancel: cancel sent — clientOrderId={} exchange={} symbol={} — awaits CANCELED via stream",
+                command.clientOrderId(), command.exchangeId(), command.symbol());
     }
 
     private SendOrderRequest toSendOrderRequest(OrderDispatchCommand command, String exchangeName) {

--- a/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
+++ b/spring-application/src/main/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapter.java
@@ -17,7 +17,10 @@ import com.marmitt.core.ports.outbound.exchange.OrderDispatchPort;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -25,8 +28,17 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrderDispatchAdapter implements OrderDispatchPort {
 
+    /**
+     * Janela de de-dup de cancel: uma estrategia deterministica reemite SHOULD_CANCEL a cada tick
+     * enquanto o CANCELED async nao chega. Suprimimos reenvios do mesmo clientOrderId dentro desta
+     * janela (evita rate-limit). A marca e gravada APENAS apos um envio real — blocked/unsupported
+     * nao consomem a janela, para nao bloquear um retry legitimo apos um no-op.
+     */
+    private static final Duration CANCEL_COOLDOWN = Duration.ofSeconds(30);
+
     private final ExchangeAdapterRepositoryPort exchangeAdapterRepository;
     private final OrderConciliationPort orderConciliation;
+    private final Map<String, Instant> recentCancelByClientOrderId = new ConcurrentHashMap<>();
 
     public OrderDispatchAdapter(ExchangeAdapterRepositoryPort exchangeAdapterRepository,
                                 OrderConciliationPort orderConciliation) {
@@ -86,6 +98,16 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
             return;
         }
 
+        // De-dup: nao reenvia o mesmo cancel dentro da janela de cooldown (marca gravada so apos envio real).
+        Instant now = Instant.now();
+        recentCancelByClientOrderId.entrySet().removeIf(
+                e -> Duration.between(e.getValue(), now).compareTo(CANCEL_COOLDOWN) >= 0);
+        if (recentCancelByClientOrderId.containsKey(command.clientOrderId())) {
+            log.debug("cancel: already sent recently for clientOrderId={} (cooldown) — skipping duplicate",
+                    command.clientOrderId());
+            return;
+        }
+
         // Fire-and-forget: envia o cancelamento; o CANCELED real (e a liberacao de capital) chega
         // pelo stream e e conciliado pelo caminho idempotente. Sem marcacao terminal otimista.
         // A capability pode estar anunciada mas o verbo de cancel ser nao suportado (ex.: Coinbase):
@@ -99,6 +121,8 @@ public class OrderDispatchAdapter implements OrderDispatchPort {
             return;
         }
 
+        // Marca o cooldown APENAS apos o envio real bem-sucedido.
+        recentCancelByClientOrderId.put(command.clientOrderId(), now);
         log.debug("cancel: cancel sent — clientOrderId={} exchange={} symbol={} — awaits CANCELED via stream",
                 command.clientOrderId(), command.exchangeId(), command.symbol());
     }

--- a/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
@@ -186,6 +186,29 @@ class OrderDispatchAdapterTest {
         assertEquals(1, execution.canceled.size(), "blocked no-op must not consume the de-dup slot");
     }
 
+    @Test
+    void cancel_releasesDeDupSlot_whenCancelUnsupported() {
+        List<SendCancelOrderRequest> sent = new ArrayList<>();
+        int[] calls = {0};
+        ExchangeOrderExecutionPort flaky = new ExchangeOrderExecutionPort() {
+            @Override public OrderDataDto submitOrder(SendOrderRequest request) { throw new UnsupportedOperationException(); }
+            @Override public OrderDataDto cancelOrder(SendCancelOrderRequest request) {
+                if (calls[0]++ == 0) { throw new UnsupportedOperationException(); }
+                sent.add(request);
+                return null;
+            }
+        };
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.dispatched()), flaky);
+        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, new RecordingConciliationPort());
+        OrderCancelCommand command = new OrderCancelCommand("t01-BUY-001", UUID.randomUUID(), SYMBOL, EXCHANGE);
+
+        adapter.cancel(command); // unsupported -> reserva e LIBERA o slot
+        adapter.cancel(command); // mesma ordem -> tenta de novo (slot livre) e envia
+
+        assertEquals(1, sent.size(), "unsupported no-op must release the de-dup slot for retry");
+    }
+
     // ---- stubs ----
 
     static class RecordingConciliationPort implements OrderConciliationPort {

--- a/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
@@ -113,6 +113,34 @@ class OrderDispatchAdapterTest {
     }
 
     @Test
+    void cancel_isSkipped_whenDispatchBlocked() {
+        RecordingOrderExecutionPort execution = new RecordingOrderExecutionPort();
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.dispatched()), execution) {
+            @Override public boolean isDispatchBlocked(String exchangeName) { return true; }
+        };
+
+        OrderCancelCommand command = new OrderCancelCommand("t01-BUY-001", UUID.randomUUID(), SYMBOL, EXCHANGE);
+        new OrderDispatchAdapter(adapterRepo, new RecordingConciliationPort()).cancel(command);
+
+        assertTrue(execution.canceled.isEmpty(), "blocked exchange must not receive a cancel");
+    }
+
+    @Test
+    void cancel_isNoOp_whenCancelUnsupported() {
+        ExchangeOrderExecutionPort throwing = new ExchangeOrderExecutionPort() {
+            @Override public OrderDataDto submitOrder(SendOrderRequest request) { throw new UnsupportedOperationException(); }
+            @Override public OrderDataDto cancelOrder(SendCancelOrderRequest request) { throw new UnsupportedOperationException(); }
+        };
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.dispatched()), throwing);
+
+        OrderCancelCommand command = new OrderCancelCommand("t01-BUY-001", UUID.randomUUID(), SYMBOL, EXCHANGE);
+        // capability anunciada mas cancel nao suportado -> no-op logado, sem propagar excecao.
+        assertDoesNotThrow(() -> new OrderDispatchAdapter(adapterRepo, new RecordingConciliationPort()).cancel(command));
+    }
+
+    @Test
     void cancel_isNoOp_whenOrderExecutionNotAvailable() {
         RecordingConciliationPort conciliation = new RecordingConciliationPort();
         StubAdapterRepository adapterRepo = new StubAdapterRepository(

--- a/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
@@ -3,13 +3,16 @@ package com.marmitt.application.spring.infrastructure.exchange;
 import com.marmitt.core.domain.Symbol;
 import com.marmitt.core.domain.runner.ClientOrderId;
 import com.marmitt.core.dto.exchange.OrderSubmissionResult;
+import com.marmitt.core.dto.runner.OrderCancelCommand;
 import com.marmitt.core.dto.runner.OrderDispatchCommand;
 import com.marmitt.core.dto.websocket.data.OrderDataDto;
+import com.marmitt.core.dto.websocket.request.SendCancelOrderRequest;
 import com.marmitt.core.dto.websocket.request.SendOrderRequest;
 import com.marmitt.core.enums.TransactionType;
 import com.marmitt.core.ports.inbound.runner.OrderConciliationPort;
 import com.marmitt.core.ports.outbound.exchange.ExchangeAdapterDescriptor;
 import com.marmitt.core.ports.outbound.exchange.ExchangeOrderPort;
+import com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort;
 import com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSession;
 import com.marmitt.core.ports.outbound.repository.ExchangeAdapterRepositoryPort;
 import org.junit.jupiter.api.Test;
@@ -94,11 +97,45 @@ class OrderDispatchAdapterTest {
         assertEquals("filter violation: stepSize", conciliation.received.get(0).rejectReason());
     }
 
+    @Test
+    void cancel_translatesToSendCancelOrderRequest_andInvokesOrderExecution() {
+        RecordingOrderExecutionPort execution = new RecordingOrderExecutionPort();
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.dispatched()), execution);
+
+        OrderCancelCommand command = new OrderCancelCommand("t01-BUY-001", UUID.randomUUID(), SYMBOL, EXCHANGE);
+        new OrderDispatchAdapter(adapterRepo, new RecordingConciliationPort()).cancel(command);
+
+        assertEquals(1, execution.canceled.size(), "cancel must reach the order execution transport");
+        SendCancelOrderRequest sent = execution.canceled.get(0);
+        assertEquals("t01-BUY-001", sent.getClientOrderId());
+        assertEquals(SYMBOL, sent.getSymbol());
+    }
+
+    @Test
+    void cancel_isNoOp_whenOrderExecutionNotAvailable() {
+        RecordingConciliationPort conciliation = new RecordingConciliationPort();
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.dispatched())); // sem orderExecution
+
+        OrderCancelCommand command = new OrderCancelCommand("t01-BUY-001", UUID.randomUUID(), SYMBOL, EXCHANGE);
+        // hasOrderExecution()=false -> no-op logado, sem excecao.
+        new OrderDispatchAdapter(adapterRepo, conciliation).cancel(command);
+
+        assertTrue(conciliation.received.isEmpty());
+    }
+
     // ---- stubs ----
 
     static class RecordingConciliationPort implements OrderConciliationPort {
         final List<OrderDataDto> received = new ArrayList<>();
         @Override public void execute(OrderDataDto orderData) { received.add(orderData); }
+    }
+
+    static class RecordingOrderExecutionPort implements ExchangeOrderExecutionPort {
+        final List<SendCancelOrderRequest> canceled = new ArrayList<>();
+        @Override public OrderDataDto submitOrder(SendOrderRequest request) { throw new UnsupportedOperationException(); }
+        @Override public OrderDataDto cancelOrder(SendCancelOrderRequest request) { canceled.add(request); return null; }
     }
 
     static class StubOrderPort implements ExchangeOrderPort {
@@ -110,7 +147,12 @@ class OrderDispatchAdapterTest {
 
     static class StubDescriptor implements ExchangeAdapterDescriptor {
         private final ExchangeOrderPort orderPort;
-        StubDescriptor(ExchangeOrderPort orderPort) { this.orderPort = orderPort; }
+        private final ExchangeOrderExecutionPort orderExecution;
+        StubDescriptor(ExchangeOrderPort orderPort) { this(orderPort, null); }
+        StubDescriptor(ExchangeOrderPort orderPort, ExchangeOrderExecutionPort orderExecution) {
+            this.orderPort = orderPort;
+            this.orderExecution = orderExecution;
+        }
         @Override public String exchangeName() { return EXCHANGE; }
         @Override public com.marmitt.core.ports.outbound.exchange.streaming.ExchangeStreamingPort streaming() { return null; }
         @Override public ExchangeOrderPort orderPort() { return orderPort; }
@@ -118,8 +160,11 @@ class OrderDispatchAdapterTest {
         @Override public com.marmitt.core.ports.outbound.exchange.streaming.ExchangeUserStreamPort userStream() { throw new com.marmitt.core.exceptions.UnsupportedCapabilityException(EXCHANGE, "userStream"); }
         @Override public boolean hasUserStreamSession() { return false; }
         @Override public com.marmitt.core.ports.outbound.exchange.streaming.UserStreamSessionPort userStreamSession() { throw new com.marmitt.core.exceptions.UnsupportedCapabilityException(EXCHANGE, "userStreamSession"); }
-        @Override public boolean hasOrderExecution() { return false; }
-        @Override public com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderExecutionPort orderExecution() { throw new com.marmitt.core.exceptions.UnsupportedCapabilityException(EXCHANGE, "orderExecution"); }
+        @Override public boolean hasOrderExecution() { return orderExecution != null; }
+        @Override public ExchangeOrderExecutionPort orderExecution() {
+            if (orderExecution == null) { throw new com.marmitt.core.exceptions.UnsupportedCapabilityException(EXCHANGE, "orderExecution"); }
+            return orderExecution;
+        }
         @Override public boolean hasOrderQuery() { return false; }
         @Override public com.marmitt.core.ports.outbound.exchange.rest.ExchangeOrderQueryPort orderQuery() { throw new com.marmitt.core.exceptions.UnsupportedCapabilityException(EXCHANGE, "orderQuery"); }
         @Override public boolean hasAccountQuery() { return false; }
@@ -133,6 +178,9 @@ class OrderDispatchAdapterTest {
     static class StubAdapterRepository implements ExchangeAdapterRepositoryPort {
         private final ExchangeAdapterDescriptor descriptor;
         StubAdapterRepository(ExchangeOrderPort orderPort) { this.descriptor = new StubDescriptor(orderPort); }
+        StubAdapterRepository(ExchangeOrderPort orderPort, ExchangeOrderExecutionPort orderExecution) {
+            this.descriptor = new StubDescriptor(orderPort, orderExecution);
+        }
         @Override public Optional<ExchangeAdapterDescriptor> findAdapter(String n) { return Optional.of(descriptor); }
         @Override public boolean hasAdapter(String n) { return true; }
         @Override public Set<String> getAllExchangeNames() { return Set.of(EXCHANGE); }

--- a/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
+++ b/spring-application/src/test/java/com/marmitt/application/spring/infrastructure/exchange/OrderDispatchAdapterTest.java
@@ -153,6 +153,39 @@ class OrderDispatchAdapterTest {
         assertTrue(conciliation.received.isEmpty());
     }
 
+    @Test
+    void cancel_deDupesRepeatedSendsForSameOrderWithinCooldown() {
+        RecordingOrderExecutionPort execution = new RecordingOrderExecutionPort();
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.dispatched()), execution);
+        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, new RecordingConciliationPort());
+
+        OrderCancelCommand command = new OrderCancelCommand("t01-BUY-001", UUID.randomUUID(), SYMBOL, EXCHANGE);
+        adapter.cancel(command);
+        adapter.cancel(command); // mesmo clientOrderId dentro do cooldown
+
+        assertEquals(1, execution.canceled.size(), "duplicate cancel for same order within cooldown must be suppressed");
+    }
+
+    @Test
+    void cancel_doesNotConsumeDeDupSlot_whenBlocked() {
+        java.util.concurrent.atomic.AtomicBoolean blocked = new java.util.concurrent.atomic.AtomicBoolean(true);
+        RecordingOrderExecutionPort execution = new RecordingOrderExecutionPort();
+        StubAdapterRepository adapterRepo = new StubAdapterRepository(
+                new StubOrderPort(OrderSubmissionResult.dispatched()), execution) {
+            @Override public boolean isDispatchBlocked(String exchangeName) { return blocked.get(); }
+        };
+        OrderDispatchAdapter adapter = new OrderDispatchAdapter(adapterRepo, new RecordingConciliationPort());
+        OrderCancelCommand command = new OrderCancelCommand("t01-BUY-001", UUID.randomUUID(), SYMBOL, EXCHANGE);
+
+        adapter.cancel(command); // blocked -> no-op, NAO marca o cooldown
+        assertTrue(execution.canceled.isEmpty());
+
+        blocked.set(false);
+        adapter.cancel(command); // mesma ordem -> envia, pois o no-op nao consumiu o slot
+        assertEquals(1, execution.canceled.size(), "blocked no-op must not consume the de-dup slot");
+    }
+
     // ---- stubs ----
 
     static class RecordingConciliationPort implements OrderConciliationPort {


### PR DESCRIPTION
Entrega o cancelamento de ordem **viva** dirigido pela estratégia. Dois commits, duas tasks:

## T33 — fundação do verbo de cancelamento (`7e8364e`)
- `OrderDispatchPort.cancel(OrderCancelCommand)` espelhando o fire-and-forget de `dispatch`.
- `OrderCancelCommand` (core, agnóstico: `clientOrderId/runnerId/symbol/exchangeId`).
- `OrderDispatchAdapter.cancel` resolve o adapter e traduz para `SendCancelOrderRequest` via `orderExecution().cancelOrder` (no-op logado se a capability não existir). Sem gatilho automático.

## T32 — ação `SHOULD_CANCEL` na estratégia (`69f0b25`)
- `TradingAction.SHOULD_CANCEL`; `StrategyOutputDto` ganha `targetTransactionId` + factory `cancel()` + `shouldCancel()`.
- `CancelSignalHandler`: valida ownership e estado cancelável (`PENDING`/`SUBMITTED`/`PARTIAL`); alvo inexistente, de outro runner ou terminal → no-op logado (nunca exceção que derrube o tick); despacha `OrderDispatchPort.cancel`. Sem marcação terminal otimista — o `CANCELED` chega via stream e é conciliado pelo caminho idempotente.
- `ProcessTradeSignalUseCase` roteia `SHOULD_CANCEL` **antes** do pipeline de trade (sem reserva de capital nem normalização de quantidade).

## Validation
- `:core:test`: passed
- `:spring-application:test` (suíte completa): passed
- compile de `:core`, `:strategy`, `:spring-application`: passed

## Documentation
- `.ai/tasks/T33-*` e `.ai/tasks/T32-*` marcadas como Concluído; `docs/tasks/BACKLOG.md` atualizado.

## Notes
- **Follow-up (registrado na T32):** estratégia de referência emitindo `SHOULD_CANCEL` + teste de integração end-to-end (cancel → CANCELED via stream → conciliação libera capital). Não foi incluído para não alterar a semântica da `SimpleMovingAverageStrategy` de produção e por exigir wiring de estratégia no harness; a lógica está coberta em camadas por unit tests (contrato + handler + verbo do adapter).
- Sem gatilho de TTL global cancelando ordem viva (anularia estratégias de horizonte longo) — fora de escopo por design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)